### PR TITLE
:building_construction: feat(dynamodb): テナント専用DynamoDBテーブルスタックの実装

### DIFF
--- a/docs/tenant-provisioning-guide.md
+++ b/docs/tenant-provisioning-guide.md
@@ -1,0 +1,228 @@
+# Tenant Provisioning Guide
+
+This guide explains how to provision DynamoDB tables for new tenants in the multi-tenant architecture.
+
+## Overview
+
+Each tenant gets their own set of DynamoDB tables to ensure complete data isolation:
+- `ChatHistory-tenant-{tenantId}` - Stores chat conversations
+- `TokenUsageStats-tenant-{tenantId}` - Stores token usage statistics
+
+## Provisioning Methods
+
+### Method 1: Using the REST API (Recommended)
+
+The easiest way to provision a new tenant is through the REST API endpoint:
+
+```bash
+# Onboard a new tenant
+curl -X POST https://your-api-gateway-url/tenants \
+  -H "Authorization: Bearer YOUR_JWT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "tenantId": "acme-corp",
+    "tenantName": "ACME Corporation",
+    "adminEmail": "admin@acme.com"
+  }'
+```
+
+Response:
+```json
+{
+  "message": "Tenant onboarding initiated successfully",
+  "tenantId": "acme-corp",
+  "stackName": "TenantDynamoDB-acme-corp",
+  "tables": {
+    "chatHistory": "ChatHistory-tenant-acme-corp",
+    "tokenUsageStats": "TokenUsageStats-tenant-acme-corp"
+  }
+}
+```
+
+Check tenant status:
+```bash
+curl -X GET https://your-api-gateway-url/tenants/acme-corp \
+  -H "Authorization: Bearer YOUR_JWT_TOKEN"
+```
+
+### Method 2: Using CDK CLI
+
+For manual provisioning or testing, you can use the CDK directly:
+
+```bash
+# Navigate to the CDK directory
+cd packages/cdk
+
+# Install dependencies
+npm install
+
+# Deploy tables for a specific tenant
+cdk deploy TenantDynamoDB-acme-corp \
+  --context tenantId=acme-corp
+```
+
+### Method 3: Using the Provisioning Script
+
+A TypeScript script is provided for batch provisioning:
+
+```bash
+# Navigate to the CDK directory
+cd packages/cdk
+
+# Run the provisioning script
+npm run provision-tenant -- --tenant-id acme-corp --region us-east-1
+
+# With AWS profile
+npm run provision-tenant -- --tenant-id acme-corp --profile production
+```
+
+## Tenant ID Requirements
+
+- Must be unique across your system
+- Alphanumeric characters and hyphens only
+- Will be sanitized automatically (special characters replaced with hyphens)
+- Recommended format: lowercase with hyphens (e.g., `acme-corp`, `tenant-123`)
+
+## Table Configuration
+
+### Default Settings
+
+- **Billing Mode**: PAY_PER_REQUEST (on-demand)
+- **Encryption**: AWS managed encryption (SSE)
+- **Point-in-Time Recovery**: Enabled
+- **Removal Policy**: RETAIN (tables are kept when stack is deleted)
+
+### Indexes
+
+#### ChatHistory Table
+- Primary Key: `id` (HASH), `createdDate` (RANGE)
+- Global Secondary Index: `FeedbackIndex` on `feedback` attribute
+
+#### TokenUsageStats Table
+- Primary Key: `id` (HASH), `userId` (RANGE)
+- Global Secondary Index: `MonthIndex` on `month` (HASH), `userId` (RANGE)
+
+## IAM Permissions
+
+### For Tenant Onboarding
+
+The onboarding Lambda function requires:
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "cloudformation:CreateStack",
+        "cloudformation:DescribeStacks",
+        "dynamodb:CreateTable",
+        "dynamodb:DescribeTable",
+        "dynamodb:TagResource"
+      ],
+      "Resource": [
+        "arn:aws:cloudformation:*:*:stack/TenantDynamoDB-*/*",
+        "arn:aws:dynamodb:*:*:table/*-tenant-*"
+      ]
+    }
+  ]
+}
+```
+
+### For Application Access
+
+Lambda functions accessing tenant tables need:
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "dynamodb:PutItem",
+        "dynamodb:GetItem",
+        "dynamodb:Query",
+        "dynamodb:UpdateItem",
+        "dynamodb:DeleteItem",
+        "dynamodb:BatchWriteItem",
+        "dynamodb:BatchGetItem"
+      ],
+      "Resource": [
+        "arn:aws:dynamodb:*:*:table/*-tenant-*",
+        "arn:aws:dynamodb:*:*:table/*-tenant-*/index/*"
+      ]
+    }
+  ]
+}
+```
+
+## Monitoring and Alerts
+
+### CloudFormation Stack Status
+
+Monitor stack creation through:
+- AWS CloudFormation Console
+- CloudWatch Events for stack state changes
+- API endpoint: `GET /tenants/{tenantId}`
+
+### Table Metrics
+
+Key metrics to monitor per tenant:
+- ConsumedReadCapacityUnits
+- ConsumedWriteCapacityUnits
+- UserErrors
+- SystemErrors
+- ThrottledRequests
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Stack Creation Failed**
+   - Check CloudFormation events for detailed error
+   - Verify IAM permissions
+   - Ensure tenant ID is unique
+
+2. **Table Already Exists**
+   - Tenant might be already provisioned
+   - Check with `GET /tenants/{tenantId}`
+
+3. **Access Denied**
+   - Verify Lambda execution role has correct permissions
+   - Check if tenant tables exist
+   - Ensure JWT contains correct tenant ID claim
+
+### Cleanup
+
+To remove a tenant's resources:
+
+```bash
+# Using AWS CLI
+aws cloudformation delete-stack --stack-name TenantDynamoDB-acme-corp
+
+# Or using CDK
+cdk destroy TenantDynamoDB-acme-corp
+```
+
+**WARNING**: This will delete all data unless tables have RETAIN removal policy.
+
+## Best Practices
+
+1. **Tenant ID Naming**: Use consistent, meaningful IDs
+2. **Monitoring**: Set up CloudWatch alarms for each tenant
+3. **Backup**: Enable continuous backups for production tenants
+4. **Cost Tracking**: Use tags to track costs per tenant
+5. **Capacity Planning**: Monitor usage patterns and adjust if needed
+
+## Migration from Shared Tables
+
+For existing deployments using shared tables:
+
+1. Export data from shared tables filtered by user
+2. Transform data to include tenant context
+3. Import into tenant-specific tables
+4. Update application configuration
+5. Verify data integrity
+6. Switch traffic to new tables
+
+See `migration-guide.md` for detailed steps.

