### PR TITLE
Validate bot store scope values

### DIFF
--- a/packages/cdk/lib/temp-bedrock-chat/backend/app/repositories/bot_store.py
+++ b/packages/cdk/lib/temp-bedrock-chat/backend/app/repositories/bot_store.py
@@ -14,6 +14,8 @@ INDEX_NAME = f"{env_prefix}bot"
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.DEBUG)
 
+VALID_SCOPES = {"private", "organization", "all"}
+
 
 def find_bots_by_query(
     query: str,
@@ -51,6 +53,10 @@ def find_bots_by_query(
     """
     client = client or get_opensearch_client()
     logger.info(f"Searching bots with query: {query}, scope: {scope}, starred: {starred}, sort: {sort}")
+
+    if scope is not None and scope not in VALID_SCOPES:
+        logger.warning("Received invalid scope value '%s'", scope)
+        raise ValueError(f"Invalid scope '{scope}'. Valid options are: {sorted(VALID_SCOPES)}.")
 
     # Include only BOT items
     filter_must = [{"prefix": {"SK.keyword": "BOT"}}]

--- a/packages/cdk/lib/temp-bedrock-chat/backend/app/routes/bot_store.py
+++ b/packages/cdk/lib/temp-bedrock-chat/backend/app/routes/bot_store.py
@@ -1,7 +1,7 @@
 from app.routes.schemas.bot import BotMetaOutput
 from app.usecases.bot_store import fetch_pickup_bots, fetch_popular_bots, search_bots
 from app.user import User
-from fastapi import APIRouter, Depends, Request
+from fastapi import APIRouter, HTTPException, Request
 
 router = APIRouter(tags=["bot_store"])
 
@@ -25,14 +25,17 @@ def search_bots_by_query(
     """
     current_user: User = request.state.current_user
 
-    bots = search_bots(
-        current_user,
-        query=query,
-        scope=scope,
-        starred=starred,
-        limit=limit,
-        sort=sort
-    )
+    try:
+        bots = search_bots(
+            current_user,
+            query=query,
+            scope=scope,
+            starred=starred,
+            limit=limit,
+            sort=sort
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
     return bots
 
 


### PR DESCRIPTION
## Summary
- ensure bot store queries reject invalid scope values instead of falling back to unrestricted access
- surface validation failures from the repository layer as HTTP 400 errors in the bot store route

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_b_68cbb1aea6308328848d7eb2a7a8aa31