### PR TITLE
🐛fix(RAGChatBot): Starredの実装を修正

### DIFF
--- a/packages/cdk/lib/temp-bedrock-chat/backend/app/repositories/bot_store.py
+++ b/packages/cdk/lib/temp-bedrock-chat/backend/app/repositories/bot_store.py
@@ -21,7 +21,6 @@ def find_bots_by_query(
     query: str,
     user: User,
     scope: str = None,
-    starred: bool = None,
     limit: int = 20,
     sort: str = "usage",
     client: OpenSearch | None = None,
@@ -52,7 +51,7 @@ def find_bots_by_query(
         - Admins can see their own private bots (`PK.keyword = admin-user`)
     """
     client = client or get_opensearch_client()
-    logger.info(f"Searching bots with query: {query}, scope: {scope}, starred: {starred}, sort: {sort}")
+    logger.info(f"Searching bots with query: {query}, scope: {scope}, sort: {sort}")
 
     if scope is not None and scope not in VALID_SCOPES:
         logger.warning("Received invalid scope value '%s'", scope)
@@ -72,11 +71,6 @@ def find_bots_by_query(
     elif scope == "all":
         # Only fully public bots
         filter_must.append({"term": {"SharedScope.keyword": "all"}})
-
-    # Apply starred filtering
-    if starred is not None:
-        if starred:
-            filter_must.append({"term": {"IsStarred": True}})
 
     # Condition for bots that can be acquired
     filter_should = []
@@ -452,7 +446,6 @@ def find_random_bots(
 def find_bots_by_filters(
     user: User,
     scope: str = None,
-    starred: bool = None,
     limit: int = 20,
     client: OpenSearch | None = None,
 ) -> list[BotMeta]:
@@ -461,7 +454,6 @@ def find_bots_by_filters(
         query=None,
         user=user,
         scope=scope,
-        starred=starred,
         limit=limit,
         sort="usage",
         client=client,

--- a/packages/cdk/lib/temp-bedrock-chat/backend/app/repositories/models/custom_bot.py
+++ b/packages/cdk/lib/temp-bedrock-chat/backend/app/repositories/models/custom_bot.py
@@ -928,7 +928,7 @@ class BotMeta(BaseModel):
             description=source["Description"],
             create_time=float(source["CreateTime"]),
             last_used_time=float(source.get("LastUsedTime", source["CreateTime"])),
-            is_starred=source.get("IsStarred", False),
+            is_starred=False,  # Will be populated from DynamoDB later
             sync_status=source["SyncStatus"],
             has_bedrock_knowledge_base=bool(source.get("BedrockKnowledgeBase")),
             owned=source["PK"] == user_id,

--- a/packages/cdk/lib/temp-bedrock-chat/backend/app/usecases/bot_store.py
+++ b/packages/cdk/lib/temp-bedrock-chat/backend/app/usecases/bot_store.py
@@ -6,6 +6,7 @@ from app.repositories.bot_store import (
     find_random_bots,
     find_bots_by_filters,
 )
+from app.repositories.custom_bot import find_starred_bots_by_user_id
 from app.routes.schemas.bot import BotMetaOutput
 from app.routes.schemas.bot_guardrails import BedrockGuardrailsOutput
 from app.routes.schemas.bot_kb import BedrockKnowledgeBaseOutput
@@ -24,12 +25,50 @@ def search_bots(
     sort: str = "usage",
 ) -> list[BotMetaOutput]:
     """Search bots by query string with filtering options."""
-    # If no query is provided and sort is 'usage', use the sorted by usage count function
+
+    # Special handling for starred filter
+    if starred is True:
+        # First get starred bot IDs from DynamoDB
+        starred_bots = find_starred_bots_by_user_id(user.id)
+        starred_bot_ids = {bot.id for bot in starred_bots}
+
+        # If no starred bots, return empty list
+        if not starred_bot_ids:
+            return []
+
+        # Get bots from OpenSearch
+        if not query and sort == "usage":
+            bots = find_bots_by_filters(
+                user,
+                scope=scope,
+                limit=limit * 3,  # Get more results to filter
+            )
+        else:
+            bots = find_bots_by_query(
+                query,
+                user,
+                scope=scope,
+                limit=limit * 3,  # Get more results to filter
+                sort=sort,
+            )
+
+        # Filter to only starred bots and set is_starred flag
+        filtered_bots = []
+        for bot in bots:
+            if bot.id in starred_bot_ids:
+                bot.is_starred = True
+                filtered_bots.append(bot)
+                if len(filtered_bots) >= limit:
+                    break
+
+        bot_metas = [bot.to_output() for bot in filtered_bots]
+        return bot_metas
+
+    # Normal search without starred filter
     if not query and sort == "usage":
         bots = find_bots_by_filters(
             user,
             scope=scope,
-            starred=starred,
             limit=limit,
         )
     else:
@@ -37,13 +76,25 @@ def search_bots(
             query,
             user,
             scope=scope,
-            starred=starred,
             limit=limit,
             sort=sort,
         )
-    bot_metas = []
-    for bot in bots:
-        bot_metas.append(bot.to_output())
+
+    # If starred is False or None, we need to check DynamoDB for starred status
+    if starred is False or starred is None:
+        # Get starred bot IDs from DynamoDB
+        starred_bots = find_starred_bots_by_user_id(user.id)
+        starred_bot_ids = {bot.id for bot in starred_bots}
+
+        # Update is_starred flag for each bot
+        for bot in bots:
+            bot.is_starred = bot.id in starred_bot_ids
+
+    # Filter out starred bots if starred is False
+    if starred is False:
+        bots = [bot for bot in bots if not bot.is_starred]
+
+    bot_metas = [bot.to_output() for bot in bots]
     return bot_metas
 
 
@@ -58,9 +109,16 @@ def fetch_popular_bots(
         user,
         limit=limit,
     )
-    bot_metas = []
+
+    # Get starred bot IDs from DynamoDB
+    starred_bots = find_starred_bots_by_user_id(user.id)
+    starred_bot_ids = {bot.id for bot in starred_bots}
+
+    # Update is_starred flag for each bot
     for bot in bots:
-        bot_metas.append(bot.to_output())
+        bot.is_starred = bot.id in starred_bot_ids
+
+    bot_metas = [bot.to_output() for bot in bots]
     return bot_metas
 
 
@@ -75,7 +133,14 @@ def fetch_pickup_bots(
         user,
         limit=limit,
     )
-    bot_metas = []
+
+    # Get starred bot IDs from DynamoDB
+    starred_bots = find_starred_bots_by_user_id(user.id)
+    starred_bot_ids = {bot.id for bot in starred_bots}
+
+    # Update is_starred flag for each bot
     for bot in bots:
-        bot_metas.append(bot.to_output())
+        bot.is_starred = bot.id in starred_bot_ids
+
+    bot_metas = [bot.to_output() for bot in bots]
     return bot_metas

--- a/packages/cdk/lib/temp-bedrock-chat/codebuild-source/cdk/lib/app/repositories/bot_store.py
+++ b/packages/cdk/lib/temp-bedrock-chat/codebuild-source/cdk/lib/app/repositories/bot_store.py
@@ -19,7 +19,6 @@ def find_bots_by_query(
     query: str,
     user: User,
     scope: str = None,
-    starred: bool = None,
     limit: int = 20,
     sort: str = "usage",
     client: OpenSearch | None = None,
@@ -50,7 +49,7 @@ def find_bots_by_query(
         - Admins can see their own private bots (`PK.keyword = admin-user`)
     """
     client = client or get_opensearch_client()
-    logger.info(f"Searching bots with query: {query}, scope: {scope}, starred: {starred}, sort: {sort}")
+    logger.info(f"Searching bots with query: {query}, scope: {scope}, sort: {sort}")
 
     # Include only BOT items
     filter_must = [{"prefix": {"SK.keyword": "BOT"}}]
@@ -66,13 +65,6 @@ def find_bots_by_query(
     elif scope == "all":
         # Only fully public bots
         filter_must.append({"term": {"SharedScope.keyword": "all"}})
-
-    # Apply starred filtering
-    if starred is not None:
-        if starred:
-            filter_must.append({"term": {"IsStarred": True}})
-        else:
-            filter_must.append({"term": {"IsStarred": False}})
 
     # Condition for bots that can be acquired
     filter_should = []
@@ -448,7 +440,6 @@ def find_random_bots(
 def find_bots_by_filters(
     user: User,
     scope: str = None,
-    starred: bool = None,
     limit: int = 20,
     client: OpenSearch | None = None,
 ) -> list[BotMeta]:
@@ -457,7 +448,6 @@ def find_bots_by_filters(
         query=None,
         user=user,
         scope=scope,
-        starred=starred,
         limit=limit,
         sort="usage",
         client=client,

--- a/packages/cdk/lib/temp-bedrock-chat/codebuild-source/cdk/lib/app/repositories/models/custom_bot.py
+++ b/packages/cdk/lib/temp-bedrock-chat/codebuild-source/cdk/lib/app/repositories/models/custom_bot.py
@@ -928,7 +928,7 @@ class BotMeta(BaseModel):
             description=source["Description"],
             create_time=float(source["CreateTime"]),
             last_used_time=float(source.get("LastUsedTime", source["CreateTime"])),
-            is_starred=source.get("IsStarred", False),
+            is_starred=False,  # Will be populated from DynamoDB later
             sync_status=source["SyncStatus"],
             has_bedrock_knowledge_base=bool(source.get("BedrockKnowledgeBase")),
             owned=source["PK"] == user_id,


### PR DESCRIPTION
## 変更の概要
正常に機能していなかったisStarredフィルタリングが機能するようにした
1. OpenSearchからisStarredを削除
- OpenSearchのインデックスからIsStarredフィールドを削除
- bot_store.pyのfind_bots_by_queryから、starred関連のフィルタリング処理を削除
2. 検索処理の修正
- isStarred=falseの場合
    - OpenSearchで検索→DynamoDBからstarred情報を参照して検索結果にマージ
- isStarred=trueの場合
    - 先にDynamoDBからstarred bot_idリストを取得→OpenSearchで検索

## 申し送り事項

<!-- レビュワーに伝えておきたい事柄等を書く（Draftの理由など） -->

## Checklist（レビュワー用）

- [ ] `npm run lint`でエラーが出ない
- [ ] TypeScriptのビルドで型エラーが出ない
- [ ] 手元でフォーマットした際に差分が出ない