--- a/packages/cdk/lambda/getTenantStatus.ts
+++ b/packages/cdk/lambda/getTenantStatus.ts
@@ -1,0 +1,143 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { CloudFormationClient, DescribeStacksCommand } from '@aws-sdk/client-cloudformation';
+import { DynamoDBClient, DescribeTableCommand } from '@aws-sdk/client-dynamodb';
+
+const cfnClient = new CloudFormationClient({});
+const dynamoClient = new DynamoDBClient({});
+
+/**
+ * Lambda function to get the status of a tenant's resources
+ */
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    const tenantId = event.pathParameters?.tenantId;
+    
+    if (!tenantId) {
+      return {
+        statusCode: 400,
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+        },
+        body: JSON.stringify({
+          message: 'Tenant ID is required',
+        }),
+      };
+    }
+
+    // Sanitize tenant ID
+    const sanitizedTenantId = tenantId.replace(/[^a-zA-Z0-9-]/g, '-');
+    const stackName = `TenantDynamoDB-${sanitizedTenantId}`;
+
+    try {
+      // Get stack status
+      const describeResult = await cfnClient.send(
+        new DescribeStacksCommand({
+          StackName: stackName,
+        })
+      );
+
+      const stack = describeResult.Stacks?.[0];
+      if (!stack) {
+        return {
+          statusCode: 404,
+          headers: {
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': '*',
+          },
+          body: JSON.stringify({
+            message: `Tenant ${tenantId} not found`,
+          }),
+        };
+      }
+
+      // Get table details if stack is complete
+      const tables: any = {};
+      if (stack.StackStatus === 'CREATE_COMPLETE' || stack.StackStatus === 'UPDATE_COMPLETE') {
+        try {
+          // Check chat history table
+          const chatTableName = `ChatHistory-tenant-${sanitizedTenantId}`;
+          const chatTableDesc = await dynamoClient.send(
+            new DescribeTableCommand({
+              TableName: chatTableName,
+            })
+          );
+          tables.chatHistory = {
+            name: chatTableName,
+            status: chatTableDesc.Table?.TableStatus,
+            itemCount: chatTableDesc.Table?.ItemCount,
+            sizeBytes: chatTableDesc.Table?.TableSizeBytes,
+            createdAt: chatTableDesc.Table?.CreationDateTime,
+          };
+
+          // Check token usage stats table
+          const statsTableName = `TokenUsageStats-tenant-${sanitizedTenantId}`;
+          const statsTableDesc = await dynamoClient.send(
+            new DescribeTableCommand({
+              TableName: statsTableName,
+            })
+          );
+          tables.tokenUsageStats = {
+            name: statsTableName,
+            status: statsTableDesc.Table?.TableStatus,
+            itemCount: statsTableDesc.Table?.ItemCount,
+            sizeBytes: statsTableDesc.Table?.TableSizeBytes,
+            createdAt: statsTableDesc.Table?.CreationDateTime,
+          };
+        } catch (error) {
+          console.error('Error describing tables:', error);
+        }
+      }
+
+      return {
+        statusCode: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+        },
+        body: JSON.stringify({
+          tenantId,
+          stackName,
+          stackStatus: stack.StackStatus,
+          stackStatusReason: stack.StackStatusReason,
+          createdAt: stack.CreationTime,
+          updatedAt: stack.LastUpdatedTime,
+          tables,
+          outputs: stack.Outputs?.reduce((acc, output) => {
+            acc[output.OutputKey!] = output.OutputValue;
+            return acc;
+          }, {} as Record<string, string>),
+        }),
+      };
+    } catch (error: any) {
+      if (error.name === 'ValidationError' && error.message.includes('does not exist')) {
+        return {
+          statusCode: 404,
+          headers: {
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': '*',
+          },
+          body: JSON.stringify({
+            message: `Tenant ${tenantId} not found`,
+          }),
+        };
+      }
+      throw error;
+    }
+  } catch (error) {
+    console.error('Error getting tenant status:', error);
+    return {
+      statusCode: 500,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      },
+      body: JSON.stringify({
+        message: 'Internal server error',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }),
+    };
+  }
+};

