### PR TITLE
:bug: fix(web): prevent API requests on window focus

### DIFF
--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -10,6 +10,7 @@ import {
   createBrowserRouter,
   RouteObject,
 } from 'react-router-dom';
+import { SWRConfig } from 'swr';
 import LandingPage from './pages/LandingPage';
 import Setting from './pages/Setting';
 import StatPage from './pages/StatPage.tsx';
@@ -289,7 +290,15 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
     {/* eslint-disable-next-line @shopify/jsx-no-hardcoded-content */}
     <React.Suspense fallback={<div>Loading...</div>}>
       <Authenticator.Provider>
-        <RouterProvider router={router} />
+        <SWRConfig
+          value={{
+            revalidateOnFocus: false,
+            revalidateOnReconnect: true,
+            revalidateOnMount: true,
+          }}
+        >
+          <RouterProvider router={router} />
+        </SWRConfig>
         <Toaster />
       </Authenticator.Provider>
     </React.Suspense>


### PR DESCRIPTION
## Summary
- Adds SWRConfig wrapper to prevent automatic API requests when window gains focus
- Configures `revalidateOnFocus: false` to stop unnecessary refetches on tab switching
- Maintains data freshness on network reconnect and initial mount

## Problem
API requests were being posted every time the window gained focus due to SWR's default `revalidateOnFocus: true` behavior. This caused unnecessary network traffic and potential performance issues when users frequently switched between browser tabs.

## Solution
- Added `SWRConfig` wrapper around `RouterProvider` in `main.tsx`
- Set `revalidateOnFocus: false` to disable focus-based revalidation
- Kept `revalidateOnReconnect: true` for network recovery scenarios
- Kept `revalidateOnMount: true` for initial data loading

## Test plan
- [ ] Open browser DevTools Network tab
- [ ] Load the application and verify normal data fetching
- [ ] Switch to another browser tab, then back to the application
- [ ] Verify no automatic API requests are triggered on focus
- [ ] Test that manual refresh and user interactions still work properly
- [ ] Verify data updates correctly for network reconnection scenarios

🤖 Generated with [Claude Code](https://claude.ai/code)