### PR TITLE
🔧 fix(test): update tenant-s3 tests to match 5-bucket implementation

### DIFF
--- a/packages/cdk/lib/stacks/tenant/tenant-s3-stack.ts
+++ b/packages/cdk/lib/stacks/tenant/tenant-s3-stack.ts
@@ -37,6 +37,18 @@ export interface TenantS3StackProps extends cdk.StackProps {
   readonly analyticsBucketBaseName?: string;
 
   /**
+   * Base name for the transcripts bucket
+   * @default 'transcripts'
+   */
+  readonly transcriptsBucketBaseName?: string;
+
+  /**
+   * Base name for the videos bucket
+   * @default 'videos'
+   */
+  readonly videosBucketBaseName?: string;
+
+  /**
    * Whether to enable versioning on buckets
    * @default true
    */
@@ -92,6 +104,8 @@ export class TenantS3Stack extends cdk.Stack {
       documentsBucketBaseName: props?.documentsBucketBaseName,
       chatBucketBaseName: props?.chatBucketBaseName,
       analyticsBucketBaseName: props?.analyticsBucketBaseName,
+      transcriptsBucketBaseName: props?.transcriptsBucketBaseName,
+      videosBucketBaseName: props?.videosBucketBaseName,
       enableVersioning: props?.enableVersioning,
       enableAccessLogging: props?.enableAccessLogging,
     });
@@ -154,6 +168,44 @@ export class TenantS3Stack extends cdk.Stack {
       exportName: `${this.stackName}-AnalyticsBucketDomainName`,
     });
 
+    // Transcripts Bucket outputs
+    new cdk.CfnOutput(this, 'StackTranscriptsBucketArn', {
+      value: this.tenantS3.transcriptsBucket.bucketArn,
+      description: `ARN of the transcripts bucket for tenant ${tenantId}`,
+      exportName: `${this.stackName}-TranscriptsBucketArn`,
+    });
+
+    new cdk.CfnOutput(this, 'StackTranscriptsBucketName', {
+      value: this.tenantS3.transcriptsBucket.bucketName,
+      description: `Name of the transcripts bucket for tenant ${tenantId}`,
+      exportName: `${this.stackName}-TranscriptsBucketName`,
+    });
+
+    new cdk.CfnOutput(this, 'StackTranscriptsBucketDomainName', {
+      value: this.tenantS3.transcriptsBucket.bucketDomainName,
+      description: `Domain name of the transcripts bucket for tenant ${tenantId}`,
+      exportName: `${this.stackName}-TranscriptsBucketDomainName`,
+    });
+
+    // Videos Bucket outputs
+    new cdk.CfnOutput(this, 'StackVideosBucketArn', {
+      value: this.tenantS3.videosBucket.bucketArn,
+      description: `ARN of the videos bucket for tenant ${tenantId}`,
+      exportName: `${this.stackName}-VideosBucketArn`,
+    });
+
+    new cdk.CfnOutput(this, 'StackVideosBucketName', {
+      value: this.tenantS3.videosBucket.bucketName,
+      description: `Name of the videos bucket for tenant ${tenantId}`,
+      exportName: `${this.stackName}-VideosBucketName`,
+    });
+
+    new cdk.CfnOutput(this, 'StackVideosBucketDomainName', {
+      value: this.tenantS3.videosBucket.bucketDomainName,
+      description: `Domain name of the videos bucket for tenant ${tenantId}`,
+      exportName: `${this.stackName}-VideosBucketDomainName`,
+    });
+
     // Add tags
     cdk.Tags.of(this).add('TenantId', tenantId.toString());
     cdk.Tags.of(this).add('Environment', environment);
@@ -192,5 +244,19 @@ export class TenantS3Stack extends cdk.Stack {
    */
   public getAnalyticsBucket() {
     return this.tenantS3.analyticsBucket;
+  }
+
+  /**
+   * Get the transcripts bucket
+   */
+  public getTranscriptsBucket() {
+    return this.tenantS3.transcriptsBucket;
+  }
+
+  /**
+   * Get the videos bucket
+   */
+  public getVideosBucket() {
+    return this.tenantS3.videosBucket;
   }
 }

