### PR TITLE
:recycle: refactor(auth): Cognito Enhanced Flow 移行後のクリーンアップ

### DIFF
--- a/packages/cdk/lambda/createMessages.ts
+++ b/packages/cdk/lambda/createMessages.ts
@@ -10,6 +10,41 @@ const isValidExtraData = (extra: ExtraData, bucketName: string): boolean => {
   );
 };
 
+const validateMessages = (
+  messages: CreateMessagesRequest['messages'],
+  bucketName: string
+): { isValid: boolean; error?: string } => {
+  if (!messages) {
+    return { isValid: true };
+  }
+
+  for (const message of messages) {
+    if (!message.extraData || message.extraData.length === 0) {
+      continue;
+    }
+
+    for (const extra of message.extraData) {
+      if (!isValidExtraData(extra, bucketName)) {
+        return { isValid: false, error: 'Invalid extraData' };
+      }
+    }
+  }
+
+  return { isValid: true };
+};
+
+const createResponse = (
+  statusCode: number,
+  body: object
+): APIGatewayProxyResult => ({
+  statusCode,
+  headers: {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+  },
+  body: JSON.stringify(body),
+});
+
 export const handler = async (
   event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResult> => {
@@ -22,37 +57,16 @@ export const handler = async (
     // Authorization check: Verify if the specified chat belongs to the user
     const chat = await findChatById(userId, chatId, event);
     if (chat === null) {
-      return {
-        statusCode: 403,
-        headers: {
-          'Content-Type': 'application/json',
-          'Access-Control-Allow-Origin': '*',
-        },
-        body: JSON.stringify({
-          message: 'You do not have permission to post messages in the chat.',
-        }),
-      };
+      return createResponse(403, {
+        message: 'You do not have permission to post messages in the chat.',
+      });
     }
 
-    if (req.messages) {
-      for (const message of req.messages) {
-        if (message.extraData && message.extraData.length > 0) {
-          for (const extra of message.extraData) {
-            if (!isValidExtraData(extra, FILE_UPLOAD_BUCKET_NAME)) {
-              return {
-                statusCode: 400,
-                headers: {
-                  'Content-Type': 'application/json',
-                  'Access-Control-Allow-Origin': '*',
-                },
-                body: JSON.stringify({
-                  message: 'Invalid extraData',
-                }),
-              };
-            }
-          }
-        }
-      }
+    const validation = validateMessages(req.messages, FILE_UPLOAD_BUCKET_NAME);
+    if (!validation.isValid) {
+      return createResponse(400, {
+        message: validation.error,
+      });
     }
 
     const messages = await batchCreateMessages(
@@ -62,25 +76,9 @@ export const handler = async (
       event
     );
 
-    return {
-      statusCode: 200,
-      headers: {
-        'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
-      },
-      body: JSON.stringify({
-        messages,
-      }),
-    };
+    return createResponse(200, { messages });
   } catch (error) {
     console.log(error);
-    return {
-      statusCode: 500,
-      headers: {
-        'Content-Type': 'application/json',
-        'Access-Control-Allow-Origin': '*',
-      },
-      body: JSON.stringify({ message: 'Internal Server Error' }),
-    };
+    return createResponse(500, { message: 'Internal Server Error' });
   }
 };

--- a/packages/cdk/lambda/pre_token_generation/index.py
+++ b/packages/cdk/lambda/pre_token_generation/index.py
@@ -1,4 +1,7 @@
 import json
+import os
+
+DEFAULT_TENANT_ID = os.environ.get('DEFAULT_TENANT_ID', 'default')
 
 def handler(event, context):
     """
@@ -9,7 +12,7 @@ def handler(event, context):
         print(f"Pre Token Generation Event: {json.dumps(event, indent=2)}")
         
         user_attributes = event["request"]["userAttributes"]
-        tenant_id = user_attributes.get("custom:tenant_id", "default")
+        tenant_id = user_attributes.get("custom:tenant_id", DEFAULT_TENANT_ID)
         
         # For Identity Pool Enhanced Flow, we only need to ensure the custom:tenant_id
         # claim is present in the JWT. The Identity Pool will automatically map

--- a/packages/cdk/lambda/repository.ts
+++ b/packages/cdk/lambda/repository.ts
@@ -25,10 +25,11 @@ import { APIGatewayProxyEvent } from 'aws-lambda';
 import { getTenantId } from './utils/tenantUtils';
 import { createTenantDynamoDBClient } from './utils/tenantDynamoDBClient';
 
-const TABLE_PREFIX: string = process.env.TABLE_NAME!;
+const TABLE_PREFIX: string = process.env.TABLE_PREFIX!;
 const DEFAULT_TABLE_NAME: string = process.env.DEFAULT_TABLE_NAME!;
 const STATS_TABLE_PREFIX: string = process.env.STATS_TABLE_NAME!;
 const DEFAULT_STATS_TABLE_NAME: string = process.env.DEFAULT_STATS_TABLE_NAME!;
+const DEFAULT_TENANT_ID: string = process.env.DEFAULT_TENANT_ID!;
 
 /**
  * Get or create a tenant-specific DynamoDB document client
@@ -40,14 +41,13 @@ async function getTenantDynamoDBDocument(
   const tenantId = getTenantId(event);
 
   // For default tenant, use standard DynamoDB client
-  if (!tenantId || tenantId === 'default') {
+  if (!tenantId || tenantId === DEFAULT_TENANT_ID) {
     // Create standard DynamoDB client without AssumeRole
     return DynamoDBDocumentClient.from(new DynamoDBClient({}));
   }
 
   try {
     // Try to create client with tenant credentials
-    // Each request gets fresh credentials to ensure proper user isolation
     const dynamoDb = await createTenantDynamoDBClient(event);
     return DynamoDBDocumentClient.from(dynamoDb);
   } catch (error) {
@@ -69,7 +69,7 @@ function getTableName(event: APIGatewayProxyEvent): string {
   const tenantId = getTenantId(event);
 
   // For default/fallback users, use the actual CDK-generated table name
-  if (!tenantId || tenantId === 'default') {
+  if (!tenantId || tenantId === DEFAULT_TENANT_ID) {
     return DEFAULT_TABLE_NAME;
   }
 
@@ -84,29 +84,12 @@ function getStatsTableName(event: APIGatewayProxyEvent): string {
   const tenantId = getTenantId(event);
 
   // For default/fallback users, use the actual CDK-generated stats table name
-  if (!tenantId || tenantId === 'default') {
+  if (!tenantId || tenantId === DEFAULT_TENANT_ID) {
     return DEFAULT_STATS_TABLE_NAME;
   }
 
   // For tenant users, construct tenant-specific stats table name directly
   return `${STATS_TABLE_PREFIX}-tenant-${tenantId}`;
-}
-
-// ============================================
-// Helper Functions
-// ============================================
-
-/**
- * Execute DynamoDB operation with proper tenant table selection
- */
-async function executeDynamoDBOperation<T>(
-  event: APIGatewayProxyEvent,
-  operation: (client: DynamoDBDocumentClient, tableName: string) => Promise<T>
-): Promise<T> {
-  const dynamoDbDocument = await getTenantDynamoDBDocument(event);
-  const tableName = getTableName(event);
-
-  return await operation(dynamoDbDocument, tableName);
 }
 
 // ============================================
@@ -117,6 +100,9 @@ export const createChat = async (
   _userId: string,
   event: APIGatewayProxyEvent
 ): Promise<Chat> => {
+  const dynamoDbDocument = await getTenantDynamoDBDocument(event);
+  const tableName = getTableName(event);
+
   const userId = `user#${_userId}`;
   const chatId = `chat#${crypto.randomUUID()}`;
   const item = {
@@ -128,16 +114,11 @@ export const createChat = async (
     updatedDate: '',
   };
 
-  await executeDynamoDBOperation(
-    event,
-    async (client, tableName) => {
-      return client.send(
-        new PutCommand({
-          TableName: tableName,
-          Item: item,
-        })
-      );
-    }
+  await dynamoDbDocument.send(
+    new PutCommand({
+      TableName: tableName,
+      Item: item,
+    })
   );
 
   return item;
@@ -148,28 +129,26 @@ export const findChatById = async (
   _chatId: string,
   event: APIGatewayProxyEvent
 ): Promise<Chat | null> => {
+  const dynamoDbDocument = await getTenantDynamoDBDocument(event);
+  const tableName = getTableName(event);
+
   const userId = `user#${_userId}`;
   const chatId = `chat#${_chatId}`;
 
-  const res = await executeDynamoDBOperation(
-    event,
-    async (client, tableName) => {
-      return client.send(
-        new QueryCommand({
-          TableName: tableName,
-          KeyConditionExpression: '#id = :id',
-          FilterExpression: '#chatId = :chatId',
-          ExpressionAttributeNames: {
-            '#id': 'id',
-            '#chatId': 'chatId',
-          },
-          ExpressionAttributeValues: {
-            ':id': userId,
-            ':chatId': chatId,
-          },
-        })
-      );
-    }
+  const res = await dynamoDbDocument.send(
+    new QueryCommand({
+      TableName: tableName,
+      KeyConditionExpression: '#id = :id',
+      FilterExpression: '#chatId = :chatId',
+      ExpressionAttributeNames: {
+        '#id': 'id',
+        '#chatId': 'chatId',
+      },
+      ExpressionAttributeValues: {
+        ':id': userId,
+        ':chatId': chatId,
+      },
+    })
   );
 
   if (!res.Items || res.Items.length === 0) {
@@ -184,28 +163,26 @@ export const findSystemContextById = async (
   _systemContextId: string,
   event: APIGatewayProxyEvent
 ): Promise<SystemContext | null> => {
+  const dynamoDbDocument = await getTenantDynamoDBDocument(event);
+  const tableName = getTableName(event);
+
   const userId = `systemContext#${_userId}`;
   const systemContextId = `systemContext#${_systemContextId}`;
 
-  const res = await executeDynamoDBOperation(
-    event,
-    async (client, tableName) => {
-      return client.send(
-        new QueryCommand({
-          TableName: tableName,
-          KeyConditionExpression: '#id = :id',
-          FilterExpression: '#systemContextId = :systemContextId',
-          ExpressionAttributeNames: {
-            '#id': 'id',
-            '#systemContextId': 'systemContextId',
-          },
-          ExpressionAttributeValues: {
-            ':id': userId,
-            ':systemContextId': systemContextId,
-          },
-        })
-      );
-    }
+  const res = await dynamoDbDocument.send(
+    new QueryCommand({
+      TableName: tableName,
+      KeyConditionExpression: '#id = :id',
+      FilterExpression: '#systemContextId = :systemContextId',
+      ExpressionAttributeNames: {
+        '#id': 'id',
+        '#systemContextId': 'systemContextId',
+      },
+      ExpressionAttributeValues: {
+        ':id': userId,
+        ':systemContextId': systemContextId,
+      },
+    })
   );
 
   if (!res.Items || res.Items.length === 0) {

--- a/packages/cdk/lambda/repositoryVideoJob.ts
+++ b/packages/cdk/lambda/repositoryVideoJob.ts
@@ -24,7 +24,7 @@ import {
 import { initBedrockRuntimeClient } from './utils/bedrockClient';
 
 const BUCKET_NAME: string = process.env.BUCKET_NAME!;
-const TABLE_NAME: string = process.env.TABLE_NAME!;
+const TABLE_NAME: string = process.env.TABLE_PREFIX!;
 const COPY_VIDEO_JOB_FUNCTION_ARN = process.env.COPY_VIDEO_JOB_FUNCTION_ARN!;
 const dynamoDb = new DynamoDBClient({});
 const dynamoDbDocument = DynamoDBDocumentClient.from(dynamoDb);

--- a/packages/cdk/lambda/utils/tenantCredentials.ts
+++ b/packages/cdk/lambda/utils/tenantCredentials.ts
@@ -14,7 +14,6 @@ const RETRY_DELAY = 1000; // milliseconds
 /**
  * Get credentials using Cognito Identity Pool Enhanced Flow with retry logic
  * The Identity Pool automatically maps JWT claims to principal tags for ABAC
- * NOTE: No caching to ensure proper user isolation within tenants
  */
 export async function getTenantCredentials(
   event: APIGatewayProxyEvent
@@ -32,7 +31,7 @@ export async function getTenantCredentials(
 
   // Extract tenant ID for logging
   const tenantId =
-    event.requestContext?.authorizer?.claims?.['custom:tenant_id'] || 'default';
+    event.requestContext?.authorizer?.claims?.['custom:tenant_id'] || process.env.DEFAULT_TENANT_ID;
 
   // Extract user ID for logging
   const userId =

--- a/packages/cdk/lambda/utils/tenantDynamoDBClient.ts
+++ b/packages/cdk/lambda/utils/tenantDynamoDBClient.ts
@@ -5,7 +5,6 @@ import { getTenantCredentials } from './tenantCredentials';
 /**
  * Create a DynamoDB client with tenant-isolated credentials from Cognito Identity Pool
  * IAM policies automatically restrict access to tenant-specific resources via principal tags
- * NOTE: No caching to ensure proper user isolation within tenants
  */
 export async function createTenantDynamoDBClient(
   event: APIGatewayProxyEvent

--- a/packages/cdk/lambda/utils/tenantUtils.ts
+++ b/packages/cdk/lambda/utils/tenantUtils.ts
@@ -1,5 +1,7 @@
 import { APIGatewayProxyEvent } from 'aws-lambda';
 
+const DEFAULT_TENANT_ID = process.env.DEFAULT_TENANT_ID!;
+
 /**
  * Extract tenant ID from the JWT claims in the API Gateway event
  */
@@ -9,10 +11,9 @@ export const getTenantId = (event: APIGatewayProxyEvent): string => {
     event.requestContext?.authorizer?.claims?.['custom:tenant_id'] ||
     event.requestContext?.authorizer?.['custom:tenant_id'] ||
     // Fallback to a default tenant for backwards compatibility
-    process.env.DEFAULT_TENANT_ID ||
-    'default';
+    DEFAULT_TENANT_ID;
 
-  if (!tenantId || tenantId === 'default') {
+  if (!tenantId || tenantId === DEFAULT_TENANT_ID) {
     console.warn('No tenant ID found in request, using default tenant');
   }
 

--- a/packages/cdk/lib/construct/api.ts
+++ b/packages/cdk/lib/construct/api.ts
@@ -255,7 +255,7 @@ export class Api extends Construct {
         nodeModules: ['@aws-sdk/client-bedrock-runtime'],
       },
       environment: {
-        TABLE_NAME: TABLE_PREFIX,
+        TABLE_PREFIX: TABLE_PREFIX,
         DEFAULT_TABLE_NAME: props.table.tableName,
         DEFAULT_TENANT_ID: DEFAULT_TENANT_ID,
         MULTI_TENANT_ROLE_ARN: props.multiTenantRole.roleArn,
@@ -307,7 +307,7 @@ export class Api extends Construct {
         VIDEO_BUCKET_REGION_MAP: JSON.stringify(props.videoBucketRegionMap),
         CROSS_ACCOUNT_BEDROCK_ROLE_ARN: crossAccountBedrockRoleArn ?? '',
         BUCKET_NAME: fileBucket.bucketName,
-        TABLE_NAME: TABLE_PREFIX,
+        TABLE_PREFIX: TABLE_PREFIX,
         DEFAULT_TABLE_NAME: props.table.tableName,
         DEFAULT_TENANT_ID: DEFAULT_TENANT_ID,
         LITELLM_ENDPOINT: litellmEndpoint ?? '',
@@ -348,7 +348,7 @@ export class Api extends Construct {
         VIDEO_BUCKET_REGION_MAP: JSON.stringify(props.videoBucketRegionMap),
         CROSS_ACCOUNT_BEDROCK_ROLE_ARN: crossAccountBedrockRoleArn ?? '',
         BUCKET_NAME: fileBucket.bucketName,
-        TABLE_NAME: TABLE_PREFIX,
+        TABLE_PREFIX: TABLE_PREFIX,
         DEFAULT_TABLE_NAME: props.table.tableName,
         DEFAULT_TENANT_ID: DEFAULT_TENANT_ID,
         MULTI_TENANT_ROLE_ARN: props.multiTenantRole.roleArn,
@@ -388,7 +388,7 @@ export class Api extends Construct {
         VIDEO_BUCKET_REGION_MAP: JSON.stringify(props.videoBucketRegionMap),
         CROSS_ACCOUNT_BEDROCK_ROLE_ARN: crossAccountBedrockRoleArn ?? '',
         BUCKET_NAME: fileBucket.bucketName,
-        TABLE_NAME: TABLE_PREFIX,
+        TABLE_PREFIX: TABLE_PREFIX,
         DEFAULT_TABLE_NAME: props.table.tableName,
         DEFAULT_TENANT_ID: DEFAULT_TENANT_ID,
         MULTI_TENANT_ROLE_ARN: props.multiTenantRole.roleArn,
@@ -412,7 +412,7 @@ export class Api extends Construct {
         MODEL_IDS: JSON.stringify(modelIds),
         IMAGE_GENERATION_MODEL_IDS: JSON.stringify(imageGenerationModelIds),
         VIDEO_GENERATION_MODEL_IDS: JSON.stringify(videoGenerationModelIds),
-        TABLE_NAME: TABLE_PREFIX,
+        TABLE_PREFIX: TABLE_PREFIX,
         DEFAULT_TABLE_NAME: props.table.tableName,
         DEFAULT_TENANT_ID: DEFAULT_TENANT_ID,
         MULTI_TENANT_ROLE_ARN: props.multiTenantRole.roleArn,
@@ -573,7 +573,7 @@ export class Api extends Construct {
       entry: './lambda/createChat.ts',
       timeout: Duration.minutes(15),
       environment: {
-        TABLE_NAME: TABLE_PREFIX,
+        TABLE_PREFIX: TABLE_PREFIX,
         DEFAULT_TABLE_NAME: props.table.tableName,
         DEFAULT_TENANT_ID: DEFAULT_TENANT_ID,
         MULTI_TENANT_ROLE_ARN: props.multiTenantRole.roleArn,
@@ -589,7 +589,7 @@ export class Api extends Construct {
       entry: './lambda/deleteChat.ts',
       timeout: Duration.minutes(15),
       environment: {
-        TABLE_NAME: TABLE_PREFIX,
+        TABLE_PREFIX: TABLE_PREFIX,
         DEFAULT_TABLE_NAME: props.table.tableName,
         DEFAULT_TENANT_ID: DEFAULT_TENANT_ID,
         MULTI_TENANT_ROLE_ARN: props.multiTenantRole.roleArn,
@@ -605,7 +605,7 @@ export class Api extends Construct {
       entry: './lambda/createMessages.ts',
       timeout: Duration.minutes(15),
       environment: {
-        TABLE_NAME: TABLE_PREFIX,
+        TABLE_PREFIX: TABLE_PREFIX,
         DEFAULT_TABLE_NAME: props.table.tableName,
         STATS_TABLE_NAME: STATS_TABLE_PREFIX,
         DEFAULT_STATS_TABLE_NAME: props.statsTable.tableName,
@@ -628,7 +628,7 @@ export class Api extends Construct {
         entry: './lambda/updateTitle.ts',
         timeout: Duration.minutes(15),
         environment: {
-          TABLE_NAME: TABLE_PREFIX,
+          TABLE_PREFIX: TABLE_PREFIX,
           DEFAULT_TABLE_NAME: props.table.tableName,
           DEFAULT_TENANT_ID: DEFAULT_TENANT_ID,
           MULTI_TENANT_ROLE_ARN: props.multiTenantRole.roleArn,
@@ -645,7 +645,7 @@ export class Api extends Construct {
       entry: './lambda/listChats.ts',
       timeout: Duration.minutes(15),
       environment: {
-        TABLE_NAME: TABLE_PREFIX,
+        TABLE_PREFIX: TABLE_PREFIX,
         DEFAULT_TABLE_NAME: props.table.tableName,
         STATS_TABLE_NAME: STATS_TABLE_PREFIX,
         DEFAULT_STATS_TABLE_NAME: props.statsTable.tableName,
@@ -663,7 +663,7 @@ export class Api extends Construct {
       entry: './lambda/findChatById.ts',
       timeout: Duration.minutes(15),
       environment: {
-        TABLE_NAME: TABLE_PREFIX,
+        TABLE_PREFIX: TABLE_PREFIX,
         DEFAULT_TABLE_NAME: props.table.tableName,
         DEFAULT_TENANT_ID: DEFAULT_TENANT_ID,
         MULTI_TENANT_ROLE_ARN: props.multiTenantRole.roleArn,
@@ -679,7 +679,7 @@ export class Api extends Construct {
       entry: './lambda/listMessages.ts',
       timeout: Duration.minutes(15),
       environment: {
-        TABLE_NAME: TABLE_PREFIX,
+        TABLE_PREFIX: TABLE_PREFIX,
         DEFAULT_TABLE_NAME: props.table.tableName,
         DEFAULT_TENANT_ID: DEFAULT_TENANT_ID,
         MULTI_TENANT_ROLE_ARN: props.multiTenantRole.roleArn,
@@ -695,7 +695,7 @@ export class Api extends Construct {
       entry: './lambda/updateFeedback.ts',
       timeout: Duration.minutes(15),
       environment: {
-        TABLE_NAME: TABLE_PREFIX,
+        TABLE_PREFIX: TABLE_PREFIX,
         DEFAULT_TABLE_NAME: props.table.tableName,
         DEFAULT_TENANT_ID: DEFAULT_TENANT_ID,
         MULTI_TENANT_ROLE_ARN: props.multiTenantRole.roleArn,
@@ -717,7 +717,7 @@ export class Api extends Construct {
       entry: './lambda/createShareId.ts',
       timeout: Duration.minutes(15),
       environment: {
-        TABLE_NAME: TABLE_PREFIX,
+        TABLE_PREFIX: TABLE_PREFIX,
         DEFAULT_TABLE_NAME: props.table.tableName,
         DEFAULT_TENANT_ID: DEFAULT_TENANT_ID,
         MULTI_TENANT_ROLE_ARN: props.multiTenantRole.roleArn,
@@ -733,7 +733,7 @@ export class Api extends Construct {
       entry: './lambda/getSharedChat.ts',
       timeout: Duration.minutes(15),
       environment: {
-        TABLE_NAME: TABLE_PREFIX,
+        TABLE_PREFIX: TABLE_PREFIX,
         DEFAULT_TABLE_NAME: props.table.tableName,
         DEFAULT_TENANT_ID: DEFAULT_TENANT_ID,
         MULTI_TENANT_ROLE_ARN: props.multiTenantRole.roleArn,
@@ -749,7 +749,7 @@ export class Api extends Construct {
       entry: './lambda/findShareId.ts',
       timeout: Duration.minutes(15),
       environment: {
-        TABLE_NAME: TABLE_PREFIX,
+        TABLE_PREFIX: TABLE_PREFIX,
         DEFAULT_TABLE_NAME: props.table.tableName,
         DEFAULT_TENANT_ID: DEFAULT_TENANT_ID,
         MULTI_TENANT_ROLE_ARN: props.multiTenantRole.roleArn,
@@ -765,7 +765,7 @@ export class Api extends Construct {
       entry: './lambda/deleteShareId.ts',
       timeout: Duration.minutes(15),
       environment: {
-        TABLE_NAME: TABLE_PREFIX,
+        TABLE_PREFIX: TABLE_PREFIX,
         DEFAULT_TABLE_NAME: props.table.tableName,
         DEFAULT_TENANT_ID: DEFAULT_TENANT_ID,
         MULTI_TENANT_ROLE_ARN: props.multiTenantRole.roleArn,
@@ -784,7 +784,7 @@ export class Api extends Construct {
         entry: './lambda/listSystemContexts.ts',
         timeout: Duration.minutes(15),
         environment: {
-          TABLE_NAME: TABLE_PREFIX,
+          TABLE_PREFIX: TABLE_PREFIX,
           DEFAULT_TABLE_NAME: props.table.tableName,
           DEFAULT_TENANT_ID: DEFAULT_TENANT_ID,
           MULTI_TENANT_ROLE_ARN: props.multiTenantRole.roleArn,
@@ -804,7 +804,7 @@ export class Api extends Construct {
         entry: './lambda/createSystemContext.ts',
         timeout: Duration.minutes(15),
         environment: {
-          TABLE_NAME: TABLE_PREFIX,
+          TABLE_PREFIX: TABLE_PREFIX,
           DEFAULT_TABLE_NAME: props.table.tableName,
           DEFAULT_TENANT_ID: DEFAULT_TENANT_ID,
           MULTI_TENANT_ROLE_ARN: props.multiTenantRole.roleArn,
@@ -824,7 +824,7 @@ export class Api extends Construct {
         entry: './lambda/updateSystemContextTitle.ts',
         timeout: Duration.minutes(15),
         environment: {
-          TABLE_NAME: TABLE_PREFIX,
+          TABLE_PREFIX: TABLE_PREFIX,
           DEFAULT_TABLE_NAME: props.table.tableName,
           DEFAULT_TENANT_ID: DEFAULT_TENANT_ID,
           MULTI_TENANT_ROLE_ARN: props.multiTenantRole.roleArn,
@@ -846,7 +846,7 @@ export class Api extends Construct {
         entry: './lambda/deleteSystemContext.ts',
         timeout: Duration.minutes(15),
         environment: {
-          TABLE_NAME: TABLE_PREFIX,
+          TABLE_PREFIX: TABLE_PREFIX,
           DEFAULT_TABLE_NAME: props.table.tableName,
           DEFAULT_TENANT_ID: DEFAULT_TENANT_ID,
           MULTI_TENANT_ROLE_ARN: props.multiTenantRole.roleArn,
@@ -873,7 +873,7 @@ export class Api extends Construct {
       runtime: LAMBDA_RUNTIME_NODEJS,
       entry: './lambda/getTokenUsage.ts',
       environment: {
-        TABLE_NAME: TABLE_PREFIX,
+        TABLE_PREFIX: TABLE_PREFIX,
         DEFAULT_TABLE_NAME: props.table.tableName,
         DEFAULT_TENANT_ID: DEFAULT_TENANT_ID,
         STATS_TABLE_NAME: STATS_TABLE_PREFIX,

--- a/packages/cdk/lib/construct/multi-tenant-role.ts
+++ b/packages/cdk/lib/construct/multi-tenant-role.ts
@@ -47,10 +47,8 @@ export class MultiTenantRole extends Construct {
           's3:ListBucket',
         ],
         resources: [
-          // Bucket-level permissions (stack-specific)
-          `arn:aws:s3:::generativeaiusecasesstack${props.env || ''}-*-tenant-\${aws:PrincipalTag/TenantID}`,
-          // Object-level permissions (stack-specific)
-          `arn:aws:s3:::generativeaiusecasesstack${props.env || ''}-*-tenant-\${aws:PrincipalTag/TenantID}/*`,
+          `arn:aws:s3:::${Stack.of(this).stackName}-*-tenant-\${aws:PrincipalTag/TenantID}`,
+          `arn:aws:s3:::${Stack.of(this).stackName}-*-tenant-\${aws:PrincipalTag/TenantID}/*`,
         ],
       })
     );


### PR DESCRIPTION
## 概要
PR#15のレビューコメントに対応し、Cognito Enhanced Flow実装のクリーンアップを実施しました。

## 対応した課題
PR#15のレビューフィードバックに基づく修正:
- ✅ 不要なキャッシュコメントを削除
- ✅ S3バケットARNパターンをグローバル一意性に対応
- ✅ 旧設計の未使用ファイルを削除 (tenant-iam-role.ts, tenant-iam-role-stack.ts, create-tenant-stacks.ts)
- ✅ DEFAULT_TENANT_ID使用を統一
- ✅ DynamoDB操作パターンを統一
- ✅ 環境変数命名の一貫性を修正
- ✅ createMessages.tsのネスト複雑度を軽減
- ✅ ハードコードされた'default'テナントIDを環境変数に置換

## 実施した変更

### コードクリーンアップ
- **不要コメント削除**: 認証情報ユーティリティの"NOTE: No caching"コメントを削除
- **未使用ファイル削除**: 
  - tenant-iam-role.ts (以前のAssumeRoleWithWebIdentity設計)
  - tenant-iam-role-stack.ts (上記に依存)
  - create-tenant-stacks.ts (上記に依存)
  - generative-ai-use-cases-tenant.ts (上記を使用するCDKアプリ)

### アーキテクチャ改善
- **S3バケットARNパターン**: multi-tenant-role.tsでハードコードパターンの代わりに`Stack.of(this).stackName`を使用
- **定数統一**: 全ファイルでDEFAULT_TENANT_ID使用を統一

### 一貫性向上
- **DynamoDBパターン**: `executeDynamoDBOperation`ラッパーを削除し、直接アクセスパターンに統一
- **環境変数**: api.tsとlambda関数全体でTABLE_NAME → TABLE_PREFIX命名を修正
- **コード構造**: 全関数で一貫したgetTenantDynamoDBDocument + getTableNameパターンに統一

### コード品質向上
- **ネスト軽減**: createMessages.tsのネストレベルを4+から2レベルに削減
- **ヘルパー抽出**: validateMessagesとcreateResponseユーティリティ関数を追加
- **保守性向上**: 関心の分離とエラーハンドリングを改善

### 設定管理改善
- **デフォルトテナントID**: ハードコード文字列を環境変数に統一
  - repository.ts: `const DEFAULT_TENANT_ID = process.env.DEFAULT_TENANT_ID!;` を追加
  - tenantUtils.ts: 定数定義を環境変数ベースに変更
  - tenantCredentials.ts: 直接`process.env.DEFAULT_TENANT_ID`を使用
  - pre_token_generation/index.py: `DEFAULT_TENANT_ID = os.environ.get('DEFAULT_TENANT_ID', 'default')`を追加

## テスト
- ✅ TypeScriptコンパイル成功 (tsc --noEmit)
- ✅ ビルド成功
- ✅ 全インポートと依存関係が解決済み

## 破壊的変更
なし - 全て内部リファクタリングとクリーンアップです。

🤖 Generated with [Claude Code](https://claude.ai/code)