### PR TITLE
✨ feat(iam): add multi-tenant IAM role with AssumeRoleWithWebIdentity

### DIFF
--- a/docs/multi-tenant-iam-guide.md
+++ b/docs/multi-tenant-iam-guide.md
@@ -1,0 +1,261 @@
+# Multi-Tenant IAM with AssumeRoleWithWebIdentity
+
+This guide explains how to implement tenant-isolated access to AWS resources using IAM roles with AssumeRoleWithWebIdentity.
+
+## Overview
+
+The multi-tenant IAM solution provides:
+- **Tenant Isolation**: Each tenant can only access their own data
+- **Dynamic Permissions**: Permissions are evaluated at runtime based on JWT claims
+- **Scalable Architecture**: No need to create separate resources per tenant
+- **Security**: Uses AWS IAM's native security features
+
+## Architecture
+
+```
+┌─────────────┐       ┌──────────────┐       ┌─────────────┐
+│   Client    │──────▶│ Identity     │──────▶│   AWS STS   │
+│ Application │       │ Provider     │       │             │
+└─────────────┘       │ (Cognito/    │       └─────────────┘
+                      │  OIDC)       │              │
+                      └──────────────┘              ▼
+                                              ┌─────────────┐
+                                              │  IAM Role   │
+                                              │ (Tenant)    │
+                                              └─────────────┘
+                                                     │
+                                    ┌────────────────┴────────────────┐
+                                    ▼                                 ▼
+                              ┌──────────┐                      ┌──────────┐
+                              │ DynamoDB │                      │    S3    │
+                              │  Table   │                      │  Bucket  │
+                              └──────────┘                      └──────────┘
+```
+
+## Key Components
+
+### 1. MultiTenantIam Construct
+
+The CDK construct that creates:
+- IAM role with web identity trust policy
+- Managed policy with tenant-specific conditions
+- Resource access policies for DynamoDB and S3
+
+### 2. Trust Policy
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "Federated": "arn:aws:cognito-idp:region:account:userpool/pool-id"
+    },
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "StringEquals": {
+        "cognito-idp.region.amazonaws.com/pool-id:aud": "client-id"
+      }
+    }
+  }]
+}
+```
+
+### 3. Tenant Isolation Policies
+
+#### DynamoDB Policy
+```json
+{
+  "Effect": "Allow",
+  "Action": ["dynamodb:GetItem", "dynamodb:PutItem", "dynamodb:Query", ...],
+  "Resource": ["arn:aws:dynamodb:region:account:table/TableName"],
+  "Condition": {
+    "ForAllValues:StringEquals": {
+      "dynamodb:LeadingKeys": ["${cognito-idp.region.amazonaws.com/pool-id:custom:tenant_id}"]
+    }
+  }
+}
+```
+
+#### S3 Policy
+```json
+{
+  "Effect": "Allow",
+  "Action": ["s3:GetObject", "s3:PutObject", ...],
+  "Resource": ["arn:aws:s3:::bucket/tenants/${cognito-idp.region.amazonaws.com/pool-id:custom:tenant_id}/*"]
+}
+```
+
+## Deployment
+
+### Prerequisites
+- AWS CDK installed
+- AWS credentials configured
+- Node.js 14+ installed
+
+### Deploy the Stack
+
+```bash
+# Install dependencies
+cd packages/cdk
+npm install
+
+# Deploy the multi-tenant IAM stack
+npx cdk deploy MultiTenantIamStack \
+  --parameters IdentityProviderArn=arn:aws:cognito-idp:region:account:userpool/pool-id \
+  --parameters Audience=your-client-id
+```
+
+### With Existing Cognito User Pool
+
+```typescript
+const stack = new MultiTenantIamStack(app, 'MultiTenantIamStack', {
+  userPoolId: 'us-east-1_XXXXXXXXX',
+  identityProviderName: 'cognito-idp.us-east-1.amazonaws.com/us-east-1_XXXXXXXXX',
+  audience: 'your-app-client-id',
+});
+```
+
+## Usage Examples
+
+### 1. Client-Side Token Exchange
+
+```javascript
+// Obtain ID token from Cognito
+const idToken = await getIdTokenFromCognito();
+
+// Exchange for temporary credentials
+const sts = new AWS.STS();
+const params = {
+  RoleArn: 'arn:aws:iam::account:role/TenantRole',
+  RoleSessionName: `tenant-session-${tenantId}`,
+  WebIdentityToken: idToken,
+  DurationSeconds: 3600,
+};
+
+const credentials = await sts.assumeRoleWithWebIdentity(params).promise();
+```
+
+### 2. Lambda Function Usage
+
+```typescript
+import { TenantDataAccess } from './multi-tenant-data-access';
+
+const tenantAccess = new TenantDataAccess({
+  roleArn: process.env.TENANT_ROLE_ARN,
+  tableName: process.env.TENANT_TABLE_NAME,
+  bucketName: process.env.TENANT_BUCKET_NAME,
+});
+
+// In your handler
+const credentials = await tenantAccess.assumeTenantRole(webIdentityToken, tenantId);
+const { docClient, s3Client } = tenantAccess.createTenantClients(credentials);
+
+// Now use the clients with tenant-specific access
+const data = await tenantAccess.queryTenantData(docClient, tenantId);
+```
+
+### 3. DynamoDB Table Design
+
+For proper tenant isolation, use tenant ID as the partition key:
+
+```typescript
+const table = new dynamodb.Table(this, 'TenantData', {
+  partitionKey: {
+    name: 'tenantId',
+    type: dynamodb.AttributeType.STRING,
+  },
+  sortKey: {
+    name: 'dataId',
+    type: dynamodb.AttributeType.STRING,
+  },
+});
+```
+
+### 4. S3 Bucket Structure
+
+Organize files by tenant:
+```
+bucket/
+├── tenants/
+│   ├── tenant-123/
+│   │   ├── documents/
+│   │   └── images/
+│   └── tenant-456/
+│       ├── documents/
+│       └── images/
+```
+
+## Security Best Practices
+
+1. **Token Validation**: Always validate JWT tokens before using them
+2. **Least Privilege**: Grant only necessary permissions
+3. **Audit Logging**: Enable CloudTrail for all API calls
+4. **Encryption**: Use encryption at rest for DynamoDB and S3
+5. **Session Duration**: Keep session duration short (1 hour recommended)
+6. **Token Refresh**: Implement token refresh logic in your application
+
+## Customization
+
+### Adding Custom Claims
+
+Configure your identity provider to include custom claims:
+
+```javascript
+// Cognito example
+{
+  "custom:tenant_id": "tenant-123",
+  "custom:role": "admin",
+  "custom:permissions": ["read", "write"]
+}
+```
+
+### Extending Permissions
+
+Add more services to the tenant role:
+
+```typescript
+multiTenantIam.grantAdditionalPermissions(
+  new iam.PolicyStatement({
+    effect: iam.Effect.ALLOW,
+    actions: ['secretsmanager:GetSecretValue'],
+    resources: [`arn:aws:secretsmanager:*:*:secret:${tenantId}/*`],
+  })
+);
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Access Denied**: Check that the tenant ID claim matches the resource prefix
+2. **Invalid Token**: Ensure the token hasn't expired and is from the correct provider
+3. **Role Trust**: Verify the identity provider ARN in the trust policy
+
+### Debug Commands
+
+```bash
+# Test assume role
+aws sts assume-role-with-web-identity \
+  --role-arn arn:aws:iam::account:role/TenantRole \
+  --role-session-name test-session \
+  --web-identity-token $TOKEN
+
+# Decode JWT token
+echo $TOKEN | cut -d. -f2 | base64 -d | jq
+```
+
+## Cost Optimization
+
+1. Use DynamoDB on-demand billing for variable workloads
+2. Implement S3 lifecycle policies for tenant data
+3. Monitor and set up alarms for unusual access patterns
+4. Use AWS Cost Explorer to track per-tenant costs via tags
+
+## Next Steps
+
+1. Implement monitoring and alerting
+2. Add API Gateway with Cognito authorizer
+3. Create tenant onboarding automation
+4. Implement data retention policies
+5. Add cross-region replication for disaster recovery