--- a/packages/cdk/lambda/onboardTenant.ts
+++ b/packages/cdk/lambda/onboardTenant.ts
@@ -1,0 +1,300 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { CloudFormationClient, CreateStackCommand, DescribeStacksCommand, Stack } from '@aws-sdk/client-cloudformation';
+import { DynamoDBClient, DescribeTableCommand } from '@aws-sdk/client-dynamodb';
+
+const cfnClient = new CloudFormationClient({});
+const dynamoClient = new DynamoDBClient({});
+
+interface OnboardTenantRequest {
+  tenantId: string;
+  tenantName?: string;
+  adminEmail?: string;
+  billingMode?: 'PAY_PER_REQUEST' | 'PROVISIONED';
+}
+
+/**
+ * Lambda function to onboard a new tenant by creating their DynamoDB tables
+ */
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    // Parse request body
+    const request: OnboardTenantRequest = JSON.parse(event.body || '{}');
+    
+    if (!request.tenantId) {
+      return {
+        statusCode: 400,
+        headers: {
+          'Content-Type': 'application/json',
+          'Access-Control-Allow-Origin': '*',
+        },
+        body: JSON.stringify({
+          message: 'Tenant ID is required',
+        }),
+      };
+    }
+
+    // Sanitize tenant ID
+    const sanitizedTenantId = request.tenantId.replace(/[^a-zA-Z0-9-]/g, '-');
+    const stackName = `TenantDynamoDB-${sanitizedTenantId}`;
+
+    // Check if stack already exists
+    try {
+      const describeResult = await cfnClient.send(
+        new DescribeStacksCommand({
+          StackName: stackName,
+        })
+      );
+
+      const stack = describeResult.Stacks?.[0];
+      if (stack && stack.StackStatus !== 'DELETE_COMPLETE') {
+        return {
+          statusCode: 409,
+          headers: {
+            'Content-Type': 'application/json',
+            'Access-Control-Allow-Origin': '*',
+          },
+          body: JSON.stringify({
+            message: `Tenant ${request.tenantId} already exists`,
+            stackName,
+            status: stack.StackStatus,
+          }),
+        };
+      }
+    } catch (error: any) {
+      // Stack doesn't exist, which is what we want
+      if (error.name !== 'ValidationError') {
+        throw error;
+      }
+    }
+
+    // Create CloudFormation template
+    const template = {
+      AWSTemplateFormatVersion: '2010-09-09',
+      Description: `DynamoDB tables for tenant ${request.tenantId}`,
+      Resources: {
+        ChatHistoryTable: {
+          Type: 'AWS::DynamoDB::Table',
+          Properties: {
+            TableName: `ChatHistory-tenant-${sanitizedTenantId}`,
+            AttributeDefinitions: [
+              {
+                AttributeName: 'id',
+                AttributeType: 'S',
+              },
+              {
+                AttributeName: 'createdDate',
+                AttributeType: 'S',
+              },
+              {
+                AttributeName: 'feedback',
+                AttributeType: 'S',
+              },
+            ],
+            KeySchema: [
+              {
+                AttributeName: 'id',
+                KeyType: 'HASH',
+              },
+              {
+                AttributeName: 'createdDate',
+                KeyType: 'RANGE',
+              },
+            ],
+            BillingMode: request.billingMode || 'PAY_PER_REQUEST',
+            PointInTimeRecoverySpecification: {
+              PointInTimeRecoveryEnabled: true,
+            },
+            SSESpecification: {
+              SSEEnabled: true,
+            },
+            GlobalSecondaryIndexes: [
+              {
+                IndexName: 'FeedbackIndex',
+                KeySchema: [
+                  {
+                    AttributeName: 'feedback',
+                    KeyType: 'HASH',
+                  },
+                ],
+                Projection: {
+                  ProjectionType: 'ALL',
+                },
+              },
+            ],
+            Tags: [
+              {
+                Key: 'TenantId',
+                Value: request.tenantId,
+              },
+              {
+                Key: 'Purpose',
+                Value: 'TenantChatHistory',
+              },
+            ],
+          },
+        },
+        TokenUsageStatsTable: {
+          Type: 'AWS::DynamoDB::Table',
+          Properties: {
+            TableName: `TokenUsageStats-tenant-${sanitizedTenantId}`,
+            AttributeDefinitions: [
+              {
+                AttributeName: 'id',
+                AttributeType: 'S',
+              },
+              {
+                AttributeName: 'userId',
+                AttributeType: 'S',
+              },
+              {
+                AttributeName: 'month',
+                AttributeType: 'S',
+              },
+            ],
+            KeySchema: [
+              {
+                AttributeName: 'id',
+                KeyType: 'HASH',
+              },
+              {
+                AttributeName: 'userId',
+                KeyType: 'RANGE',
+              },
+            ],
+            BillingMode: request.billingMode || 'PAY_PER_REQUEST',
+            PointInTimeRecoverySpecification: {
+              PointInTimeRecoveryEnabled: true,
+            },
+            SSESpecification: {
+              SSEEnabled: true,
+            },
+            GlobalSecondaryIndexes: [
+              {
+                IndexName: 'MonthIndex',
+                KeySchema: [
+                  {
+                    AttributeName: 'month',
+                    KeyType: 'HASH',
+                  },
+                  {
+                    AttributeName: 'userId',
+                    KeyType: 'RANGE',
+                  },
+                ],
+                Projection: {
+                  ProjectionType: 'ALL',
+                },
+              },
+            ],
+            Tags: [
+              {
+                Key: 'TenantId',
+                Value: request.tenantId,
+              },
+              {
+                Key: 'Purpose',
+                Value: 'TenantTokenUsageStats',
+              },
+            ],
+          },
+        },
+      },
+      Outputs: {
+        ChatHistoryTableName: {
+          Description: 'Name of the chat history table',
+          Value: { Ref: 'ChatHistoryTable' },
+          Export: {
+            Name: `${stackName}-ChatHistoryTableName`,
+          },
+        },
+        TokenUsageStatsTableName: {
+          Description: 'Name of the token usage stats table',
+          Value: { Ref: 'TokenUsageStatsTable' },
+          Export: {
+            Name: `${stackName}-TokenUsageStatsTableName`,
+          },
+        },
+        ChatHistoryTableArn: {
+          Description: 'ARN of the chat history table',
+          Value: { 'Fn::GetAtt': ['ChatHistoryTable', 'Arn'] },
+          Export: {
+            Name: `${stackName}-ChatHistoryTableArn`,
+          },
+        },
+        TokenUsageStatsTableArn: {
+          Description: 'ARN of the token usage stats table',
+          Value: { 'Fn::GetAtt': ['TokenUsageStatsTable', 'Arn'] },
+          Export: {
+            Name: `${stackName}-TokenUsageStatsTableArn`,
+          },
+        },
+      },
+    };
+
+    // Create the stack
+    await cfnClient.send(
+      new CreateStackCommand({
+        StackName: stackName,
+        TemplateBody: JSON.stringify(template),
+        Tags: [
+          {
+            Key: 'TenantId',
+            Value: request.tenantId,
+          },
+          {
+            Key: 'TenantName',
+            Value: request.tenantName || request.tenantId,
+          },
+          {
+            Key: 'Purpose',
+            Value: 'TenantDynamoDBStack',
+          },
+        ],
+        Capabilities: ['CAPABILITY_IAM'],
+      })
+    );
+
+    // Log tenant metadata if needed
+    if (request.adminEmail || request.tenantName) {
+      console.log('Tenant onboarded:', {
+        tenantId: request.tenantId,
+        tenantName: request.tenantName,
+        adminEmail: request.adminEmail,
+        stackName,
+        timestamp: new Date().toISOString(),
+      });
+    }
+
+    return {
+      statusCode: 201,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      },
+      body: JSON.stringify({
+        message: 'Tenant onboarding initiated successfully',
+        tenantId: request.tenantId,
+        stackName,
+        tables: {
+          chatHistory: `ChatHistory-tenant-${sanitizedTenantId}`,
+          tokenUsageStats: `TokenUsageStats-tenant-${sanitizedTenantId}`,
+        },
+      }),
+    };
+  } catch (error) {
+    console.error('Error onboarding tenant:', error);
+    return {
+      statusCode: 500,
+      headers: {
+        'Content-Type': 'application/json',
+        'Access-Control-Allow-Origin': '*',
+      },
+      body: JSON.stringify({
+        message: 'Internal server error',
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }),
+    };
+  }
+};

