### PR TITLE
✨ feat(auth): メールアドレス単位でホワイトリストを設定できる項目を追加

### DIFF
--- a/packages/cdk/cdk.example.json
+++ b/packages/cdk/cdk.example.json
@@ -34,6 +34,7 @@
     "queryDecompositionEnabled": false,
     "selfSignUpEnabled": true,
     "allowedSignUpEmailDomains": null,
+    "allowedSignUpEmails": null,
     "samlAuthEnabled": false,
     "samlCognitoDomainName": "",
     "samlCognitoFederatedIdentityProviderName": "",

--- a/packages/cdk/lambda/checkEmailDomain.ts
+++ b/packages/cdk/lambda/checkEmailDomain.ts
@@ -6,16 +6,32 @@ const ALLOWED_SIGN_UP_EMAIL_DOMAINS: string[] = JSON.parse(
   ALLOWED_SIGN_UP_EMAIL_DOMAINS_STR!
 );
 
-// Determine if the email domain is allowed
-const checkEmailDomain = (email: string): boolean => {
-  // If the number of @ in the email address is not one, always allow it
+const ALLOWED_SIGN_UP_EMAILS_STR = process.env.ALLOWED_SIGN_UP_EMAILS_STR;
+const ALLOWED_SIGN_UP_EMAILS: string[] = JSON.parse(
+  ALLOWED_SIGN_UP_EMAILS_STR || '[]'
+);
+
+// Determine if the email is allowed
+const checkEmail = (email: string): boolean => {
+  // If the number of @ in the email address is not one, always reject it
   if (email.split('@').length !== 2) {
     return false;
   }
 
-  // If the domain part of the email address matches any of the allowed domains, allow it
-  // Otherwise, do not allow it
-  // (If ALLOWED_SIGN_UP_EMAIL_DOMAINS is empty, always allow it)
+  // If both allowed emails and domains are empty, allow all
+  if (
+    ALLOWED_SIGN_UP_EMAILS.length === 0 &&
+    ALLOWED_SIGN_UP_EMAIL_DOMAINS.length === 0
+  ) {
+    return true;
+  }
+
+  // Check if the email is in the allowed emails list
+  if (ALLOWED_SIGN_UP_EMAILS.includes(email)) {
+    return true;
+  }
+
+  // Check if the domain part of the email address matches any of the allowed domains
   const domain = email.split('@')[1];
   return ALLOWED_SIGN_UP_EMAIL_DOMAINS.includes(domain);
 };
@@ -35,13 +51,13 @@ exports.handler = async (
   try {
     console.log('Received event:', JSON.stringify(event, null, 2));
 
-    const isAllowed = checkEmailDomain(event.request.userAttributes.email);
+    const isAllowed = checkEmail(event.request.userAttributes.email);
     if (isAllowed) {
       // If successful, return the event object as is
       callback(null, event);
     } else {
       // If failed, return an error message
-      callback(new Error('Invalid email domain'));
+      callback(new Error('Invalid email domain or email address'));
     }
   } catch (error) {
     console.log('Error ocurred:', error);

--- a/packages/cdk/lib/construct/auth.ts
+++ b/packages/cdk/lib/construct/auth.ts
@@ -21,6 +21,7 @@ export interface AuthProps {
   readonly allowedIpV4AddressRanges?: string[] | null;
   readonly allowedIpV6AddressRanges?: string[] | null;
   readonly allowedSignUpEmailDomains?: string[] | null;
+  readonly allowedSignUpEmails?: string[] | null;
   readonly samlAuthEnabled: boolean;
 }
 
@@ -112,7 +113,7 @@ export class Auth extends Construct {
     );
 
     // Lambda
-    if (props.allowedSignUpEmailDomains) {
+    if (props.allowedSignUpEmailDomains || props.allowedSignUpEmails) {
       const checkEmailDomainFunction = new NodejsFunction(
         this,
         'CheckEmailDomain',
@@ -122,7 +123,10 @@ export class Auth extends Construct {
           timeout: Duration.minutes(15),
           environment: {
             ALLOWED_SIGN_UP_EMAIL_DOMAINS_STR: JSON.stringify(
-              props.allowedSignUpEmailDomains
+              props.allowedSignUpEmailDomains || []
+            ),
+            ALLOWED_SIGN_UP_EMAILS_STR: JSON.stringify(
+              props.allowedSignUpEmails || []
             ),
           },
         }

--- a/packages/cdk/lib/stack-input.ts
+++ b/packages/cdk/lib/stack-input.ts
@@ -10,6 +10,7 @@ const baseStackInputSchema = z.object({
   // Auth
   selfSignUpEnabled: z.boolean().default(true),
   allowedSignUpEmailDomains: z.array(z.string()).nullish(),
+  allowedSignUpEmails: z.array(z.string()).nullish(),
   samlAuthEnabled: z.boolean().default(false),
   samlCognitoDomainName: z.string().nullish(),
   samlCognitoFederatedIdentityProviderName: z.string().nullish(),

--- a/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
@@ -62,6 +62,7 @@ export class GenerativeAiUseCasesStack extends Stack {
       allowedIpV4AddressRanges: params.allowedIpV4AddressRanges,
       allowedIpV6AddressRanges: params.allowedIpV6AddressRanges,
       allowedSignUpEmailDomains: params.allowedSignUpEmailDomains,
+      allowedSignUpEmails: params.allowedSignUpEmails,
       samlAuthEnabled: params.samlAuthEnabled,
     });
 


### PR DESCRIPTION
## 変更の概要
これまではドメイン単位でのホワイトリストを設定することで、ログイン可能なユーザを制限することが可能でした
今回の変更では、ドメイン単位だけではなくメールアドレス全体のホワイトリストを設定することも可能となります

## 申し送り事項

<!-- レビュワーに伝えておきたい事柄等を書く（Draftの理由など） -->

## Checklist（レビュワー用）

- [ ] `npm run lint`でエラーが出ない
- [ ] TypeScriptのビルドで型エラーが出ない
- [ ] 手元でフォーマットした際に差分が出ない