--- a/packages/cdk/lambda/multi-tenant-data-access.ts
+++ b/packages/cdk/lambda/multi-tenant-data-access.ts
@@ -1,0 +1,238 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { S3Client, GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
+import { DynamoDBDocumentClient, QueryCommand, PutCommand } from '@aws-sdk/lib-dynamodb';
+import { AssumeRoleWithWebIdentityCommand, STSClient } from '@aws-sdk/client-sts';
+
+export interface TenantDataAccessConfig {
+  roleArn: string;
+  tableName: string;
+  bucketName: string;
+}
+
+export class TenantDataAccess {
+  private stsClient: STSClient;
+  private config: TenantDataAccessConfig;
+
+  constructor(config: TenantDataAccessConfig) {
+    this.config = config;
+    this.stsClient = new STSClient({});
+  }
+
+  /**
+   * Assume the tenant role using the provided web identity token
+   */
+  async assumeTenantRole(webIdentityToken: string, tenantId: string) {
+    const command = new AssumeRoleWithWebIdentityCommand({
+      RoleArn: this.config.roleArn,
+      RoleSessionName: `tenant-session-${tenantId}`,
+      WebIdentityToken: webIdentityToken,
+      DurationSeconds: 3600, // 1 hour
+    });
+
+    const response = await this.stsClient.send(command);
+    return response.Credentials;
+  }
+
+  /**
+   * Create clients with tenant-specific credentials
+   */
+  createTenantClients(credentials: any) {
+    const config = {
+      credentials: {
+        accessKeyId: credentials.AccessKeyId!,
+        secretAccessKey: credentials.SecretAccessKey!,
+        sessionToken: credentials.SessionToken!,
+      },
+    };
+
+    const dynamoClient = new DynamoDBClient(config);
+    const docClient = DynamoDBDocumentClient.from(dynamoClient);
+    const s3Client = new S3Client(config);
+
+    return { docClient, s3Client };
+  }
+
+  /**
+   * Query tenant-specific data from DynamoDB
+   */
+  async queryTenantData(
+    docClient: DynamoDBDocumentClient,
+    tenantId: string,
+    dataType?: string
+  ) {
+    const params: any = {
+      TableName: this.config.tableName,
+      KeyConditionExpression: 'tenantId = :tenantId',
+      ExpressionAttributeValues: {
+        ':tenantId': tenantId,
+      },
+    };
+
+    if (dataType) {
+      params.IndexName = 'dataTypeIndex';
+      params.KeyConditionExpression += ' AND dataType = :dataType';
+      params.ExpressionAttributeValues[':dataType'] = dataType;
+    }
+
+    const command = new QueryCommand(params);
+    const response = await docClient.send(command);
+    return response.Items;
+  }
+
+  /**
+   * Store tenant data in DynamoDB
+   */
+  async storeTenantData(
+    docClient: DynamoDBDocumentClient,
+    tenantId: string,
+    dataId: string,
+    data: any
+  ) {
+    const command = new PutCommand({
+      TableName: this.config.tableName,
+      Item: {
+        tenantId,
+        dataId,
+        ...data,
+        timestamp: new Date().toISOString(),
+      },
+    });
+
+    await docClient.send(command);
+  }
+
+  /**
+   * Upload file to tenant-specific S3 path
+   */
+  async uploadTenantFile(
+    s3Client: S3Client,
+    tenantId: string,
+    fileName: string,
+    fileContent: Buffer | Uint8Array | string
+  ) {
+    const command = new PutObjectCommand({
+      Bucket: this.config.bucketName,
+      Key: `tenants/${tenantId}/${fileName}`,
+      Body: fileContent,
+      ServerSideEncryption: 'AES256',
+    });
+
+    await s3Client.send(command);
+  }
+
+  /**
+   * Download file from tenant-specific S3 path
+   */
+  async downloadTenantFile(
+    s3Client: S3Client,
+    tenantId: string,
+    fileName: string
+  ) {
+    const command = new GetObjectCommand({
+      Bucket: this.config.bucketName,
+      Key: `tenants/${tenantId}/${fileName}`,
+    });
+
+    const response = await s3Client.send(command);
+    return response.Body;
+  }
+}
+
+/**
+ * Example Lambda handler using the tenant data access
+ */
+export const handler = async (event: any) => {
+  // Extract tenant information from the event
+  const tenantId = event.requestContext?.authorizer?.claims?.['custom:tenant_id'];
+  const webIdentityToken = event.headers?.Authorization?.replace('Bearer ', '');
+
+  if (!tenantId || !webIdentityToken) {
+    return {
+      statusCode: 401,
+      body: JSON.stringify({ error: 'Unauthorized' }),
+    };
+  }
+
+  const config: TenantDataAccessConfig = {
+    roleArn: process.env.TENANT_ROLE_ARN!,
+    tableName: process.env.TENANT_TABLE_NAME!,
+    bucketName: process.env.TENANT_BUCKET_NAME!,
+  };
+
+  const tenantAccess = new TenantDataAccess(config);
+
+  try {
+    // Assume the tenant role
+    const credentials = await tenantAccess.assumeTenantRole(webIdentityToken, tenantId);
+    const { docClient, s3Client } = tenantAccess.createTenantClients(credentials);
+
+    // Perform operations based on the request
+    const { action, ...params } = JSON.parse(event.body || '{}');
+
+    switch (action) {
+      case 'query':
+        const data = await tenantAccess.queryTenantData(
+          docClient,
+          tenantId,
+          params.dataType
+        );
+        return {
+          statusCode: 200,
+          body: JSON.stringify({ data }),
+        };
+
+      case 'store':
+        await tenantAccess.storeTenantData(
+          docClient,
+          tenantId,
+          params.dataId,
+          params.data
+        );
+        return {
+          statusCode: 200,
+          body: JSON.stringify({ success: true }),
+        };
+
+      case 'uploadFile':
+        await tenantAccess.uploadTenantFile(
+          s3Client,
+          tenantId,
+          params.fileName,
+          Buffer.from(params.fileContent, 'base64')
+        );
+        return {
+          statusCode: 200,
+          body: JSON.stringify({ success: true }),
+        };
+
+      case 'downloadFile':
+        const fileStream = await tenantAccess.downloadTenantFile(
+          s3Client,
+          tenantId,
+          params.fileName
+        );
+        // Convert stream to base64 for API response
+        const chunks: any[] = [];
+        for await (const chunk of fileStream as any) {
+          chunks.push(chunk);
+        }
+        const fileContent = Buffer.concat(chunks).toString('base64');
+        return {
+          statusCode: 200,
+          body: JSON.stringify({ fileContent }),
+        };
+
+      default:
+        return {
+          statusCode: 400,
+          body: JSON.stringify({ error: 'Invalid action' }),
+        };
+    }
+  } catch (error) {
+    console.error('Error:', error);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: 'Internal server error' }),
+    };
+  }
+};