--- a/packages/cdk/lib/construct/api.ts
+++ b/packages/cdk/lib/construct/api.ts
@@ -29,6 +29,7 @@ import {
 } from '@generative-ai-use-cases/common';
 import { allowS3AccessWithSourceIpCondition } from '../utils/s3-access-policy';
 import { LAMBDA_RUNTIME_NODEJS } from '../../consts';
+import { TenantManagement } from './tenant-management';
 
 export interface BackendApiProps {
   // Context Params
@@ -1078,6 +1079,13 @@ export class Api extends Construct {
       new LambdaIntegration(getTokenUsageFunction),
       commonAuthorizerProps
     );
+
+    // Add tenant management endpoints
+    new TenantManagement(this, 'TenantManagement', {
+      api,
+      userPool,
+      authorizer,
+    });
 
     this.api = api;
     this.predictStreamFunction = predictStreamFunction;

--- a/packages/cdk/lib/construct/tenant-management.ts
+++ b/packages/cdk/lib/construct/tenant-management.ts
@@ -1,0 +1,147 @@
+import { Construct } from 'constructs';
+import { Duration, Stack } from 'aws-cdk-lib';
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { AuthorizationType, CognitoUserPoolsAuthorizer, LambdaIntegration, RestApi } from 'aws-cdk-lib/aws-apigateway';
+import { UserPool } from 'aws-cdk-lib/aws-cognito';
+import { LAMBDA_RUNTIME_NODEJS } from '../../consts';
+
+export interface TenantManagementProps {
+  /**
+   * The API Gateway REST API to add tenant management endpoints to
+   */
+  readonly api: RestApi;
+
+  /**
+   * The Cognito User Pool for authentication
+   */
+  readonly userPool: UserPool;
+
+  /**
+   * The User Pool authorizer
+   */
+  readonly authorizer: CognitoUserPoolsAuthorizer;
+}
+
+/**
+ * Construct for tenant management functionality
+ */
+export class TenantManagement extends Construct {
+  /**
+   * Lambda function for onboarding new tenants
+   */
+  public readonly onboardTenantFunction: NodejsFunction;
+
+  /**
+   * Lambda function for getting tenant status
+   */
+  public readonly getTenantStatusFunction: NodejsFunction;
+
+  constructor(scope: Construct, id: string, props: TenantManagementProps) {
+    super(scope, id);
+
+    const { api, userPool, authorizer } = props;
+
+    // Lambda function for tenant onboarding
+    this.onboardTenantFunction = new NodejsFunction(this, 'OnboardTenant', {
+      runtime: LAMBDA_RUNTIME_NODEJS,
+      entry: './lambda/onboardTenant.ts',
+      timeout: Duration.minutes(5),
+      memorySize: 256,
+      environment: {
+        USER_POOL_ID: userPool.userPoolId,
+      },
+    });
+
+    // Grant permissions to create CloudFormation stacks and DynamoDB tables
+    this.onboardTenantFunction.addToRolePolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: [
+          'cloudformation:CreateStack',
+          'cloudformation:DescribeStacks',
+          'cloudformation:ListStacks',
+        ],
+        resources: [
+          `arn:aws:cloudformation:${Stack.of(this).region}:${Stack.of(this).account}:stack/TenantDynamoDB-*/*`,
+        ],
+      })
+    );
+
+    // Grant permissions to manage DynamoDB tables
+    this.onboardTenantFunction.addToRolePolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: [
+          'dynamodb:CreateTable',
+          'dynamodb:DescribeTable',
+          'dynamodb:ListTables',
+          'dynamodb:TagResource',
+        ],
+        resources: [
+          `arn:aws:dynamodb:${Stack.of(this).region}:${Stack.of(this).account}:table/*-tenant-*`,
+        ],
+      })
+    );
+
+    // Lambda function for getting tenant status
+    this.getTenantStatusFunction = new NodejsFunction(this, 'GetTenantStatus', {
+      runtime: LAMBDA_RUNTIME_NODEJS,
+      entry: './lambda/getTenantStatus.ts',
+      timeout: Duration.minutes(1),
+      memorySize: 256,
+      environment: {
+        USER_POOL_ID: userPool.userPoolId,
+      },
+    });
+
+    // Grant permissions to describe stacks and tables
+    this.getTenantStatusFunction.addToRolePolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: [
+          'cloudformation:DescribeStacks',
+        ],
+        resources: [
+          `arn:aws:cloudformation:${Stack.of(this).region}:${Stack.of(this).account}:stack/TenantDynamoDB-*/*`,
+        ],
+      })
+    );
+
+    this.getTenantStatusFunction.addToRolePolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: [
+          'dynamodb:DescribeTable',
+        ],
+        resources: [
+          `arn:aws:dynamodb:${Stack.of(this).region}:${Stack.of(this).account}:table/*-tenant-*`,
+        ],
+      })
+    );
+
+    // API Gateway endpoints
+    const tenantsResource = api.root.addResource('tenants');
+
+    // POST /tenants - Onboard a new tenant
+    tenantsResource.addMethod(
+      'POST',
+      new LambdaIntegration(this.onboardTenantFunction),
+      {
+        authorizationType: AuthorizationType.COGNITO,
+        authorizer,
+      }
+    );
+
+    // GET /tenants/{tenantId} - Get tenant status
+    const tenantResource = tenantsResource.addResource('{tenantId}');
+    tenantResource.addMethod(
+      'GET',
+      new LambdaIntegration(this.getTenantStatusFunction),
+      {
+        authorizationType: AuthorizationType.COGNITO,
+        authorizer,
+      }
+    );
+  }
+}

