### PR TITLE
✨ WebSocketのチャンクのサイズ制限の判定を追加

### DIFF
--- a/packages/web/src/hooks/useMicrophone.ts
+++ b/packages/web/src/hooks/useMicrophone.ts
@@ -117,15 +117,10 @@ const useMicrophone = () => {
 
     const audioStream = async function* () {
       for await (const chunk of mic as unknown as Buffer[]) {
-        for (
-          let offset = 0;
-          offset < chunk.length;
-          offset += MAX_AUDIO_CHUNK_SIZE
-        ) {
-          const slice = chunk.subarray(offset, offset + MAX_AUDIO_CHUNK_SIZE);
+        if (chunk.length <= MAX_AUDIO_CHUNK_SIZE) {
           yield {
             AudioEvent: {
-              AudioChunk: pcmEncodeChunk(slice),
+              AudioChunk: pcmEncodeChunk(chunk),
             },
           };
         }


### PR DESCRIPTION
## 変更の概要

<!-- どのような変更を行ったかを書く -->
- 議事録生成の録音が勝手に止まる問題を修正しました
  - 録音したデータのチャンクがWebSocketのサイズ制限を超過していたことが問題らしいです
  - [該当Issue](https://github.com/aws/aws-sdk-js-v3/issues/2428#issuecomment-1147606384)

## 申し送り事項

<!-- レビュワーに伝えておきたい事柄等を書く（Draftの理由など） -->

## Checklist（レビュワー用）

- [ ] `npm run lint`でエラーが出ない
- [ ] TypeScriptのビルドで型エラーが出ない
- [ ] 手元でフォーマットした際に差分が出ない