--- a/packages/cdk/lib/construct/index.ts
+++ b/packages/cdk/lib/construct/index.ts
@@ -10,3 +10,4 @@ export * from './rag-knowledge-base';
 export * from './guardrail';
 export * from './speech-to-speech';
 export * from './mcp-api';
+export * from './multi-tenant-iam';

--- a/packages/cdk/lib/construct/multi-tenant-iam.ts
+++ b/packages/cdk/lib/construct/multi-tenant-iam.ts
@@ -1,0 +1,229 @@
+import * as cdk from 'aws-cdk-lib';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import { Construct } from 'constructs';
+
+export interface MultiTenantIamProps {
+  /**
+   * The identity provider ARN (e.g., OIDC provider ARN)
+   */
+  readonly identityProviderArn: string;
+
+  /**
+   * The audience/client ID for the identity provider
+   */
+  readonly audience: string;
+
+  /**
+   * The tenant identifier claim in the JWT token
+   */
+  readonly tenantIdClaim?: string;
+
+  /**
+   * DynamoDB tables that tenants need access to
+   */
+  readonly tenantTables?: dynamodb.Table[];
+
+  /**
+   * S3 buckets that tenants need access to
+   */
+  readonly tenantBuckets?: s3.Bucket[];
+
+  /**
+   * Additional resource ARNs that tenants need access to
+   */
+  readonly additionalResourceArns?: string[];
+
+  /**
+   * Tags to apply to the IAM roles
+   */
+  readonly tags?: { [key: string]: string };
+}
+
+export class MultiTenantIam extends Construct {
+  /**
+   * The IAM role that can be assumed by authenticated users
+   */
+  public readonly tenantRole: iam.Role;
+
+  /**
+   * Policy that grants access to tenant-specific resources
+   */
+  public readonly tenantPolicy: iam.ManagedPolicy;
+
+  constructor(scope: Construct, id: string, props: MultiTenantIamProps) {
+    super(scope, id);
+
+    const tenantIdClaim = props.tenantIdClaim || 'custom:tenant_id';
+
+    // Create the trust policy for AssumeRoleWithWebIdentity
+    const trustPolicy = new iam.PolicyDocument({
+      statements: [
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          principals: [new iam.FederatedPrincipal(props.identityProviderArn, {
+            'StringEquals': {
+              [`${props.identityProviderArn}:aud`]: props.audience,
+            },
+          }, 'sts:AssumeRoleWithWebIdentity')],
+          actions: ['sts:AssumeRoleWithWebIdentity'],
+        }),
+      ],
+    });
+
+    // Create the IAM role
+    this.tenantRole = new iam.Role(this, 'TenantRole', {
+      assumedBy: new iam.WebIdentityPrincipal(props.identityProviderArn, {
+        'StringEquals': {
+          [`${props.identityProviderArn}:aud`]: props.audience,
+        },
+      }),
+      description: 'Role for multi-tenant access with tenant isolation',
+      maxSessionDuration: cdk.Duration.hours(1),
+    });
+
+    // Create policy statements for tenant-specific access
+    const policyStatements: iam.PolicyStatement[] = [];
+
+    // DynamoDB access with tenant isolation
+    if (props.tenantTables && props.tenantTables.length > 0) {
+      props.tenantTables.forEach((table) => {
+        // Allow operations on items where the partition key matches the tenant ID
+        policyStatements.push(
+          new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            actions: [
+              'dynamodb:GetItem',
+              'dynamodb:PutItem',
+              'dynamodb:UpdateItem',
+              'dynamodb:DeleteItem',
+              'dynamodb:Query',
+              'dynamodb:BatchGetItem',
+              'dynamodb:BatchWriteItem',
+            ],
+            resources: [
+              table.tableArn,
+              `${table.tableArn}/index/*`,
+            ],
+            conditions: {
+              'ForAllValues:StringEquals': {
+                'dynamodb:LeadingKeys': [`$\{${props.identityProviderArn}:${tenantIdClaim}}`],
+              },
+            },
+          })
+        );
+
+        // Allow DescribeTable for table metadata
+        policyStatements.push(
+          new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            actions: ['dynamodb:DescribeTable'],
+            resources: [table.tableArn],
+          })
+        );
+      });
+    }
+
+    // S3 access with tenant isolation
+    if (props.tenantBuckets && props.tenantBuckets.length > 0) {
+      props.tenantBuckets.forEach((bucket) => {
+        // List objects in tenant-specific prefix
+        policyStatements.push(
+          new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            actions: ['s3:ListBucket'],
+            resources: [bucket.bucketArn],
+            conditions: {
+              'StringLike': {
+                's3:prefix': [`tenants/$\{${props.identityProviderArn}:${tenantIdClaim}}/*`],
+              },
+            },
+          })
+        );
+
+        // CRUD operations on tenant-specific objects
+        policyStatements.push(
+          new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            actions: [
+              's3:GetObject',
+              's3:PutObject',
+              's3:DeleteObject',
+              's3:GetObjectVersion',
+              's3:GetObjectTagging',
+              's3:PutObjectTagging',
+            ],
+            resources: [`${bucket.bucketArn}/tenants/$\{${props.identityProviderArn}:${tenantIdClaim}}/*`],
+          })
+        );
+      });
+    }
+
+    // Additional resource access
+    if (props.additionalResourceArns && props.additionalResourceArns.length > 0) {
+      policyStatements.push(
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: ['*'],
+          resources: props.additionalResourceArns,
+          conditions: {
+            'StringEquals': {
+              'aws:userid': [`$\{${props.identityProviderArn}:${tenantIdClaim}}`],
+            },
+          },
+        })
+      );
+    }
+
+    // Create managed policy
+    this.tenantPolicy = new iam.ManagedPolicy(this, 'TenantPolicy', {
+      description: 'Policy for tenant-specific resource access',
+      statements: policyStatements,
+      roles: [this.tenantRole],
+    });
+
+    // Apply tags if provided
+    if (props.tags) {
+      Object.entries(props.tags).forEach(([key, value]) => {
+        cdk.Tags.of(this.tenantRole).add(key, value);
+        cdk.Tags.of(this.tenantPolicy).add(key, value);
+      });
+    }
+
+    // Output the role ARN
+    new cdk.CfnOutput(this, 'TenantRoleArn', {
+      value: this.tenantRole.roleArn,
+      description: 'ARN of the tenant access role',
+    });
+  }
+
+  /**
+   * Grant additional permissions to the tenant role
+   */
+  public grantAdditionalPermissions(statement: iam.PolicyStatement): void {
+    this.tenantRole.addToPolicy(statement);
+  }
+
+  /**
+   * Create a session policy document for additional runtime restrictions
+   */
+  public static createSessionPolicy(tenantId: string, resourceArns: string[]): string {
+    const sessionPolicy = {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Action: '*',
+          Resource: resourceArns,
+          Condition: {
+            StringEquals: {
+              'aws:userid': tenantId,
+            },
+          },
+        },
+      ],
+    };
+    return JSON.stringify(sessionPolicy);
+  }
+}