--- a/packages/cdk/test/tenant-s3.test.ts
+++ b/packages/cdk/test/tenant-s3.test.ts
@@ -81,11 +81,21 @@ describe('TenantS3 Tests', () => {
       expect(tenantS3.videosBucketName.length).toBeLessThanOrEqual(63);
 
       // Check that names follow the expected pattern
-      expect(tenantS3.documentsBucketName).toMatch(/^docs-dev-tenant-test-tenant-short-[a-f0-9]+$/);
-      expect(tenantS3.chatBucketName).toMatch(/^chat-dev-tenant-test-tenant-short-[a-f0-9]+$/);
-      expect(tenantS3.analyticsBucketName).toMatch(/^analytics-dev-tenant-test-tenant-short-[a-f0-9]+$/);
-      expect(tenantS3.transcriptsBucketName).toMatch(/^transcripts-dev-tenant-test-tenant-short-[a-f0-9]+$/);
-      expect(tenantS3.videosBucketName).toMatch(/^videos-dev-tenant-test-tenant-short-[a-f0-9]+$/);
+      expect(tenantS3.documentsBucketName).toMatch(
+        /^docs-dev-tenant-test-tenant-short-[a-f0-9]+$/
+      );
+      expect(tenantS3.chatBucketName).toMatch(
+        /^chat-dev-tenant-test-tenant-short-[a-f0-9]+$/
+      );
+      expect(tenantS3.analyticsBucketName).toMatch(
+        /^analytics-dev-tenant-test-tenant-short-[a-f0-9]+$/
+      );
+      expect(tenantS3.transcriptsBucketName).toMatch(
+        /^transcripts-dev-tenant-test-tenant-short-[a-f0-9]+$/
+      );
+      expect(tenantS3.videosBucketName).toMatch(
+        /^videos-dev-tenant-test-tenant-short-[a-f0-9]+$/
+      );
     });
 
     test('Should sanitize tenant ID for resource names', () => {
@@ -101,11 +111,21 @@ describe('TenantS3 Tests', () => {
 
       // Assert
       // Check that special characters are replaced with hyphens and converted to lowercase
-      expect(tenantS3.documentsBucketName).toMatch(/^docs-dev-tenant-test-tenant-123--[a-f0-9]+$/);
-      expect(tenantS3.chatBucketName).toMatch(/^chat-dev-tenant-test-tenant-123--[a-f0-9]+$/);
-      expect(tenantS3.analyticsBucketName).toMatch(/^analytics-dev-tenant-test-tenant-123--[a-f0-9]+$/);
-      expect(tenantS3.transcriptsBucketName).toMatch(/^transcripts-dev-tenant-test-tenant-123--[a-f0-9]+$/);
-      expect(tenantS3.videosBucketName).toMatch(/^videos-dev-tenant-test-tenant-123--[a-f0-9]+$/);
+      expect(tenantS3.documentsBucketName).toMatch(
+        /^docs-dev-tenant-test-tenant-123--[a-f0-9]+$/
+      );
+      expect(tenantS3.chatBucketName).toMatch(
+        /^chat-dev-tenant-test-tenant-123--[a-f0-9]+$/
+      );
+      expect(tenantS3.analyticsBucketName).toMatch(
+        /^analytics-dev-tenant-test-tenant-123--[a-f0-9]+$/
+      );
+      expect(tenantS3.transcriptsBucketName).toMatch(
+        /^transcripts-dev-tenant-test-tenant-123--[a-f0-9]+$/
+      );
+      expect(tenantS3.videosBucketName).toMatch(
+        /^videos-dev-tenant-test-tenant-123--[a-f0-9]+$/
+      );
     });
 
     test('Should throw error if tenant ID is empty', () => {
@@ -219,12 +239,17 @@ describe('TenantS3 Tests', () => {
       });
 
       // Assert
-      expect(tenantS3.documentsBucketName).toMatch(/^custom-docs-dev-tenant-test-tenant-custom-[a-f0-9]+$/);
-      expect(tenantS3.chatBucketName).toMatch(/^custom-chat-dev-tenant-test-tenant-custom-[a-f0-9]+$/);
-      expect(tenantS3.analyticsBucketName).toMatch(/^custom-analytics-dev-tenant-test-tenant-custom-[a-f0-9]+$/);
+      expect(tenantS3.documentsBucketName).toMatch(
+        /^custom-docs-dev-tenant-test-tenant-custom-[a-f0-9]+$/
+      );
+      expect(tenantS3.chatBucketName).toMatch(
+        /^custom-chat-dev-tenant-test-tenant-custom-[a-f0-9]+$/
+      );
+      expect(tenantS3.analyticsBucketName).toMatch(
+        /^custom-analytics-dev-tenant-test-tenant-custom-[a-f0-9]+$/
+      );
       // Note: custom base names are only tested for the three original buckets
     });
-
 
     test('Should throw error for overly long names', () => {
       // Arrange
@@ -362,11 +387,21 @@ describe('TenantS3 Tests', () => {
 
       // Check that bucket names are stored correctly in the construct
       const tenantS3 = tenantS3Stack.getTenantS3();
-      expect(tenantS3.documentsBucketName).toMatch(/^docs-dev-tenant-getter-test-tenant-[a-f0-9]+$/);
-      expect(tenantS3.chatBucketName).toMatch(/^chat-dev-tenant-getter-test-tenant-[a-f0-9]+$/);
-      expect(tenantS3.analyticsBucketName).toMatch(/^analytics-dev-tenant-getter-test-tenant-[a-f0-9]+$/);
-      expect(tenantS3.transcriptsBucketName).toMatch(/^transcripts-dev-tenant-getter-test-tenant-[a-f0-9]+$/);
-      expect(tenantS3.videosBucketName).toMatch(/^videos-dev-tenant-getter-test-tenant-[a-f0-9]+$/);
+      expect(tenantS3.documentsBucketName).toMatch(
+        /^docs-dev-tenant-getter-test-tenant-[a-f0-9]+$/
+      );
+      expect(tenantS3.chatBucketName).toMatch(
+        /^chat-dev-tenant-getter-test-tenant-[a-f0-9]+$/
+      );
+      expect(tenantS3.analyticsBucketName).toMatch(
+        /^analytics-dev-tenant-getter-test-tenant-[a-f0-9]+$/
+      );
+      expect(tenantS3.transcriptsBucketName).toMatch(
+        /^transcripts-dev-tenant-getter-test-tenant-[a-f0-9]+$/
+      );
+      expect(tenantS3.videosBucketName).toMatch(
+        /^videos-dev-tenant-getter-test-tenant-[a-f0-9]+$/
+      );
     });
   });
 });

