### PR TITLE
Add tenant config API for hidden features

### DIFF
--- a/docs/en/DEPLOY_OPTION.md
+++ b/docs/en/DEPLOY_OPTION.md
@@ -784,54 +784,23 @@ For Prompt optimization support status, please refer to [this link](https://docs
 
 ### Hiding Specific Use Cases
 
-You can hide use cases with the following options.
-If not specified or set to false, the use case will be displayed.
+Use case visibility can now be controlled per tenant. Each tenant record in the
+`Tenants-<ENVIRONMENT>` DynamoDB table contains a `hiddenFeatures` map. Set a
+feature flag to `true` to hide it for that tenant (omit the key or set it to
+`false` to keep it visible).
 
-**Edit [parameter.ts](/packages/cdk/parameter.ts)**
+Example using the AWS CLI:
 
-```typescript
-// parameter.ts
-const envs: Record<string, Partial<StackInput>> = {
-  dev: {
-    hiddenUseCases: {
-      generate: true, // Hide text generation
-      summarize: true, // Hide summarization
-      writer: true, // Hide writing
-      translate: true, // Hide translation
-      webContent: true, // Hide Web content extraction
-      image: true, // Hide image generation
-      video: true, // Hide video generation
-      videoAnalyzer: true, // Hide video analysis
-      diagram: true, // Hide diagram generation
-      meetingMinutes: true, // Hide meeting minutes generation
-      voiceChat: true, // Hide voice chat
-    },
-  },
-};
+```bash
+aws dynamodb update-item \
+  --table-name Tenants-<ENVIRONMENT> \
+  --key '{"tenantId": {"S": "tenant-a"}}' \
+  --update-expression 'SET hiddenFeatures = :hidden' \
+  --expression-attribute-values '{":hidden": {"M": {"generate": {"BOOL": true}, "image": {"BOOL": true}}}}'
 ```
 
-**Edit [packages/cdk/cdk.json](/packages/cdk/cdk.json)**
-
-```json
-// cdk.json
-{
-  "context": {
-    "hiddenUseCases": {
-      "generate": true,
-      "summarize": true,
-      "writer": true,
-      "translate": true,
-      "webContent": true,
-      "image": true,
-      "video": true,
-      "videoAnalyzer": true,
-      "diagram": true,
-      "meetingMinutes": true,
-      "voiceChat": true
-    }
-  }
-}
-```
+Client applications call the `/tenants/config` endpoint after authentication
+and automatically hide the configured features.
 
 ## Use Case Builder Configuration
 

--- a/docs/ja/DEPLOY_OPTION.md
+++ b/docs/ja/DEPLOY_OPTION.md
@@ -799,54 +799,23 @@ Prompt optimization のサポート状況は [こちら](https://docs.aws.amazon
 
 ### 特定のユースケースを非表示にする
 
-以下のオプションで指定できるユースケースは非表示にできます。
-特に指定がない場合や false を指定した場合は表示されます。
+ユースケースの表示／非表示はテナントごとに制御できます。DynamoDB の
+`Tenants-<ENVIRONMENT>` テーブルに格納されたテナントレコードには
+`hiddenFeatures` マップがあり、値を `true` に設定すると該当するユースケース
+が非表示になります（キーを省略するか `false` にすると表示されます）。
 
-**[parameter.ts](/packages/cdk/parameter.ts) を編集**
+AWS CLI での更新例:
 
-```typescript
-// parameter.ts
-const envs: Record<string, Partial<StackInput>> = {
-  dev: {
-    hiddenUseCases: {
-      generate: true, // 文章生成を非表示
-      summarize: true, // 要約を非表示
-      writer: true, // 執筆を非表示
-      translate: true, // 翻訳を非表示
-      webContent: true, // Web コンテンツ抽出を非表示
-      image: true, // 画像生成を非表示
-      video: true, // 動画生成を非表示
-      videoAnalyzer: true, // 映像分析を非表示
-      diagram: true, // ダイアグラム生成を非表示
-      meetingMinutes: true, // 議事録生成を非表示
-      voiceChat: true, // 音声チャットを非表示
-    },
-  },
-};
+```bash
+aws dynamodb update-item \
+  --table-name Tenants-<ENVIRONMENT> \
+  --key '{"tenantId": {"S": "tenant-a"}}' \
+  --update-expression 'SET hiddenFeatures = :hidden' \
+  --expression-attribute-values '{":hidden": {"M": {"generate": {"BOOL": true}, "image": {"BOOL": true}}}}'
 ```
 
-**[packages/cdk/cdk.json](/packages/cdk/cdk.json) を編集**
-
-```json
-// cdk.json
-{
-  "context": {
-    "hiddenUseCases": {
-      "generate": true,
-      "summarize": true,
-      "writer": true,
-      "translate": true,
-      "webContent": true,
-      "image": true,
-      "video": true,
-      "videoAnalyzer": true,
-      "diagram": true,
-      "meetingMinutes": true,
-      "voiceChat": true
-    }
-  }
-}
-```
+クライアントアプリケーションは認証後に `/tenants/config` エンドポイントを
+呼び出し、この設定に従って自動的にユースケースを非表示にします。
 
 ## ユースケースビルダーの設定
 

--- a/packages/cdk/cdk.example.json
+++ b/packages/cdk/cdk.example.json
@@ -45,7 +45,6 @@
     "samlDefaultAuthEnabled": false,
     "samlCognitoDomainName": "",
     "samlCognitoFederatedIdentityProviderName": "",
-    "hiddenUseCases": {},
     "modelRegion": "us-east-1",
     "modelIds": [
       "us.anthropic.claude-sonnet-4-20250514-v1:0",

--- a/packages/cdk/lambda/getTenantConfig.ts
+++ b/packages/cdk/lambda/getTenantConfig.ts
@@ -1,0 +1,119 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { HiddenUseCases, HiddenUseCasesKeys } from 'generative-ai-use-cases';
+import { getTenant, Tenant } from './tenantManager';
+import { verifyToken } from './utils/auth';
+
+const CORS_HEADERS = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': '*',
+  'Access-Control-Allow-Methods': 'GET, OPTIONS',
+};
+
+type TenantConfigResponse = {
+  tenantId: string;
+  tenantDisplayName: string;
+  hiddenFeatures: HiddenUseCases;
+};
+
+const HIDDEN_FEATURE_KEYS: HiddenUseCasesKeys[] = [
+  'generate',
+  'summarize',
+  'writer',
+  'translate',
+  'webContent',
+  'image',
+  'video',
+  'videoAnalyzer',
+  'diagram',
+  'meetingMinutes',
+  'voiceChat',
+];
+
+const buildErrorResponse = (
+  statusCode: number,
+  message: string
+): APIGatewayProxyResult => ({
+  statusCode,
+  headers: CORS_HEADERS,
+  body: JSON.stringify({ message }),
+});
+
+const normalizeHiddenFeatures = (
+  tenant: Tenant | null
+): HiddenUseCases => {
+  if (!tenant?.hiddenFeatures || typeof tenant.hiddenFeatures !== 'object') {
+    return {};
+  }
+
+  const normalized: HiddenUseCases = {};
+  for (const key of HIDDEN_FEATURE_KEYS) {
+    const value = tenant.hiddenFeatures[key];
+    if (typeof value === 'boolean') {
+      normalized[key] = value;
+    }
+  }
+  return normalized;
+};
+
+const extractDisplayName = (tenant: Tenant): string => {
+  const displayNameCandidates = [
+    tenant.metadata?.displayName,
+    tenant.metadata?.name,
+    tenant.metadata?.tenantDisplayName,
+  ];
+
+  for (const candidate of displayNameCandidates) {
+    if (typeof candidate === 'string' && candidate.trim() !== '') {
+      return candidate.trim();
+    }
+  }
+
+  return tenant.tenantId;
+};
+
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    const token = event.headers?.Authorization || event.headers?.authorization;
+    if (!token) {
+      return buildErrorResponse(401, 'Missing authorization token');
+    }
+
+    const claims = await verifyToken(token);
+    if (!claims) {
+      return buildErrorResponse(401, 'Invalid token');
+    }
+
+    const tenantId =
+      claims['custom:tenant_id'] ||
+      claims['tenant_id'] ||
+      claims['tenantId'];
+
+    if (typeof tenantId !== 'string' || tenantId.trim() === '') {
+      return buildErrorResponse(400, 'Tenant ID not found in token');
+    }
+
+    const tenant = await getTenant(tenantId);
+
+    if (!tenant) {
+      return buildErrorResponse(404, 'Tenant not found');
+    }
+
+    const response: TenantConfigResponse = {
+      tenantId: tenant.tenantId,
+      tenantDisplayName: extractDisplayName(tenant),
+      hiddenFeatures: normalizeHiddenFeatures(tenant),
+    };
+
+    return {
+      statusCode: 200,
+      headers: CORS_HEADERS,
+      body: JSON.stringify(response),
+    };
+  } catch (error) {
+    console.error('Failed to fetch tenant configuration', error);
+    return buildErrorResponse(500, 'Failed to fetch tenant configuration');
+  }
+};
+