--- a/packages/cdk/lib/stacks/tenant/tenant-dynamodb-stack.ts
+++ b/packages/cdk/lib/stacks/tenant/tenant-dynamodb-stack.ts
@@ -1,0 +1,149 @@
+import * as cdk from 'aws-cdk-lib';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import { Construct } from 'constructs';
+
+export interface TenantDynamoDBStackProps extends cdk.StackProps {
+  /**
+   * The tenant identifier
+   */
+  readonly tenantId: string;
+
+  /**
+   * Description for the stack
+   * @default 'DynamoDB tables for tenant {tenantId}'
+   */
+  readonly description?: string;
+
+  /**
+   * Billing mode for the tables
+   * @default BillingMode.PAY_PER_REQUEST
+   */
+  readonly billingMode?: dynamodb.BillingMode;
+
+  /**
+   * Enable point-in-time recovery
+   * @default true
+   */
+  readonly pointInTimeRecovery?: boolean;
+
+  /**
+   * Removal policy for tables
+   * @default RemovalPolicy.RETAIN
+   */
+  readonly removalPolicy?: cdk.RemovalPolicy;
+}
+
+/**
+ * Stack for creating tenant-specific DynamoDB tables
+ */
+export class TenantDynamoDBStack extends cdk.Stack {
+  /**
+   * The chat history table for the tenant
+   */
+  public readonly chatHistoryTable: dynamodb.Table;
+
+  /**
+   * The token usage statistics table for the tenant
+   */
+  public readonly tokenUsageStatsTable: dynamodb.Table;
+
+  constructor(scope: Construct, id: string, props: TenantDynamoDBStackProps) {
+    super(scope, id, props);
+
+    const { tenantId } = props;
+
+    // Validate tenant ID
+    if (!tenantId || tenantId.trim() === '') {
+      throw new Error('Tenant ID is required');
+    }
+
+    // Sanitize tenant ID for use in resource names
+    const sanitizedTenantId = tenantId.replace(/[^a-zA-Z0-9-]/g, '-');
+
+    // Chat History Table
+    this.chatHistoryTable = new dynamodb.Table(this, 'ChatHistoryTable', {
+      tableName: `ChatHistory-tenant-${sanitizedTenantId}`,
+      partitionKey: {
+        name: 'id',
+        type: dynamodb.AttributeType.STRING,
+      },
+      sortKey: {
+        name: 'createdDate',
+        type: dynamodb.AttributeType.STRING,
+      },
+      billingMode: props.billingMode || dynamodb.BillingMode.PAY_PER_REQUEST,
+      pointInTimeRecovery: props.pointInTimeRecovery !== false,
+      removalPolicy: props.removalPolicy || cdk.RemovalPolicy.RETAIN,
+      encryption: dynamodb.TableEncryption.AWS_MANAGED,
+    });
+
+    // Add feedback index
+    this.chatHistoryTable.addGlobalSecondaryIndex({
+      indexName: 'FeedbackIndex',
+      partitionKey: {
+        name: 'feedback',
+        type: dynamodb.AttributeType.STRING,
+      },
+    });
+
+    // Token Usage Stats Table
+    this.tokenUsageStatsTable = new dynamodb.Table(this, 'TokenUsageStatsTable', {
+      tableName: `TokenUsageStats-tenant-${sanitizedTenantId}`,
+      partitionKey: {
+        name: 'id',
+        type: dynamodb.AttributeType.STRING,
+      },
+      sortKey: {
+        name: 'userId',
+        type: dynamodb.AttributeType.STRING,
+      },
+      billingMode: props.billingMode || dynamodb.BillingMode.PAY_PER_REQUEST,
+      pointInTimeRecovery: props.pointInTimeRecovery !== false,
+      removalPolicy: props.removalPolicy || cdk.RemovalPolicy.RETAIN,
+      encryption: dynamodb.TableEncryption.AWS_MANAGED,
+    });
+
+    // Add month index for usage stats
+    this.tokenUsageStatsTable.addGlobalSecondaryIndex({
+      indexName: 'MonthIndex',
+      partitionKey: {
+        name: 'month',
+        type: dynamodb.AttributeType.STRING,
+      },
+      sortKey: {
+        name: 'userId',
+        type: dynamodb.AttributeType.STRING,
+      },
+    });
+
+    // Output table ARNs
+    new cdk.CfnOutput(this, 'ChatHistoryTableArn', {
+      value: this.chatHistoryTable.tableArn,
+      description: `ARN of the chat history table for tenant ${tenantId}`,
+      exportName: `${this.stackName}-ChatHistoryTableArn`,
+    });
+
+    new cdk.CfnOutput(this, 'TokenUsageStatsTableArn', {
+      value: this.tokenUsageStatsTable.tableArn,
+      description: `ARN of the token usage stats table for tenant ${tenantId}`,
+      exportName: `${this.stackName}-TokenUsageStatsTableArn`,
+    });
+
+    // Output table names
+    new cdk.CfnOutput(this, 'ChatHistoryTableName', {
+      value: this.chatHistoryTable.tableName,
+      description: `Name of the chat history table for tenant ${tenantId}`,
+      exportName: `${this.stackName}-ChatHistoryTableName`,
+    });
+
+    new cdk.CfnOutput(this, 'TokenUsageStatsTableName', {
+      value: this.tokenUsageStatsTable.tableName,
+      description: `Name of the token usage stats table for tenant ${tenantId}`,
+      exportName: `${this.stackName}-TokenUsageStatsTableName`,
+    });
+
+    // Add tags
+    cdk.Tags.of(this).add('TenantId', tenantId);
+    cdk.Tags.of(this).add('Purpose', 'TenantDynamoDBTables');
+  }
+}

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -9,6 +9,7 @@
     "cdk": "cdk",
     "lint": "eslint . --ext ts --report-unused-disable-directives --max-warnings 0",
     "lambda-build-dryrun": "tsc --noEmit --skipLibCheck",