--- a/packages/cdk/test/tenant-s3.test.ts
+++ b/packages/cdk/test/tenant-s3.test.ts
@@ -32,12 +32,12 @@ describe('TenantS3 Tests', () => {
       // Assert
       const template = Template.fromStack(stack);
 
-      // Check that three buckets are created
+      // Check that five buckets are created
       const resources = template.toJSON().Resources;
       const buckets = Object.values(resources).filter(
         (r: any) => r.Type === 'AWS::S3::Bucket'
       );
-      expect(buckets.length).toBe(3);
+      expect(buckets.length).toBe(5);
 
       // Check bucket properties
       template.hasResourceProperties('AWS::S3::Bucket', {
@@ -77,11 +77,15 @@ describe('TenantS3 Tests', () => {
       expect(tenantS3.documentsBucketName.length).toBeLessThanOrEqual(63);
       expect(tenantS3.chatBucketName.length).toBeLessThanOrEqual(63);
       expect(tenantS3.analyticsBucketName.length).toBeLessThanOrEqual(63);
+      expect(tenantS3.transcriptsBucketName.length).toBeLessThanOrEqual(63);
+      expect(tenantS3.videosBucketName.length).toBeLessThanOrEqual(63);
 
       // Check that names follow the expected pattern
       expect(tenantS3.documentsBucketName).toMatch(/^docs-dev-tenant-test-tenant-short-[a-f0-9]+$/);
       expect(tenantS3.chatBucketName).toMatch(/^chat-dev-tenant-test-tenant-short-[a-f0-9]+$/);
       expect(tenantS3.analyticsBucketName).toMatch(/^analytics-dev-tenant-test-tenant-short-[a-f0-9]+$/);
+      expect(tenantS3.transcriptsBucketName).toMatch(/^transcripts-dev-tenant-test-tenant-short-[a-f0-9]+$/);
+      expect(tenantS3.videosBucketName).toMatch(/^videos-dev-tenant-test-tenant-short-[a-f0-9]+$/);
     });
 
     test('Should sanitize tenant ID for resource names', () => {
@@ -100,6 +104,8 @@ describe('TenantS3 Tests', () => {
       expect(tenantS3.documentsBucketName).toMatch(/^docs-dev-tenant-test-tenant-123--[a-f0-9]+$/);
       expect(tenantS3.chatBucketName).toMatch(/^chat-dev-tenant-test-tenant-123--[a-f0-9]+$/);
       expect(tenantS3.analyticsBucketName).toMatch(/^analytics-dev-tenant-test-tenant-123--[a-f0-9]+$/);
+      expect(tenantS3.transcriptsBucketName).toMatch(/^transcripts-dev-tenant-test-tenant-123--[a-f0-9]+$/);
+      expect(tenantS3.videosBucketName).toMatch(/^videos-dev-tenant-test-tenant-123--[a-f0-9]+$/);
     });
 
     test('Should throw error if tenant ID is empty', () => {
@@ -216,6 +222,7 @@ describe('TenantS3 Tests', () => {
       expect(tenantS3.documentsBucketName).toMatch(/^custom-docs-dev-tenant-test-tenant-custom-[a-f0-9]+$/);
       expect(tenantS3.chatBucketName).toMatch(/^custom-chat-dev-tenant-test-tenant-custom-[a-f0-9]+$/);
       expect(tenantS3.analyticsBucketName).toMatch(/^custom-analytics-dev-tenant-test-tenant-custom-[a-f0-9]+$/);
+      // Note: custom base names are only tested for the three original buckets
     });
 
 
@@ -269,13 +276,19 @@ describe('TenantS3 Tests', () => {
       expect(outputKeys).toContain('StackAnalyticsBucketArn');
       expect(outputKeys).toContain('StackAnalyticsBucketName');
       expect(outputKeys).toContain('StackAnalyticsBucketDomainName');
+      expect(outputKeys).toContain('StackTranscriptsBucketArn');
+      expect(outputKeys).toContain('StackTranscriptsBucketName');
+      expect(outputKeys).toContain('StackTranscriptsBucketDomainName');
+      expect(outputKeys).toContain('StackVideosBucketArn');
+      expect(outputKeys).toContain('StackVideosBucketName');
+      expect(outputKeys).toContain('StackVideosBucketDomainName');
 
-      // Check that three buckets are created
+      // Check that five buckets are created
       const resources = template.toJSON().Resources;
       const buckets = Object.values(resources).filter(
         (r: any) => r.Type === 'AWS::S3::Bucket'
       );
-      expect(buckets.length).toBe(3);
+      expect(buckets.length).toBe(5);
     });
 
     test('Should have proper stack tags', () => {
@@ -344,12 +357,16 @@ describe('TenantS3 Tests', () => {
       expect(tenantS3Stack.getDocumentsBucket()).toBeDefined();
       expect(tenantS3Stack.getChatBucket()).toBeDefined();
       expect(tenantS3Stack.getAnalyticsBucket()).toBeDefined();
+      expect(tenantS3Stack.getTranscriptsBucket()).toBeDefined();
+      expect(tenantS3Stack.getVideosBucket()).toBeDefined();
 
       // Check that bucket names are stored correctly in the construct
       const tenantS3 = tenantS3Stack.getTenantS3();
       expect(tenantS3.documentsBucketName).toMatch(/^docs-dev-tenant-getter-test-tenant-[a-f0-9]+$/);
       expect(tenantS3.chatBucketName).toMatch(/^chat-dev-tenant-getter-test-tenant-[a-f0-9]+$/);
       expect(tenantS3.analyticsBucketName).toMatch(/^analytics-dev-tenant-getter-test-tenant-[a-f0-9]+$/);
+      expect(tenantS3.transcriptsBucketName).toMatch(/^transcripts-dev-tenant-getter-test-tenant-[a-f0-9]+$/);
+      expect(tenantS3.videosBucketName).toMatch(/^videos-dev-tenant-getter-test-tenant-[a-f0-9]+$/);
     });
   });
 });


### PR DESCRIPTION
## 変更の概要

#38 のテストコードの修正
前の実装を前提としたテスト（作成されるバケットが3つであるなど）となっていたため、最新の実装に合わせて修正

## 申し送り事項
claude codeにレビューをさせたら流れで修正までやってくれたので、PRとして提出しました
<!-- レビュワーに伝えておきたい事柄等を書く（Draftの理由など） -->

## Checklist（レビュワー用）

- [ ] `npm run lint`でエラーが出ない
- [ ] TypeScriptのビルドで型エラーが出ない
- [ ] 手元でフォーマットした際に差分が出ない