--- a/packages/cdk/lib/multi-tenant-iam-stack.ts
+++ b/packages/cdk/lib/multi-tenant-iam-stack.ts
@@ -1,0 +1,138 @@
+import * as cdk from 'aws-cdk-lib';
+import * as cognito from 'aws-cdk-lib/aws-cognito';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { Construct } from 'constructs';
+import { MultiTenantIam } from './construct/multi-tenant-iam';
+import { RemovalPolicy } from 'aws-cdk-lib';
+
+export interface MultiTenantIamStackProps extends cdk.StackProps {
+  /**
+   * The Cognito user pool ID
+   */
+  readonly userPoolId?: string;
+
+  /**
+   * The identity provider name (e.g., 'cognito-idp.us-east-1.amazonaws.com/us-east-1_XXXXXXXXX')
+   */
+  readonly identityProviderName?: string;
+
+  /**
+   * The audience/client ID
+   */
+  readonly audience?: string;
+}
+
+export class MultiTenantIamStack extends cdk.Stack {
+  public readonly tenantDataTable: dynamodb.Table;
+  public readonly tenantFilesBucket: s3.Bucket;
+  public readonly multiTenantIam: MultiTenantIam;
+
+  constructor(scope: Construct, id: string, props?: MultiTenantIamStackProps) {
+    super(scope, id, props);
+
+    // Create a DynamoDB table for tenant data
+    this.tenantDataTable = new dynamodb.Table(this, 'TenantDataTable', {
+      partitionKey: {
+        name: 'tenantId',
+        type: dynamodb.AttributeType.STRING,
+      },
+      sortKey: {
+        name: 'dataId',
+        type: dynamodb.AttributeType.STRING,
+      },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      encryption: dynamodb.TableEncryption.AWS_MANAGED,
+      pointInTimeRecovery: true,
+      removalPolicy: RemovalPolicy.DESTROY, // For demo purposes
+    });
+
+    // Add GSI for additional query patterns
+    this.tenantDataTable.addGlobalSecondaryIndex({
+      indexName: 'dataTypeIndex',
+      partitionKey: {
+        name: 'tenantId',
+        type: dynamodb.AttributeType.STRING,
+      },
+      sortKey: {
+        name: 'dataType',
+        type: dynamodb.AttributeType.STRING,
+      },
+    });
+
+    // Create an S3 bucket for tenant files
+    this.tenantFilesBucket = new s3.Bucket(this, 'TenantFilesBucket', {
+      bucketName: `tenant-files-${this.account}-${this.region}`,
+      encryption: s3.BucketEncryption.S3_MANAGED,
+      blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
+      versioned: true,
+      lifecycleRules: [
+        {
+          id: 'delete-old-versions',
+          noncurrentVersionExpiration: cdk.Duration.days(30),
+        },
+      ],
+      removalPolicy: RemovalPolicy.DESTROY, // For demo purposes
+      autoDeleteObjects: true, // For demo purposes
+    });
+
+    // Create OIDC provider ARN (example for Cognito)
+    const identityProviderArn = props?.identityProviderName
+      ? `arn:aws:cognito-idp:${this.region}:${this.account}:userpool/${props.userPoolId}`
+      : new cdk.CfnParameter(this, 'IdentityProviderArn', {
+          description: 'ARN of the identity provider (e.g., Cognito User Pool ARN)',
+          type: 'String',
+        }).valueAsString;
+
+    const audience = props?.audience || new cdk.CfnParameter(this, 'Audience', {
+      description: 'Audience/Client ID for the identity provider',
+      type: 'String',
+    }).valueAsString;
+
+    // Create the multi-tenant IAM construct
+    this.multiTenantIam = new MultiTenantIam(this, 'MultiTenantIam', {
+      identityProviderArn,
+      audience,
+      tenantIdClaim: 'custom:tenant_id',
+      tenantTables: [this.tenantDataTable],
+      tenantBuckets: [this.tenantFilesBucket],
+      tags: {
+        Purpose: 'MultiTenantDataAccess',
+        ManagedBy: 'CDK',
+      },
+    });
+
+    // Grant additional permissions for specific services if needed
+    this.multiTenantIam.grantAdditionalPermissions(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: [
+          'logs:CreateLogGroup',
+          'logs:CreateLogStream',
+          'logs:PutLogEvents',
+        ],
+        resources: [`arn:aws:logs:${this.region}:${this.account}:log-group:/aws/multi-tenant/*`],
+      })
+    );
+
+    // Output important values
+    new cdk.CfnOutput(this, 'TenantTableName', {
+      value: this.tenantDataTable.tableName,
+      description: 'Name of the tenant data table',
+    });
+
+    new cdk.CfnOutput(this, 'TenantBucketName', {
+      value: this.tenantFilesBucket.bucketName,
+      description: 'Name of the tenant files bucket',
+    });
+
+    new cdk.CfnOutput(this, 'TenantRoleArn', {
+      value: this.multiTenantIam.tenantRole.roleArn,
+      description: 'ARN of the tenant access role',
+    });
+
+    // Stack description
+    this.templateOptions.description = 'Multi-tenant IAM stack with AssumeRoleWithWebIdentity for tenant-isolated data access';
+  }
+}