+    "provision-tenant": "ts-node scripts/provision-tenant.ts",
     "postinstall": "npm ci --prefix custom-resources"
   },
   "devDependencies": {

--- a/packages/cdk/scripts/provision-tenant.ts
+++ b/packages/cdk/scripts/provision-tenant.ts
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+import * as cdk from 'aws-cdk-lib';
+import { TenantDynamoDBStack } from '../lib/stacks/tenant/tenant-dynamodb-stack';
+
+/**
+ * Script to provision DynamoDB tables for a new tenant
+ * 
+ * Usage:
+ *   npm run provision-tenant -- --tenant-id <tenant-id> [--region <region>] [--profile <profile>]
+ * 
+ * Examples:
+ *   npm run provision-tenant -- --tenant-id acme-corp
+ *   npm run provision-tenant -- --tenant-id acme-corp --region us-west-2
+ *   npm run provision-tenant -- --tenant-id acme-corp --profile production
+ */
+
+interface ProvisionTenantArgs {
+  tenantId: string;
+  region?: string;
+  profile?: string;
+  stackName?: string;
+}
+
+function parseArgs(): ProvisionTenantArgs {
+  const args = process.argv.slice(2);
+  const result: Partial<ProvisionTenantArgs> = {};
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--tenant-id':
+        result.tenantId = args[++i];
+        break;
+      case '--region':
+        result.region = args[++i];
+        break;
+      case '--profile':
+        result.profile = args[++i];
+        break;
+      case '--stack-name':
+        result.stackName = args[++i];
+        break;
+    }
+  }
+
+  if (!result.tenantId) {
+    console.error('Error: --tenant-id is required');
+    console.error('Usage: npm run provision-tenant -- --tenant-id <tenant-id> [--region <region>] [--profile <profile>]');
+    process.exit(1);
+  }
+
+  return result as ProvisionTenantArgs;
+}
+
+async function main() {
+  const args = parseArgs();
+  
+  console.log(`Provisioning DynamoDB tables for tenant: ${args.tenantId}`);
+  
+  const app = new cdk.App();
+  
+  // Generate stack name if not provided
+  const stackName = args.stackName || `TenantDynamoDB-${args.tenantId}`;
+  
+  // Create the stack
+  new TenantDynamoDBStack(app, stackName, {
+    tenantId: args.tenantId,
+    description: `DynamoDB tables for tenant ${args.tenantId}`,
+    env: {
+      region: args.region || process.env.CDK_DEFAULT_REGION,
+      account: process.env.CDK_DEFAULT_ACCOUNT,
+    },
+  });
+
+  // Synthesize
+  app.synth();
+  
+  console.log(`Stack ${stackName} synthesized successfully`);
+  console.log(`To deploy, run: cdk deploy ${stackName}${args.profile ? ` --profile ${args.profile}` : ''}`);
+}
+
+main().catch((error) => {
+  console.error('Error:', error);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- テナント専用のDynamoDBテーブルを作成するCDKスタックを実装
- REST API経由でテナントをオンボーディングする機能を追加
- テナントリソースのステータスを確認する機能を追加

## Implementation Details

### 1. TenantDynamoDBStack
- 各テナント専用のDynamoDBテーブルを作成するCDKスタック
- ChatHistoryとTokenUsageStatsの2つのテーブルを作成
- ポイントインタイムリカバリと暗号化を有効化
- 削除ポリシーはRETAIN（データ保護）

### 2. Tenant Management API
- `POST /tenants` - 新規テナントのオンボーディング
- `GET /tenants/{tenantId}` - テナントステータスの確認
- CloudFormationを使用してインフラを自動プロビジョニング

### 3. Provisioning Methods
- REST API（推奨）
- CDK CLIでの直接デプロイ
- TypeScriptスクリプトでのバッチプロビジョニング

## Benefits
- 完全なテナントデータ分離
- 自動化されたプロビジョニングプロセス
- テナント別のコスト管理とモニタリング
- スケーラブルなマルチテナントアーキテクチャ

## Testing
- [ ] テナントオンボーディングAPIのテスト
- [ ] ステータス確認APIのテスト
- [ ] CDKデプロイのテスト
- [ ] プロビジョニングスクリプトのテスト

## Documentation
- 詳細なプロビジョニングガイドを追加（docs/tenant-provisioning-guide.md）

## Related
- #16 (マルチテナントDynamoDBアクセスの実装)

🤖 Generated with [Claude Code](https://claude.ai/code)