--- a/packages/cdk/lambda/tenantManager.ts
+++ b/packages/cdk/lambda/tenantManager.ts
@@ -5,6 +5,7 @@ import {
   UpdateItemCommand,
 } from '@aws-sdk/client-dynamodb';
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb';
+import { HiddenUseCases } from 'generative-ai-use-cases';
 
 // Environment variables
 const TENANTS_TABLE_NAME = process.env.TENANTS_TABLE_NAME!;
@@ -31,6 +32,7 @@ export interface Tenant {
   metadata?: Record<string, any>;
   accountId: string;
   roleArn: string;
+  hiddenFeatures?: HiddenUseCases;
 }
 
 // Request interfaces
@@ -41,6 +43,7 @@ interface RegisterTenantRequest {
   metadata?: Record<string, any>;
   accountId: string;
   roleArn: string;
+  hiddenFeatures?: HiddenUseCases;
 }
 
 interface UpdateTenantRequest {
@@ -50,6 +53,7 @@ interface UpdateTenantRequest {
   metadata?: Record<string, any>;
   accountId?: string;
   roleArn?: string;
+  hiddenFeatures?: HiddenUseCases;
 }
 
 /**
@@ -92,6 +96,7 @@ export async function registerTenant(
     metadata: request.metadata || {},
     accountId: request.accountId,
     roleArn: request.roleArn,
+    hiddenFeatures: request.hiddenFeatures || {},
   };
 
   try {
@@ -152,6 +157,12 @@ export async function updateTenant(
       updateExpression.push('#metadata = :metadata');
       expressionAttributeNames['#metadata'] = 'metadata';
       expressionAttributeValues[':metadata'] = request.metadata;
+    }
+
+    if (request.hiddenFeatures !== undefined) {
+      updateExpression.push('#hiddenFeatures = :hiddenFeatures');
+      expressionAttributeNames['#hiddenFeatures'] = 'hiddenFeatures';
+      expressionAttributeValues[':hiddenFeatures'] = request.hiddenFeatures;
     }
 
     // Cross-account fields

--- a/packages/cdk/lambda/tenantRegistrationHandler.ts
+++ b/packages/cdk/lambda/tenantRegistrationHandler.ts
@@ -80,6 +80,7 @@ export const handler = async (
         source: 'api-registration',
         registeredVia: 'tenant-stack',
       },
+      hiddenFeatures: {},
     };
 
     await dynamoClient.send(

--- a/packages/cdk/lib/construct/api/index.ts
+++ b/packages/cdk/lib/construct/api/index.ts
@@ -45,6 +45,7 @@ import FileApi from './file';
 import FileBucket from '../file-bucket';
 import ShareApi from './share';
 import AdminApi from './admin';
+import TenantApi from './tenant';
 
 export interface BackendApiProps {
   // Context Params
@@ -330,6 +331,10 @@ export class Api extends Construct {
     new VideoApi(this, 'VideoAPI', apiProps);
     new WebTextApi(this, 'WebTextAPI', apiProps);
     new AdminApi(this, 'AdminAPI', apiProps);
+
+    if (tenantManager) {
+      new TenantApi(this, 'TenantAPI', apiProps);
+    }
 
     // Add ALL methods proxy to Bedrock Chat proxy Lambda
     this.restApi = api;

--- a/packages/cdk/lib/construct/api/tenant.ts
+++ b/packages/cdk/lib/construct/api/tenant.ts
@@ -1,0 +1,51 @@
+import { Construct } from 'constructs';
+import { Duration } from 'aws-cdk-lib';
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { LambdaIntegration } from 'aws-cdk-lib/aws-apigateway';
+import { LAMBDA_RUNTIME_NODEJS } from '../../../consts';
+import { getBaseEnvironment } from './util';
+import { GenericApiProps } from './props';
+
+export type TenantApiProps = GenericApiProps;
+
+class TenantApi extends Construct {
+  constructor(scope: Construct, id: string, props: TenantApiProps) {
+    super(scope, id);
+
+    const { api, commonAuthorizerProps, tenantManager, userPoolClient } = props;
+
+    if (!tenantManager) {
+      throw new Error('Tenant API requires tenant manager configuration');
+    }
+
+    const getTenantConfigFunction = new NodejsFunction(
+      this,
+      'GetTenantConfig',
+      {
+        runtime: LAMBDA_RUNTIME_NODEJS,
+        entry: './lambda/getTenantConfig.ts',
+        timeout: Duration.seconds(30),
+        bundling: {
+          nodeModules: ['aws-jwt-verify'],
+        },
+        environment: getBaseEnvironment(this, props, {
+          USER_POOL_CLIENT_ID: userPoolClient.userPoolClientId,
+        }),
+      }
+    );
+
+    tenantManager.tenantsTable.grantReadData(getTenantConfigFunction);
+
+    const tenantsResource = api.root.addResource('tenants');
+    const configResource = tenantsResource.addResource('config');
+
+    configResource.addMethod(
+      'GET',
+      new LambdaIntegration(getTenantConfigFunction),
+      commonAuthorizerProps
+    );
+  }
+}
+
+export default TenantApi;
+

--- a/packages/cdk/lib/construct/web.ts
+++ b/packages/cdk/lib/construct/web.ts
@@ -16,11 +16,7 @@ import * as s3 from 'aws-cdk-lib/aws-s3';
 import { ARecord, HostedZone, RecordTarget } from 'aws-cdk-lib/aws-route53';
 import { CloudFrontTarget } from 'aws-cdk-lib/aws-route53-targets';
 import { ICertificate } from 'aws-cdk-lib/aws-certificatemanager';
-import {
-  Flow,
-  HiddenUseCases,
-  ModelConfiguration,
-} from 'generative-ai-use-cases';
+import { Flow, ModelConfiguration } from 'generative-ai-use-cases';
 import { ComputeType } from 'aws-cdk-lib/aws-codebuild';
 
 export interface WebProps {
@@ -53,7 +49,6 @@ export interface WebProps {
   readonly domainName?: string | null;
   readonly hostedZoneId?: string | null;
   readonly useCaseBuilderEnabled: boolean;
-  readonly hiddenUseCases: HiddenUseCases;
   readonly speechToSpeechNamespace: string;
   readonly speechToSpeechEventApiEndpoint: string;
   readonly speechToSpeechModelIds: ModelConfiguration[];
@@ -258,7 +253,6 @@ export class Web extends Construct {
         VITE_APP_INLINE_AGENTS: props.inlineAgents.toString(),
         VITE_APP_USE_CASE_BUILDER_ENABLED:
           props.useCaseBuilderEnabled.toString(),
-        VITE_APP_HIDDEN_USE_CASES: JSON.stringify(props.hiddenUseCases),
         VITE_APP_SPEECH_TO_SPEECH_NAMESPACE: props.speechToSpeechNamespace,
         VITE_APP_SPEECH_TO_SPEECH_EVENT_API_ENDPOINT:
           props.speechToSpeechEventApiEndpoint,

--- a/packages/cdk/lib/stack-input.ts
+++ b/packages/cdk/lib/stack-input.ts
@@ -27,22 +27,6 @@ const baseStackInputSchema = z.object({
   samlDefaultAuthEnabled: z.boolean().default(false),
   samlCognitoDomainName: z.string().nullish(),
   samlCognitoFederatedIdentityProviderName: z.string().nullish(),
-  // Frontend
-  hiddenUseCases: z
-    .object({
-      generate: z.boolean().optional(),
-      summarize: z.boolean().optional(),
-      writer: z.boolean().optional(),
-      translate: z.boolean().optional(),
-      webContent: z.boolean().optional(),
-      image: z.boolean().optional(),
-      video: z.boolean().optional(),
-      videoAnalyzer: z.boolean().optional(),
-      diagram: z.boolean().optional(),
-      meetingMinutes: z.boolean().optional(),
-      voiceChat: z.boolean().optional(),
-    })
-    .default({}),
   // API
   modelRegion: z.string().default('us-east-1'),
   modelIds: z

--- a/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
@@ -204,8 +204,6 @@ export class GenerativeAiUseCasesStack extends Stack {
       speechToSpeechModelIds: params.speechToSpeechModelIds,
       mcpEnabled: params.mcpEnabled,
       mcpEndpoint,
-      // Frontend
-      hiddenUseCases: params.hiddenUseCases,
       // Custom Domain
       cert: props.cert,
       hostName: params.hostName,
@@ -403,10 +401,6 @@ export class GenerativeAiUseCasesStack extends Stack {
 
     new CfnOutput(this, 'UseCaseBuilderEnabled', {
       value: params.useCaseBuilderEnabled.toString(),
-    });
-
-    new CfnOutput(this, 'HiddenUseCases', {
-      value: JSON.stringify(params.hiddenUseCases),
     });
 
     new CfnOutput(this, 'SpeechToSpeechNamespace', {

--- a/packages/types/src/tenant.d.ts
+++ b/packages/types/src/tenant.d.ts
@@ -1,5 +1,13 @@
+import type { HiddenUseCases } from './useCases';
+
 export type SelfSignUpTenantMapEntry = {
   tenantId: string;
   domains?: string[];
   emails?: string[];
-}
+};
+
+export type TenantConfiguration = {
+  tenantId: string;
+  tenantDisplayName: string;
+  hiddenFeatures: HiddenUseCases;
+};

--- a/packages/web/src/hooks/useUseCases.ts
+++ b/packages/web/src/hooks/useUseCases.ts
@@ -1,20 +1,34 @@
+import { useCallback, useMemo } from 'react';
 import { HiddenUseCases, HiddenUseCasesKeys } from 'generative-ai-use-cases';
+import { useTenantConfig } from '../providers/TenantConfigProvider';
 
-const hiddenUseCases: HiddenUseCases = JSON.parse(
-  import.meta.env.VITE_APP_HIDDEN_USE_CASES
-);
+const EMPTY_HIDDEN_USE_CASES: HiddenUseCases = {};
 
 const useUseCases = () => {
-  const enabledSingle = (useCase: HiddenUseCasesKeys): boolean => {
-    return !hiddenUseCases[useCase];
-  };
+  const { hiddenFeatures, isLoading } = useTenantConfig();
 
-  const enabled = (...useCases: HiddenUseCasesKeys[]): boolean => {
-    return useCases.every(enabledSingle);
-  };
+  const hiddenUseCases = useMemo(() => {
+    return hiddenFeatures ?? EMPTY_HIDDEN_USE_CASES;
+  }, [hiddenFeatures]);
+
+  const enabledSingle = useCallback(
+    (useCase: HiddenUseCasesKeys): boolean => {
+      return !hiddenUseCases[useCase];
+    },
+    [hiddenUseCases]
+  );
+
+  const enabled = useCallback(
+    (...useCases: HiddenUseCasesKeys[]): boolean => {
+      return useCases.every(enabledSingle);
+    },
+    [enabledSingle]
+  );
 
   return {
     enabled,
+    hiddenUseCases,
+    isLoading,
   };
 };
 

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -1,5 +1,5 @@
 import './i18n/config';
-import React from 'react';
+import React, { useMemo } from 'react';
 import ReactDOM from 'react-dom/client';
 import AuthWithUserpool from './components/AuthWithUserpool';
 import AuthWithSAML from './components/AuthWithSAML';
@@ -50,6 +50,7 @@ import RagChatBotChatPage from './pages/RagChatBotChatPage.tsx';
 import RagChatBotHistoryPage from './pages/RagChatBotHistoryPage.tsx';
 import AdminPortal from './pages/AdminPortal.tsx';
 import useUseCases from './hooks/useUseCases';
+import { TenantConfigProvider } from './providers/TenantConfigProvider';
 import { Toaster } from 'sonner';
 
 const ragEnabled: boolean = import.meta.env.VITE_APP_RAG_ENABLED === 'true';
@@ -70,253 +71,275 @@ const {
 } = MODELS;
 const useCaseBuilderEnabled: boolean =
   import.meta.env.VITE_APP_USE_CASE_BUILDER_ENABLED === 'true';
-// eslint-disable-next-line  react-hooks/rules-of-hooks
-const { enabled } = useUseCases();
 
-const routes: RouteObject[] = [
-  {
-    path: '/',
-    element: <LandingPage />,
-  },
-  {
-    path: '/setting',
-    element: <Setting />,
-  },
-  {
-    path: '/stats',
-    element: <StatPage />,
-  },
-  {
-    path: '/chat',
-    element: <ChatPage />,
-  },
-  {
-    path: '/chat/:chatId',
-    element: <ChatPage />,
-  },
-  {
-    path: '/share/:shareId',
-    element: <SharedChatPage />,
-  },
-  enabled('generate')
-    ? {
-        path: '/generate',
-        element: <GenerateTextPage />,
-      }
-    : null,
-  enabled('summarize')
-    ? {
-        path: '/summarize',
-        element: <SummarizePage />,
-      }
-    : null,
-  enabled('meetingMinutes')
-    ? {
-        path: '/meeting-minutes',
-        element: <MeetingMinutesPage />,
-      }
-    : null,
-  enabled('writer')
-    ? {
-        path: '/writer',
-        element: <WriterPage />,
-      }
-    : null,
-  enabled('translate')
-    ? {
-        path: '/translate',
-        element: <TranslatePage />,
-      }
-    : null,
-  enabled('webContent')
-    ? {
-        path: '/web-content',
-        element: <WebContent />,
-      }
-    : null,
-  imageGenModelIds.length > 0 && enabled('image')
-    ? {
-        path: '/image',
-        element: <GenerateImagePage />,
-      }
-    : null,
-  videoGenModelIds.length > 0 && enabled('video')
-    ? {
-        path: '/video',
-        element: <GenerateVideoPage />,
-      }
-    : null,
-  enabled('diagram')
-    ? {
-        path: '/diagram',
-        element: <GenerateDiagramPage />,
-      }
-    : null,
-  optimizePromptEnabled
-    ? {
-        path: '/optimize',
-        element: <OptimizePromptPage />,
-      }
-    : null,
-  {
-    path: '/transcribe',
-    element: <TranscribePage />,
-  },
-  {
-    path: '/flow-chat',
-    element: <FlowChatPage />,
-  },
-  visionEnabled && enabled('videoAnalyzer')
-    ? {
-        path: '/video-analyzer',
-        element: <VideoAnalyzerPage />,
-      }
-    : null,
-  ragEnabled
-    ? {
-        path: '/rag',
-        element: <RagPage />,
-      }
-    : null,
-  ragKnowledgeBaseEnabled
-    ? {
-        path: '/rag-knowledge-base',
-        element: <RagKnowledgeBasePage />,
-      }
-    : null,
-  agentEnabled && !inlineAgents
-    ? {
-        path: '/agent',
-        element: <AgentChatPage />,
-      }
-    : null,
-  agentEnabled && inlineAgents
-    ? {
-        path: '/agent/:agentName',
-        element: <AgentChatPage />,
-      }
-    : null,
-  speechToSpeechModelIds.length > 0 && enabled('voiceChat')
-    ? {
-        path: '/voice-chat',
-        element: <VoiceChatPage />,
-      }
-    : null,
-  mcpEnabled
-    ? {
-        path: '/mcp',
-        element: <McpChatPage />,
-      }
-    : null,
-  {
-    path: '/rag-chat-bot',
-    element: <RagChatBotPage />,
-  },
-  {
-    path: '/rag-chat-bot/create',
-    element: <RagChatBotEditPage />,
-  },
-  {
-    path: '/rag-chat-bot/edit/:botId',
-    element: <RagChatBotEditPage />,
-  },
-  {
-    path: '/rag-chat-bot/chat/:botId',
-    element: <RagChatBotChatPage />,
-  },
-  {
-    path: '/rag-chat-bot/chat/:botId/:conversationId',
-    element: <RagChatBotChatPage />,
-  },
-  {
-    path: '/rag-chat-bot/history',
-    element: <RagChatBotHistoryPage />,
-  },
-  {
-    path: '/admin',
-    element: <AdminPortal />,
-  },
-  {
-    path: '*',
-    element: <NotFound />,
-  },
-].flatMap((r) => (r !== null ? [r] : []));
+type UseCaseEnabledChecker = ReturnType<typeof useUseCases>['enabled'];
 
-const useCaseBuilderRoutes: RouteObject[] = [
-  {
-    path: '/use-case-builder',
-    element: <UseCaseBuilderSamplesPage />,
-  },
-  {
-    path: `/use-case-builder/my-use-case`,
-    element: <UseCaseBuilderMyUseCasePage />,
-  },
-  {
-    path: `/use-case-builder/new`,
-    element: <UseCaseBuilderEditPage />,
-  },
-  {
-    path: `/use-case-builder/edit/:useCaseId`,
-    element: <UseCaseBuilderEditPage />,
-  },
-  {
-    path: `/use-case-builder/execute/:useCaseId`,
-    element: <UseCaseBuilderExecutePage />,
-  },
-  {
-    path: `/use-case-builder/setting`,
-    element: <Setting />,
-  },
-  {
-    path: '*',
-    element: <NotFound />,
-  },
-].flatMap((r) => (r !== null ? [r] : []));
+const buildRoutes = (enabled: UseCaseEnabledChecker): RouteObject[] => {
+  const routeCandidates: Array<RouteObject | null> = [
+    {
+      path: '/',
+      element: <LandingPage />,
+    },
+    {
+      path: '/setting',
+      element: <Setting />,
+    },
+    {
+      path: '/stats',
+      element: <StatPage />,
+    },
+    {
+      path: '/chat',
+      element: <ChatPage />,
+    },
+    {
+      path: '/chat/:chatId',
+      element: <ChatPage />,
+    },
+    {
+      path: '/share/:shareId',
+      element: <SharedChatPage />,
+    },
+    enabled('generate')
+      ? {
+          path: '/generate',
+          element: <GenerateTextPage />,
+        }
+      : null,
+    enabled('summarize')
+      ? {
+          path: '/summarize',
+          element: <SummarizePage />,
+        }
+      : null,
+    enabled('meetingMinutes')
+      ? {
+          path: '/meeting-minutes',
+          element: <MeetingMinutesPage />,
+        }
+      : null,
+    enabled('writer')
+      ? {
+          path: '/writer',
+          element: <WriterPage />,
+        }
+      : null,
+    enabled('translate')
+      ? {
+          path: '/translate',
+          element: <TranslatePage />,
+        }
+      : null,
+    enabled('webContent')
+      ? {
+          path: '/web-content',
+          element: <WebContent />,
+        }
+      : null,
+    imageGenModelIds.length > 0 && enabled('image')
+      ? {
+          path: '/image',
+          element: <GenerateImagePage />,
+        }
+      : null,
+    videoGenModelIds.length > 0 && enabled('video')
+      ? {
+          path: '/video',
+          element: <GenerateVideoPage />,
+        }
+      : null,
+    enabled('diagram')
+      ? {
+          path: '/diagram',
+          element: <GenerateDiagramPage />,
+        }
+      : null,
+    optimizePromptEnabled
+      ? {
+          path: '/optimize',
+          element: <OptimizePromptPage />,
+        }
+      : null,
+    {
+      path: '/transcribe',
+      element: <TranscribePage />,
+    },
+    {
+      path: '/flow-chat',
+      element: <FlowChatPage />,
+    },
+    visionEnabled && enabled('videoAnalyzer')
+      ? {
+          path: '/video-analyzer',
+          element: <VideoAnalyzerPage />,
+        }
+      : null,
+    ragEnabled
+      ? {
+          path: '/rag',
+          element: <RagPage />,
+        }
+      : null,
+    ragKnowledgeBaseEnabled
+      ? {
+          path: '/rag-knowledge-base',
+          element: <RagKnowledgeBasePage />,
+        }
+      : null,
+    agentEnabled && !inlineAgents
+      ? {
+          path: '/agent',
+          element: <AgentChatPage />,
+        }
+      : null,
+    agentEnabled && inlineAgents
+      ? {
+          path: '/agent/:agentName',
+          element: <AgentChatPage />,
+        }
+      : null,
+    speechToSpeechModelIds.length > 0 && enabled('voiceChat')
+      ? {
+          path: '/voice-chat',
+          element: <VoiceChatPage />,
+        }
+      : null,
+    mcpEnabled
+      ? {
+          path: '/mcp',
+          element: <McpChatPage />,
+        }
+      : null,
+    {
+      path: '/rag-chat-bot',
+      element: <RagChatBotPage />,
+    },
+    {
+      path: '/rag-chat-bot/create',
+      element: <RagChatBotEditPage />,
+    },
+    {
+      path: '/rag-chat-bot/edit/:botId',
+      element: <RagChatBotEditPage />,
+    },
+    {
+      path: '/rag-chat-bot/chat/:botId',
+      element: <RagChatBotChatPage />,
+    },
+    {
+      path: '/rag-chat-bot/chat/:botId/:conversationId',
+      element: <RagChatBotChatPage />,
+    },
+    {
+      path: '/rag-chat-bot/history',
+      element: <RagChatBotHistoryPage />,
+    },
+    {
+      path: '/admin',
+      element: <AdminPortal />,
+    },
+    {
+      path: '*',
+      element: <NotFound />,
+    },
+  ];
 
-const router = createBrowserRouter([
-  {
-    path: '/',
-    element: samlAuthEnabled ? (
-      samlDefaultAuthEnabled ? (
-        <AuthWithSamlOrUserpool>
-          <App />
-        </AuthWithSamlOrUserpool>
+  return routeCandidates.flatMap((route) => (route ? [route] : []));
+};
+
+const buildUseCaseBuilderRoutes = (): RouteObject[] => {
+  return [
+    {
+      path: '/use-case-builder',
+      element: <UseCaseBuilderSamplesPage />,
+    },
+    {
+      path: `/use-case-builder/my-use-case`,
+      element: <UseCaseBuilderMyUseCasePage />,
+    },
+    {
+      path: `/use-case-builder/new`,
+      element: <UseCaseBuilderEditPage />,
+    },
+    {
+      path: `/use-case-builder/edit/:useCaseId`,
+      element: <UseCaseBuilderEditPage />,
+    },
+    {
+      path: `/use-case-builder/execute/:useCaseId`,
+      element: <UseCaseBuilderExecutePage />,
+    },
+    {
+      path: `/use-case-builder/setting`,
+      element: <Setting />,
+    },
+    {
+      path: '*',
+      element: <NotFound />,
+    },
+  ].flatMap((route) => (route ? [route] : []));
+};
+
+const createRouteConfig = (enabled: UseCaseEnabledChecker): RouteObject[] => {
+  const baseRoutes = buildRoutes(enabled);
+
+  const config: RouteObject[] = [
+    {
+      path: '/',
+      element: samlAuthEnabled ? (
+        samlDefaultAuthEnabled ? (
+          <AuthWithSamlOrUserpool>
+            <App />
+          </AuthWithSamlOrUserpool>
+        ) : (
+          <AuthWithSAML>
+            <App />
+          </AuthWithSAML>
+        )
       ) : (
-        <AuthWithSAML>
+        <AuthWithUserpool>
           <App />
-        </AuthWithSAML>
-      )
-    ) : (
-      <AuthWithUserpool>
-        <App />
-      </AuthWithUserpool>
-    ),
-    children: routes,
-  },
-  ...(useCaseBuilderEnabled
-    ? [
-        {
-          path: '/use-case-builder',
-          element: samlAuthEnabled ? (
-            samlDefaultAuthEnabled ? (
-              <AuthWithSamlOrUserpool>
-                <UseCaseBuilderRoot />
-              </AuthWithSamlOrUserpool>
-            ) : (
-              <AuthWithSAML>
-                <UseCaseBuilderRoot />
-              </AuthWithSAML>
-            )
-          ) : (
-            <AuthWithUserpool>
-              <UseCaseBuilderRoot />
-            </AuthWithUserpool>
-          ),
-          children: useCaseBuilderRoutes,
-        },
-      ]
-    : []),
-]);
+        </AuthWithUserpool>
+      ),
+      children: baseRoutes,
+    },
+  ];
+
+  if (useCaseBuilderEnabled) {
+    config.push({
+      path: '/use-case-builder',
+      element: samlAuthEnabled ? (
+        samlDefaultAuthEnabled ? (
+          <AuthWithSamlOrUserpool>
+            <UseCaseBuilderRoot />
+          </AuthWithSamlOrUserpool>
+        ) : (
+          <AuthWithSAML>
+            <UseCaseBuilderRoot />
+          </AuthWithSAML>
+        )
+      ) : (
+        <AuthWithUserpool>
+          <UseCaseBuilderRoot />
+        </AuthWithUserpool>
+      ),
+      children: buildUseCaseBuilderRoutes(),
+    });
+  }
+
+  return config;
+};
+
+const AppRouter = () => {
+  const { enabled } = useUseCases();
+
+  const router = useMemo(() => {
+    const routeConfig = createRouteConfig(enabled);
+    return createBrowserRouter(routeConfig);
+  }, [enabled]);
+
+  return <RouterProvider router={router} />;
+};
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
@@ -330,9 +353,11 @@ ReactDOM.createRoot(document.getElementById('root')!).render(
             revalidateOnMount: true,
           }}
         >
-          <RouterProvider router={router} />
+          <TenantConfigProvider>
+            <AppRouter />
+            <Toaster />
+          </TenantConfigProvider>
         </SWRConfig>
-        <Toaster />
       </Authenticator.Provider>
     </React.Suspense>
   </React.StrictMode>

--- a/packages/web/src/providers/TenantConfigProvider.tsx
+++ b/packages/web/src/providers/TenantConfigProvider.tsx
@@ -1,0 +1,49 @@
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+import { HiddenUseCases, TenantConfiguration } from 'generative-ai-use-cases';
+import useHttp from '../hooks/useHttp';
+
+type TenantConfigState = {
+  tenantId: string | null;
+  tenantDisplayName: string | null;
+  hiddenFeatures: HiddenUseCases;
+  isLoading: boolean;
+  error?: unknown;
+};
+
+const TenantConfigContext = createContext<TenantConfigState | undefined>(undefined);
+
+type TenantConfigProviderProps = {
+  children: ReactNode;
+};
+
+export const TenantConfigProvider = ({ children }: TenantConfigProviderProps) => {
+  const { get } = useHttp();
+  const { data, error, isLoading } = get<TenantConfiguration>('/tenants/config', {
+    revalidateOnFocus: false,
+  });
+
+  const value = useMemo<TenantConfigState>(() => ({
+    tenantId: data?.tenantId ?? null,
+    tenantDisplayName: data?.tenantDisplayName ?? null,
+    hiddenFeatures: data?.hiddenFeatures ?? {},
+    isLoading: Boolean(isLoading),
+    error,
+  }), [data, error, isLoading]);
+
+  return (
+    <TenantConfigContext.Provider value={value}>
+      {children}
+    </TenantConfigContext.Provider>
+  );
+};
+
+export const useTenantConfig = () => {
+  const context = useContext(TenantConfigContext);
+
+  if (!context) {
+    throw new Error('useTenantConfig must be used within TenantConfigProvider');
+  }
+
+  return context;
+};
+

--- a/packages/web/src/vite-env.d.ts
+++ b/packages/web/src/vite-env.d.ts
@@ -27,7 +27,6 @@ interface ImportMetaEnv {
   readonly VITE_APP_INLINE_AGENTS: string;
   readonly VITE_APP_USE_CASE_BUILDER_ENABLED: string;
   readonly VITE_APP_OPTIMIZE_PROMPT_FUNCTION_ARN: string;
-  readonly VITE_APP_HIDDEN_USE_CASES: string;
   readonly VITE_APP_SPEECH_TO_SPEECH_NAMESPACE: string;
   readonly VITE_APP_SPEECH_TO_SPEECH_EVENT_API_ENDPOINT: string;
   readonly VITE_APP_SPEECH_TO_SPEECH_MODEL_IDS: string;

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -46,7 +46,6 @@ export VITE_APP_AGENT_NAMES=$(extract_value "$stack_output" AgentNames | base64 
 export VITE_APP_INLINE_AGENTS=$(extract_value "$stack_output" InlineAgents)
 export VITE_APP_USE_CASE_BUILDER_ENABLED=$(extract_value "$stack_output" UseCaseBuilderEnabled)
 export VITE_APP_OPTIMIZE_PROMPT_FUNCTION_ARN=$(extract_value "$stack_output" OptimizePromptFunctionArn)
-export VITE_APP_HIDDEN_USE_CASES=$(extract_value "$stack_output" HiddenUseCases)
 export VITE_APP_SPEECH_TO_SPEECH_NAMESPACE=$(extract_value "$stack_output" SpeechToSpeechNamespace)
 export VITE_APP_SPEECH_TO_SPEECH_EVENT_API_ENDPOINT=$(extract_value "$stack_output" SpeechToSpeechEventApiEndpoint)
 export VITE_APP_SPEECH_TO_SPEECH_MODEL_IDS=$(extract_value "$stack_output" SpeechToSpeechModelIds)

--- a/web_devw_win.ps1
+++ b/web_devw_win.ps1
@@ -79,7 +79,6 @@ $env:VITE_APP_AGENT_NAMES = [System.Text.Encoding]::UTF8.GetString([System.Conve
 $env:VITE_APP_INLINE_AGENTS = Extract-Value $stack_output "InlineAgents"
 $env:VITE_APP_USE_CASE_BUILDER_ENABLED = Extract-Value $stack_output "UseCaseBuilderEnabled"
 $env:VITE_APP_OPTIMIZE_PROMPT_FUNCTION_ARN = Extract-Value $stack_output "OptimizePromptFunctionArn"
-$env:VITE_APP_HIDDEN_USE_CASES = Extract-Value $stack_output "HiddenUseCases"
 $env:VITE_APP_SPEECH_TO_SPEECH_NAMESPACE = Extract-Value $stack_output "SpeechToSpeechNamespace"
 $env:VITE_APP_SPEECH_TO_SPEECH_EVENT_API_ENDPOINT = Extract-Value $stack_output "SpeechToSpeechEventApiEndpoint"
 $env:VITE_APP_SPEECH_TO_SPEECH_MODEL_IDS = Extract-Value $stack_output "SpeechToSpeechModelIds"


### PR DESCRIPTION
## Summary
- document the new per-tenant hidden feature workflow and remove the legacy CDK context instructions
- extend the tenant manager and registration flows to persist `hiddenFeatures`, and add a `/tenants/config` lambda wired into API Gateway
- update the web app to fetch tenant configuration via a provider so hidden use cases are driven by runtime data instead of env vars

## Testing
- `NODE_PATH=../../node_modules npm -w packages/web run lint` *(fails: numerous pre-existing lint violations in shared files)*
- `npm -w packages/cdk run test` *(fails: requires Docker/AWS region configuration for bundle-heavy stacks and DynamoDB calls)*
- `npm -w packages/web run build`

------
https://chatgpt.com/codex/tasks/task_b_68cbd99faaa883289e8e7797ab639390