--- a/scripts/deploy-multi-tenant-iam.sh
+++ b/scripts/deploy-multi-tenant-iam.sh
@@ -1,0 +1,233 @@
+#!/bin/bash
+
+# Multi-Tenant IAM Deployment Script
+# This script deploys the multi-tenant IAM infrastructure using AWS CDK
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+print_status() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+print_warning() {
+    echo -e "${YELLOW}[WARNING]${NC} $1"
+}
+
+# Function to check prerequisites
+check_prerequisites() {
+    print_status "Checking prerequisites..."
+    
+    # Check if AWS CLI is installed
+    if ! command -v aws &> /dev/null; then
+        print_error "AWS CLI is not installed. Please install it first."
+        exit 1
+    fi
+    
+    # Check if CDK is installed
+    if ! command -v cdk &> /dev/null; then
+        print_error "AWS CDK is not installed. Please install it with: npm install -g aws-cdk"
+        exit 1
+    fi
+    
+    # Check if Node.js is installed
+    if ! command -v node &> /dev/null; then
+        print_error "Node.js is not installed. Please install Node.js 14 or later."
+        exit 1
+    fi
+    
+    # Check AWS credentials
+    if ! aws sts get-caller-identity &> /dev/null; then
+        print_error "AWS credentials are not configured. Please run 'aws configure'."
+        exit 1
+    fi
+    
+    print_status "All prerequisites met!"
+}
+
+# Function to get user input
+get_deployment_params() {
+    print_status "Configuring deployment parameters..."
+    
+    # Get AWS account and region
+    AWS_ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
+    AWS_REGION=$(aws configure get region)
+    
+    print_status "AWS Account: $AWS_ACCOUNT"
+    print_status "AWS Region: $AWS_REGION"
+    
+    # Get identity provider details
+    read -p "Enter Identity Provider Type (cognito/custom) [cognito]: " PROVIDER_TYPE
+    PROVIDER_TYPE=${PROVIDER_TYPE:-cognito}
+    
+    if [ "$PROVIDER_TYPE" = "cognito" ]; then
+        read -p "Enter Cognito User Pool ID: " USER_POOL_ID
+        if [ -z "$USER_POOL_ID" ]; then
+            print_error "User Pool ID is required"
+            exit 1
+        fi
+        IDENTITY_PROVIDER_ARN="arn:aws:cognito-idp:${AWS_REGION}:${AWS_ACCOUNT}:userpool/${USER_POOL_ID}"
+        IDENTITY_PROVIDER_NAME="cognito-idp.${AWS_REGION}.amazonaws.com/${USER_POOL_ID}"
+    else
+        read -p "Enter Identity Provider ARN: " IDENTITY_PROVIDER_ARN
+        if [ -z "$IDENTITY_PROVIDER_ARN" ]; then
+            print_error "Identity Provider ARN is required"
+            exit 1
+        fi
+    fi
+    
+    read -p "Enter Client/Audience ID: " AUDIENCE_ID
+    if [ -z "$AUDIENCE_ID" ]; then
+        print_error "Audience ID is required"
+        exit 1
+    fi
+    
+    # Optional: Custom tenant ID claim
+    read -p "Enter tenant ID claim name [custom:tenant_id]: " TENANT_ID_CLAIM
+    TENANT_ID_CLAIM=${TENANT_ID_CLAIM:-custom:tenant_id}
+    
+    # Stack name
+    read -p "Enter stack name [MultiTenantIamStack]: " STACK_NAME
+    STACK_NAME=${STACK_NAME:-MultiTenantIamStack}
+}
+
+# Function to install dependencies
+install_dependencies() {
+    print_status "Installing dependencies..."
+    
+    cd packages/cdk
+    npm install
+    cd ../..
+}
+
+# Function to bootstrap CDK (if needed)
+bootstrap_cdk() {
+    print_status "Checking CDK bootstrap status..."
+    
+    if ! aws cloudformation describe-stacks --stack-name CDKToolkit &> /dev/null; then
+        print_status "Bootstrapping CDK..."
+        cd packages/cdk
+        cdk bootstrap aws://${AWS_ACCOUNT}/${AWS_REGION}
+        cd ../..
+    else
+        print_status "CDK already bootstrapped"
+    fi
+}
+
+# Function to synthesize the stack
+synth_stack() {
+    print_status "Synthesizing CloudFormation template..."
+    
+    cd packages/cdk
+    cdk synth ${STACK_NAME} \
+        --context identityProviderArn="${IDENTITY_PROVIDER_ARN}" \
+        --context audience="${AUDIENCE_ID}" \
+        --context tenantIdClaim="${TENANT_ID_CLAIM}"
+    cd ../..
+}
+
+# Function to deploy the stack
+deploy_stack() {
+    print_status "Deploying stack ${STACK_NAME}..."
+    
+    cd packages/cdk
+    
+    if [ "$PROVIDER_TYPE" = "cognito" ]; then
+        cdk deploy ${STACK_NAME} \
+            --parameters IdentityProviderArn="${IDENTITY_PROVIDER_ARN}" \
+            --parameters Audience="${AUDIENCE_ID}" \
+            --require-approval never
+    else
+        cdk deploy ${STACK_NAME} \
+            --parameters IdentityProviderArn="${IDENTITY_PROVIDER_ARN}" \
+            --parameters Audience="${AUDIENCE_ID}" \
+            --require-approval never
+    fi
+    
+    cd ../..
+}
+
+# Function to display outputs
+display_outputs() {
+    print_status "Deployment complete! Here are the important outputs:"
+    
+    # Get stack outputs
+    OUTPUTS=$(aws cloudformation describe-stacks \
+        --stack-name ${STACK_NAME} \
+        --query 'Stacks[0].Outputs' \
+        --output json)
+    
+    echo "$OUTPUTS" | jq -r '.[] | "\(.OutputKey): \(.OutputValue)"'
+    
+    # Save outputs to file
+    echo "$OUTPUTS" > deployment-outputs.json
+    print_status "Outputs saved to deployment-outputs.json"
+}
+
+# Function to create example configuration
+create_example_config() {
+    print_status "Creating example configuration..."
+    
+    ROLE_ARN=$(aws cloudformation describe-stacks \
+        --stack-name ${STACK_NAME} \
+        --query 'Stacks[0].Outputs[?OutputKey==`TenantRoleArn`].OutputValue' \
+        --output text)
+    
+    TABLE_NAME=$(aws cloudformation describe-stacks \
+        --stack-name ${STACK_NAME} \
+        --query 'Stacks[0].Outputs[?OutputKey==`TenantTableName`].OutputValue' \
+        --output text)
+    
+    BUCKET_NAME=$(aws cloudformation describe-stacks \
+        --stack-name ${STACK_NAME} \
+        --query 'Stacks[0].Outputs[?OutputKey==`TenantBucketName`].OutputValue' \
+        --output text)
+    
+    cat > example-config.json <<EOF
+{
+  "tenantRoleArn": "${ROLE_ARN}",
+  "tableName": "${TABLE_NAME}",
+  "bucketName": "${BUCKET_NAME}",
+  "identityProvider": {
+    "type": "${PROVIDER_TYPE}",
+    "arn": "${IDENTITY_PROVIDER_ARN}",
+    "audience": "${AUDIENCE_ID}",
+    "tenantIdClaim": "${TENANT_ID_CLAIM}"
+  },
+  "region": "${AWS_REGION}",
+  "account": "${AWS_ACCOUNT}"
+}
+EOF
+    
+    print_status "Example configuration saved to example-config.json"
+}
+
+# Main deployment flow
+main() {
+    print_status "Starting Multi-Tenant IAM deployment..."
+    
+    check_prerequisites
+    get_deployment_params
+    install_dependencies
+    bootstrap_cdk
+    synth_stack
+    deploy_stack
+    display_outputs
+    create_example_config
+    
+    print_status "Deployment completed successfully!"
+    print_status "Check the documentation at docs/multi-tenant-iam-guide.md for usage examples"
+}
+
+# Run main function
+main


### PR DESCRIPTION
## Summary
- Implemented a comprehensive multi-tenant IAM solution using AssumeRoleWithWebIdentity
- Created reusable CDK constructs for tenant-isolated resource access
- Added deployment automation and detailed documentation

## Features
### 🏗️ CDK Infrastructure
- **MultiTenantIam Construct**: Core construct that creates IAM roles with web identity trust policies
- **MultiTenantIamStack**: Example stack demonstrating DynamoDB and S3 tenant isolation
- Dynamic policy generation based on JWT token claims

### 🔐 Security Features
- Tenant isolation at IAM level using JWT claims
- Support for custom tenant ID claims
- Conditional policies for DynamoDB (partition key isolation)
- Path-based isolation for S3 buckets
- Configurable session duration and tags

### 📝 Documentation & Examples
- Comprehensive guide with architecture diagrams
- Lambda function example showing token exchange and data access
- Deployment script with interactive configuration
- Security best practices and troubleshooting guide

## Technical Details
The solution uses AWS STS AssumeRoleWithWebIdentity to:
1. Exchange JWT tokens from identity providers (Cognito, OIDC) for temporary AWS credentials
2. Apply runtime policy conditions based on token claims
3. Enforce tenant isolation without creating separate resources per tenant

## Files Changed
- `packages/cdk/lib/construct/multi-tenant-iam.ts` - Core IAM construct
- `packages/cdk/lib/multi-tenant-iam-stack.ts` - Example deployment stack
- `packages/cdk/lambda/multi-tenant-data-access.ts` - Lambda function for tenant data operations
- `docs/multi-tenant-iam-guide.md` - Comprehensive documentation
- `scripts/deploy-multi-tenant-iam.sh` - Deployment automation script

## Test Plan
- [ ] Deploy stack with test Cognito user pool
- [ ] Verify tenant isolation for DynamoDB operations
- [ ] Test S3 path-based access restrictions
- [ ] Validate token exchange and credential generation
- [ ] Test cross-tenant access denial

🤖 Generated with [Claude Code](https://claude.ai/code)