### PR TITLE
refactor: CDKスタックをリソースグループごとに分割

### DIFF
--- a/packages/cdk/lib/create-stacks.ts
+++ b/packages/cdk/lib/create-stacks.ts
@@ -1,6 +1,5 @@
 import * as cdk from 'aws-cdk-lib';
 import { IConstruct } from 'constructs';
-import { GenerativeAiUseCasesStack } from './stacks/common/generative-ai-use-cases-stack';
 import { CloudFrontWafStack } from './stacks/common/cloud-front-waf-stack';
 import { DashboardStack } from './stacks/common/dashboard-stack';
 import { AgentStack } from './stacks/common/agent-stack';
@@ -8,6 +7,13 @@ import { RagKnowledgeBaseStack } from './stacks/common/rag-knowledge-base-stack'
 import { GuardrailStack } from './stacks/common/guardrail-stack';
 import { ProcessedStackInput } from './stack-input';
 import { VideoTmpBucketStack } from './stacks/common/video-tmp-bucket-stack';
+import { AuthStack } from './stacks/common/auth-stack';
+import { DatabaseStack } from './stacks/common/database-stack';
+import { ApiStack } from './stacks/common/api-stack';
+import { WebStack } from './stacks/common/web-stack';
+import { RagStack } from './stacks/common/rag-stack';
+import { ExtensionStack } from './stacks/common/extension-stack';
+import { WafAssociationStack } from './stacks/common/waf-association-stack';
 
 class DeletionPolicySetter implements cdk.IAspect {
   constructor(private readonly policy: cdk.RemovalPolicy) {}
@@ -104,44 +110,155 @@ export const createStacks = (app: cdk.App, params: ProcessedStackInput) => {
     videoBucketRegionMap[region] = videoTmpBucketStack.bucketName;
   }
 
-  // GenU Stack
+  // Core Stacks
   const isSageMakerStudio = 'SAGEMAKER_APP_TYPE_LOWERCASE' in process.env;
-  const generativeAiUseCasesStack = new GenerativeAiUseCasesStack(
-    app,
-    `GenerativeAiUseCasesStack${params.env}`,
-    {
-      env: {
-        account: params.account,
-        region: params.region,
-      },
-      description: params.anonymousUsageTracking
-        ? 'Generative AI Use Cases (uksb-1tupboc48)'
-        : undefined,
-      params: params,
-      crossRegionReferences: true,
-      // RAG Knowledge Base
-      knowledgeBaseId: ragKnowledgeBaseStack?.knowledgeBaseId,
-      knowledgeBaseDataSourceBucketName:
-        ragKnowledgeBaseStack?.dataSourceBucketName,
-      // Agent
-      agents: agentStack?.agents,
-      // Video Generation
-      videoBucketRegionMap,
-      // Guardrail
-      guardrailIdentifier: guardrail?.guardrailIdentifier,
-      guardrailVersion: 'DRAFT',
-      // WAF
-      webAclId: cloudFrontWafStack?.webAclArn,
-      // Custom Domain
-      cert: cloudFrontWafStack?.cert,
-      // Image build environment
-      isSageMakerStudio,
-    }
-  );
 
-  cdk.Aspects.of(generativeAiUseCasesStack).add(
+  // 1. Auth Stack
+  const authStack = new AuthStack(app, `AuthStack${params.env}`, {
+    env: {
+      account: params.account,
+      region: params.region,
+    },
+    params: params,
+    crossRegionReferences: true,
+  });
+
+  // 2. Database Stack
+  const databaseStack = new DatabaseStack(app, `DatabaseStack${params.env}`, {
+    env: {
+      account: params.account,
+      region: params.region,
+    },
+    params: params,
+    crossRegionReferences: true,
+  });
+
+  // 3. API Stack
+  const apiStack = new ApiStack(app, `ApiStack${params.env}`, {
+    env: {
+      account: params.account,
+      region: params.region,
+    },
+    params: params,
+    userPoolId: authStack.userPool.userPoolId,
+    userPoolClientId: authStack.userPoolClient.userPoolClientId,
+    idPoolId: authStack.idPool.identityPoolId,
+    tableName: databaseStack.table.tableName,
+    statsTableName: databaseStack.statsTable.tableName,
+    tenantManagerTableName: databaseStack.tenantManager.tenantsTable.tableName,
+    tenantRegistrationLambdaArn: databaseStack.tenantManager.registrationLambda.functionArn,
+    knowledgeBaseId: ragKnowledgeBaseStack?.knowledgeBaseId,
+    agents: agentStack?.agents,
+    guardrailIdentifier: guardrail?.guardrailIdentifier,
+    guardrailVersion: 'DRAFT',
+    videoBucketRegionMap,
+    isSageMakerStudio,
+    crossRegionReferences: true,
+  });
+
+  // 4. WAF Association Stack (optional)
+  const wafAssociationStack = (
+    params.allowedIpV4AddressRanges ||
+    params.allowedIpV6AddressRanges ||
+    params.allowedCountryCodes
+  )
+    ? new WafAssociationStack(app, `WafAssociationStack${params.env}`, {
+        env: {
+          account: params.account,
+          region: params.region,
+        },
+        params: params,
+        apiGatewayArn: apiStack.restApiArn,
+        userPoolArn: authStack.userPool.userPoolArn,
+        crossRegionReferences: true,
+      })
+    : null;
+
+  // 5. Extension Stack
+  const extensionStack = new ExtensionStack(app, `ExtensionStack${params.env}`, {
+    env: {
+      account: params.account,
+      region: params.region,
+    },
+    params: params,
+    userPoolId: authStack.userPool.userPoolId,
+    idPoolId: authStack.idPool.identityPoolId,
+    apiRestApiId: apiStack.restApiId,
+    apiRestApiRootResourceId: apiStack.restApiRootResourceId,
+    fileBucketName: apiStack.fileBucketName,
+    tenantManagerTableName: databaseStack.tenantManager.tenantsTable.tableName,
+    tenantRegistrationLambdaArn: databaseStack.tenantManager.registrationLambda.functionArn,
+    isSageMakerStudio,
+    crossRegionReferences: true,
+  });
+
+  // 6. RAG Stack (optional)
+  const ragStack = (params.ragEnabled || params.ragKnowledgeBaseEnabled)
+    ? new RagStack(app, `RagStack${params.env}`, {
+        env: {
+          account: params.account,
+          region: params.region,
+        },
+        params: params,
+        userPoolId: authStack.userPool.userPoolId,
+        apiRestApiId: apiStack.restApiId,
+        apiRestApiRootResourceId: apiStack.restApiRootResourceId,
+        getFileDownloadSignedUrlFunctionArn: apiStack.getFileDownloadSignedUrlFunctionArn,
+        knowledgeBaseId: ragKnowledgeBaseStack?.knowledgeBaseId,
+        knowledgeBaseDataSourceBucketName: ragKnowledgeBaseStack?.dataSourceBucketName,
+        crossRegionReferences: true,
+      })
+    : null;
+
+  // 7. Web Stack
+  const webStack = new WebStack(app, `WebStack${params.env}`, {
+    env: {
+      account: params.account,
+      region: params.region,
+    },
+    params: params,
+    userPoolId: authStack.userPool.userPoolId,
+    userPoolClientId: authStack.userPoolClient.userPoolClientId,
+    idPoolId: authStack.idPool.identityPoolId,
+    apiEndpointUrl: apiStack.restApiUrl,
+    predictStreamFunctionArn: apiStack.predictStreamFunctionArn,
+    invokeFlowFunctionArn: apiStack.invokeFlowFunctionArn,
+    optimizePromptFunctionArn: apiStack.optimizePromptFunctionArn,
+    modelRegion: apiStack.modelRegion,
+    modelIds: apiStack.modelIds,
+    imageGenerationModelIds: apiStack.imageGenerationModelIds,
+    videoGenerationModelIds: apiStack.videoGenerationModelIds,
+    endpointNames: apiStack.endpointNames,
+    agentNames: apiStack.agentNames,
+    speechToSpeechNamespace: extensionStack.speechToSpeechNamespace,
+    speechToSpeechEventApiEndpoint: extensionStack.speechToSpeechEventApiEndpoint,
+    mcpEndpoint: extensionStack.mcpEndpoint ?? undefined,
+    webAclId: cloudFrontWafStack?.webAclArn,
+    cert: cloudFrontWafStack?.cert,
+    crossRegionReferences: true,
+  });
+
+  // Apply deletion policy to all stacks
+  cdk.Aspects.of(authStack).add(
     new DeletionPolicySetter(cdk.RemovalPolicy.DESTROY)
   );
+  cdk.Aspects.of(databaseStack).add(
+    new DeletionPolicySetter(cdk.RemovalPolicy.DESTROY)
+  );
+  cdk.Aspects.of(apiStack).add(
+    new DeletionPolicySetter(cdk.RemovalPolicy.DESTROY)
+  );
+  cdk.Aspects.of(extensionStack).add(
+    new DeletionPolicySetter(cdk.RemovalPolicy.DESTROY)
+  );
+  cdk.Aspects.of(webStack).add(
+    new DeletionPolicySetter(cdk.RemovalPolicy.DESTROY)
+  );
+  if (ragStack) {
+    cdk.Aspects.of(ragStack).add(
+      new DeletionPolicySetter(cdk.RemovalPolicy.DESTROY)
+    );
+  }
 
   const dashboardStack = params.dashboard
     ? new DashboardStack(
@@ -153,8 +270,8 @@ export const createStacks = (app: cdk.App, params: ProcessedStackInput) => {
             region: params.modelRegion,
           },
           params: params,
-          userPool: generativeAiUseCasesStack.userPool,
-          userPoolClient: generativeAiUseCasesStack.userPoolClient,
+          userPool: authStack.userPool,
+          userPoolClient: authStack.userPoolClient,
           appRegion: params.region,
           crossRegionReferences: true,
         }
@@ -166,7 +283,13 @@ export const createStacks = (app: cdk.App, params: ProcessedStackInput) => {
     ragKnowledgeBaseStack,
     agentStack,
     guardrail,
-    generativeAiUseCasesStack,
+    authStack,
+    databaseStack,
+    apiStack,
+    extensionStack,
+    wafAssociationStack,
+    ragStack,
+    webStack,
     dashboardStack,
   };
 };

--- a/packages/cdk/lib/stacks/common/api-stack.ts
+++ b/packages/cdk/lib/stacks/common/api-stack.ts
@@ -1,0 +1,207 @@
+import { Stack, StackProps, CfnOutput, Fn } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Api, LitellmProxyServer } from '../../construct';
+import * as cognito from 'aws-cdk-lib/aws-cognito';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { IdentityPool } from 'aws-cdk-lib/aws-cognito-identitypool';
+import { ProcessedStackInput } from '../../stack-input';
+import { Agent } from 'generative-ai-use-cases';
+import { TenantManager } from '../../construct/tenant-manager';
+
+export interface ApiStackProps extends StackProps {
+  readonly params: ProcessedStackInput;
+  readonly userPoolId: string;
+  readonly userPoolClientId: string;
+  readonly idPoolId: string;
+  readonly tableName: string;
+  readonly statsTableName: string;
+  readonly tenantManagerTableName: string;
+  readonly tenantRegistrationLambdaArn: string;
+  readonly knowledgeBaseId?: string;
+  readonly agents?: Agent[];
+  readonly guardrailIdentifier?: string;
+  readonly guardrailVersion?: string;
+  readonly videoBucketRegionMap: Record<string, string>;
+  readonly isSageMakerStudio: boolean;
+}
+
+export class ApiStack extends Stack {
+  public readonly restApiUrl: string;
+  public readonly restApiId: string;
+  public readonly restApiRootResourceId: string;
+  public readonly restApiArn: string;
+  public readonly predictStreamFunctionArn: string;
+  public readonly invokeFlowFunctionArn: string;
+  public readonly optimizePromptFunctionArn: string;
+  public readonly fileBucketName: string;
+  public readonly modelRegion: string;
+  public readonly modelIds: any;
+  public readonly imageGenerationModelIds: any;
+  public readonly videoGenerationModelIds: any;
+  public readonly endpointNames: any;
+  public readonly agentNames: any;
+  public readonly litellmEndpoint: string | null = null;
+  public readonly getFileDownloadSignedUrlFunctionArn?: string;
+
+  constructor(scope: Construct, id: string, props: ApiStackProps) {
+    super(scope, id, props);
+
+    const params = props.params;
+
+    const userPool = cognito.UserPool.fromUserPoolId(
+      this,
+      'ImportedUserPool',
+      props.userPoolId
+    );
+
+    const userPoolClient = cognito.UserPoolClient.fromUserPoolClientId(
+      this,
+      'ImportedUserPoolClient',
+      props.userPoolClientId
+    );
+
+    const idPool = IdentityPool.fromIdentityPoolId(
+      this,
+      'ImportedIdPool',
+      props.idPoolId
+    );
+
+    const table = dynamodb.Table.fromTableName(
+      this,
+      'ImportedTable',
+      props.tableName
+    );
+
+    const statsTable = dynamodb.Table.fromTableName(
+      this,
+      'ImportedStatsTable',
+      props.statsTableName
+    );
+
+    const tenantsTable = dynamodb.Table.fromTableName(
+      this,
+      'ImportedTenantsTable',
+      props.tenantManagerTableName
+    );
+
+    const registrationLambda = iam.Role.fromRoleArn(
+      this,
+      'ImportedRegistrationLambda',
+      props.tenantRegistrationLambdaArn
+    );
+
+    const tenantManager = {
+      tenantsTable,
+      registrationLambda: { functionArn: props.tenantRegistrationLambdaArn } as any,
+    } as TenantManager;
+
+    let litellmProxy: LitellmProxyServer | null = null;
+    if (params.litellmProxyEnabled) {
+      litellmProxy = new LitellmProxyServer(this, 'LitellmProxyServer', {
+        idPool: idPool as any,
+        isSageMakerStudio: props.isSageMakerStudio,
+        modelRegion: params.modelRegion,
+        crossAccountBedrockRoleArn:
+          params.crossAccountBedrockRoleArn || undefined,
+      });
+      this.litellmEndpoint = litellmProxy.endpoint;
+    }
+
+    const api = new Api(this, 'API', {
+      modelRegion: params.modelRegion,
+      modelIds: params.modelIds,
+      imageGenerationModelIds: params.imageGenerationModelIds,
+      videoGenerationModelIds: params.videoGenerationModelIds,
+      videoBucketRegionMap: props.videoBucketRegionMap,
+      endpointNames: params.endpointNames,
+      customAgents: params.agents,
+      queryDecompositionEnabled: params.queryDecompositionEnabled,
+      rerankingModelId: params.rerankingModelId,
+      crossAccountBedrockRoleArn: params.crossAccountBedrockRoleArn,
+      allowedIpV4AddressRanges: params.allowedIpV4AddressRanges,
+      allowedIpV6AddressRanges: params.allowedIpV6AddressRanges,
+      litellmEndpoint: this.litellmEndpoint,
+      litellmProxy: litellmProxy,
+      selfSignUpTenantMap: params.selfSignUpTenantMap,
+      userPool: userPool as cognito.UserPool,
+      idPool: idPool as any,
+      userPoolClient: userPoolClient as cognito.UserPoolClient,
+      table: table as dynamodb.Table,
+      statsTable: statsTable as dynamodb.Table,
+      knowledgeBaseId: params.ragKnowledgeBaseId || props.knowledgeBaseId,
+      agents: props.agents,
+      guardrailIdentify: props.guardrailIdentifier,
+      guardrailVersion: props.guardrailVersion,
+      environment: params.env,
+      tenantManager: tenantManager,
+      openai: params.openai,
+    });
+
+    this.restApiUrl = api.restApi.url;
+    this.restApiId = api.restApi.restApiId;
+    this.restApiRootResourceId = api.restApi.restApiRootResourceId;
+    this.restApiArn = api.restApi.deploymentStage.stageArn;
+    this.predictStreamFunctionArn = api.predictStreamFunction.functionArn;
+    this.invokeFlowFunctionArn = api.invokeFlowFunction.functionArn;
+    this.optimizePromptFunctionArn = api.optimizePromptFunction.functionArn;
+    this.fileBucketName = api.fileBucket.bucketName;
+    this.modelRegion = api.modelRegion;
+    this.modelIds = api.modelIds;
+    this.imageGenerationModelIds = api.imageGenerationModelIds;
+    this.videoGenerationModelIds = api.videoGenerationModelIds;
+    this.endpointNames = api.endpointNames;
+    this.agentNames = api.agentNames;
+    this.getFileDownloadSignedUrlFunctionArn = api.getFileDownloadSignedUrlFunction?.functionArn;
+
+    new CfnOutput(this, 'ApiEndpoint', {
+      value: api.restApi.url,
+      exportName: `${this.stackName}-ApiEndpoint`,
+    });
+
+    new CfnOutput(this, 'RestApiId', {
+      value: api.restApi.restApiId,
+      exportName: `${this.stackName}-RestApiId`,
+    });
+
+    new CfnOutput(this, 'RestApiRootResourceId', {
+      value: api.restApi.restApiRootResourceId,
+      exportName: `${this.stackName}-RestApiRootResourceId`,
+    });
+
+    new CfnOutput(this, 'RestApiArn', {
+      value: this.restApiArn,
+      exportName: `${this.stackName}-RestApiArn`,
+    });
+
+    new CfnOutput(this, 'PredictStreamFunctionArn', {
+      value: api.predictStreamFunction.functionArn,
+      exportName: `${this.stackName}-PredictStreamFunctionArn`,
+    });
+
+    new CfnOutput(this, 'OptimizePromptFunctionArn', {
+      value: api.optimizePromptFunction.functionArn,
+      exportName: `${this.stackName}-OptimizePromptFunctionArn`,
+    });
+
+    new CfnOutput(this, 'InvokeFlowFunctionArn', {
+      value: api.invokeFlowFunction.functionArn,
+      exportName: `${this.stackName}-InvokeFlowFunctionArn`,
+    });
+
+    new CfnOutput(this, 'FileBucketName', {
+      value: api.fileBucket.bucketName,
+      exportName: `${this.stackName}-FileBucketName`,
+    });
+
+    new CfnOutput(this, 'ModelRegion', {
+      value: api.modelRegion,
+      exportName: `${this.stackName}-ModelRegion`,
+    });
+
+    new CfnOutput(this, 'LitellmProxyEndpoint', {
+      value: this.litellmEndpoint ?? '',
+      exportName: `${this.stackName}-LitellmProxyEndpoint`,
+    });
+  }
+}

--- a/packages/cdk/lib/stacks/common/auth-stack.ts
+++ b/packages/cdk/lib/stacks/common/auth-stack.ts
@@ -1,0 +1,51 @@
+import { Stack, StackProps, CfnOutput } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Auth } from '../../construct';
+import * as cognito from 'aws-cdk-lib/aws-cognito';
+import { ProcessedStackInput } from '../../stack-input';
+import { IdentityPool } from 'aws-cdk-lib/aws-cognito-identitypool';
+
+export interface AuthStackProps extends StackProps {
+  readonly params: ProcessedStackInput;
+}
+
+export class AuthStack extends Stack {
+  public readonly userPool: cognito.UserPool;
+  public readonly userPoolClient: cognito.UserPoolClient;
+  public readonly idPool: IdentityPool;
+
+  constructor(scope: Construct, id: string, props: AuthStackProps) {
+    super(scope, id, props);
+
+    const params = props.params;
+
+    const auth = new Auth(this, 'Auth', {
+      selfSignUpEnabled: params.selfSignUpEnabled,
+      allowedIpV4AddressRanges: params.allowedIpV4AddressRanges,
+      allowedIpV6AddressRanges: params.allowedIpV6AddressRanges,
+      selfSignUpTenantMap: params.selfSignUpTenantMap,
+      samlAuthEnabled: params.samlAuthEnabled,
+      samlDefaultAuthEnabled: params.samlDefaultAuthEnabled,
+    });
+
+    this.userPool = auth.userPool;
+    this.userPoolClient = auth.client;
+    this.idPool = auth.idPool;
+
+    new CfnOutput(this, 'UserPoolId', {
+      value: auth.userPool.userPoolId,
+      exportName: `${this.stackName}-UserPoolId`,
+    });
+
+    new CfnOutput(this, 'UserPoolClientId', {
+      value: auth.client.userPoolClientId,
+      exportName: `${this.stackName}-UserPoolClientId`,
+    });
+
+    new CfnOutput(this, 'IdPoolId', {
+      value: auth.idPool.identityPoolId,
+      exportName: `${this.stackName}-IdPoolId`,
+    });
+  }
+}
+

--- a/packages/cdk/lib/stacks/common/database-stack.ts
+++ b/packages/cdk/lib/stacks/common/database-stack.ts
@@ -1,0 +1,52 @@
+import { Stack, StackProps, CfnOutput } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Database, TenantManager } from '../../construct';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import { ProcessedStackInput } from '../../stack-input';
+
+export interface DatabaseStackProps extends StackProps {
+  readonly params: ProcessedStackInput;
+}
+
+export class DatabaseStack extends Stack {
+  public readonly table: dynamodb.Table;
+  public readonly statsTable: dynamodb.Table;
+  public readonly tenantManager: TenantManager;
+
+  constructor(scope: Construct, id: string, props: DatabaseStackProps) {
+    super(scope, id, props);
+
+    const params = props.params;
+
+    const database = new Database(this, 'Database');
+
+    const tenantManager = new TenantManager(this, 'TenantManager', {
+      environment: params.env,
+      enableAutoDelete: params.enableAutoDelete,
+    });
+
+    this.table = database.table;
+    this.statsTable = database.statsTable;
+    this.tenantManager = tenantManager;
+
+    new CfnOutput(this, 'TableName', {
+      value: database.table.tableName,
+      exportName: `${this.stackName}-TableName`,
+    });
+
+    new CfnOutput(this, 'StatsTableName', {
+      value: database.statsTable.tableName,
+      exportName: `${this.stackName}-StatsTableName`,
+    });
+
+    new CfnOutput(this, 'TenantsTableName', {
+      value: tenantManager.tenantsTable.tableName,
+      exportName: `${this.stackName}-TenantsTableName`,
+    });
+
+    new CfnOutput(this, 'TenantRegistrationLambdaArn', {
+      value: tenantManager.registrationLambda.functionArn,
+      exportName: `${this.stackName}-TenantRegistrationLambdaArn`,
+    });
+  }
+}

--- a/packages/cdk/lib/stacks/common/extension-stack.ts
+++ b/packages/cdk/lib/stacks/common/extension-stack.ts
@@ -1,0 +1,144 @@
+import { Stack, StackProps, CfnOutput } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import {
+  Transcribe,
+  SpeechToSpeech,
+  McpApi
+} from '../../construct';
+import { UseCaseBuilder } from '../../construct/use-case-builder';
+import * as apigateway from 'aws-cdk-lib/aws-apigateway';
+import * as cognito from 'aws-cdk-lib/aws-cognito';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import { IdentityPool } from 'aws-cdk-lib/aws-cognito-identitypool';
+import { ProcessedStackInput } from '../../stack-input';
+import { TenantManager } from '../../construct/tenant-manager';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+
+export interface ExtensionStackProps extends StackProps {
+  readonly params: ProcessedStackInput;
+  readonly userPoolId: string;
+  readonly idPoolId: string;
+  readonly apiRestApiId: string;
+  readonly apiRestApiRootResourceId: string;
+  readonly fileBucketName?: string;
+  readonly tenantManagerTableName: string;
+  readonly tenantRegistrationLambdaArn: string;
+  readonly isSageMakerStudio: boolean;
+}
+
+export class ExtensionStack extends Stack {
+  public readonly speechToSpeechNamespace: string;
+  public readonly speechToSpeechEventApiEndpoint: string;
+  public readonly mcpEndpoint: string | null = null;
+
+  constructor(scope: Construct, id: string, props: ExtensionStackProps) {
+    super(scope, id, props);
+
+    const params = props.params;
+
+    const userPool = cognito.UserPool.fromUserPoolId(
+      this,
+      'ImportedUserPool',
+      props.userPoolId
+    );
+
+    const idPool = IdentityPool.fromIdentityPoolId(
+      this,
+      'ImportedIdPool',
+      props.idPoolId
+    );
+
+    const restApi = apigateway.RestApi.fromRestApiId(
+      this,
+      'ImportedRestApi',
+      props.apiRestApiId
+    );
+
+    const tenantsTable = dynamodb.Table.fromTableName(
+      this,
+      'ImportedTenantsTable',
+      props.tenantManagerTableName
+    );
+
+    const tenantManager = {
+      tenantsTable,
+      registrationLambda: { functionArn: props.tenantRegistrationLambdaArn } as any,
+    } as TenantManager;
+
+    const speechToSpeech = new SpeechToSpeech(this, 'SpeechToSpeech', {
+      envSuffix: params.env,
+      api: restApi as apigateway.RestApi,
+      userPool: userPool as cognito.UserPool,
+      speechToSpeechModelIds: params.speechToSpeechModelIds,
+      crossAccountBedrockRoleArn: params.crossAccountBedrockRoleArn,
+    });
+
+    this.speechToSpeechNamespace = speechToSpeech.namespace;
+    this.speechToSpeechEventApiEndpoint = speechToSpeech.eventApiEndpoint;
+
+    if (params.mcpEnabled && props.fileBucketName) {
+      const fileBucket = s3.Bucket.fromBucketName(
+        this,
+        'ImportedFileBucket',
+        props.fileBucketName
+      );
+
+      const mcpApi = new McpApi(this, 'McpApi', {
+        idPool: idPool as any,
+        isSageMakerStudio: props.isSageMakerStudio,
+        fileBucket: fileBucket as s3.Bucket,
+      });
+      this.mcpEndpoint = mcpApi.endpoint;
+    }
+
+    if (params.useCaseBuilderEnabled) {
+      new UseCaseBuilder(this, 'UseCaseBuilder', {
+        userPool: userPool as cognito.UserPool,
+        api: restApi as apigateway.RestApi,
+        idPool: idPool as any,
+        environment: params.env,
+        tenantManager: tenantManager,
+      });
+    }
+
+    new Transcribe(this, 'Transcribe', {
+      userPool: userPool as cognito.UserPool,
+      idPool: idPool as any,
+      api: restApi as apigateway.RestApi,
+      allowedIpV4AddressRanges: params.allowedIpV4AddressRanges,
+      allowedIpV6AddressRanges: params.allowedIpV6AddressRanges,
+      tenantManager: tenantManager,
+      environment: params.env,
+    });
+
+    new CfnOutput(this, 'SpeechToSpeechNamespace', {
+      value: speechToSpeech.namespace,
+      exportName: `${this.stackName}-SpeechToSpeechNamespace`,
+    });
+
+    new CfnOutput(this, 'SpeechToSpeechEventApiEndpoint', {
+      value: speechToSpeech.eventApiEndpoint,
+      exportName: `${this.stackName}-SpeechToSpeechEventApiEndpoint`,
+    });
+
+    new CfnOutput(this, 'SpeechToSpeechModelIds', {
+      value: JSON.stringify(params.speechToSpeechModelIds),
+      exportName: `${this.stackName}-SpeechToSpeechModelIds`,
+    });
+
+    new CfnOutput(this, 'McpEnabled', {
+      value: params.mcpEnabled.toString(),
+      exportName: `${this.stackName}-McpEnabled`,
+    });
+
+    new CfnOutput(this, 'McpEndpoint', {
+      value: this.mcpEndpoint ?? '',
+      exportName: `${this.stackName}-McpEndpoint`,
+    });
+
+    new CfnOutput(this, 'UseCaseBuilderEnabled', {
+      value: params.useCaseBuilderEnabled.toString(),
+      exportName: `${this.stackName}-UseCaseBuilderEnabled`,
+    });
+  }
+}

--- a/packages/cdk/lib/stacks/common/rag-stack.ts
+++ b/packages/cdk/lib/stacks/common/rag-stack.ts
@@ -1,0 +1,133 @@
+import { Stack, StackProps, CfnOutput, Fn } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Rag, RagKnowledgeBase } from '../../construct';
+import * as apigateway from 'aws-cdk-lib/aws-apigateway';
+import * as cognito from 'aws-cdk-lib/aws-cognito';
+import { ProcessedStackInput } from '../../stack-input';
+import { allowS3AccessWithSourceIpCondition } from '../../utils/s3-access-policy';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+
+export interface RagStackProps extends StackProps {
+  readonly params: ProcessedStackInput;
+  readonly userPoolId: string;
+  readonly apiRestApiId: string;
+  readonly apiRestApiRootResourceId: string;
+  readonly getFileDownloadSignedUrlFunctionArn?: string;
+  readonly knowledgeBaseId?: string;
+  readonly knowledgeBaseDataSourceBucketName?: string;
+}
+
+export class RagStack extends Stack {
+  public readonly dataSourceBucketName?: string;
+
+  constructor(scope: Construct, id: string, props: RagStackProps) {
+    super(scope, id, props);
+
+    const params = props.params;
+
+    const userPool = cognito.UserPool.fromUserPoolId(
+      this,
+      'ImportedUserPool',
+      props.userPoolId
+    );
+
+    const restApi = apigateway.RestApi.fromRestApiId(
+      this,
+      'ImportedRestApi',
+      props.apiRestApiId
+    );
+
+    if (params.ragEnabled) {
+      const rag = new Rag(this, 'Rag', {
+        envSuffix: params.env,
+        kendraIndexLanguage: params.kendraIndexLanguage,
+        kendraIndexArnInCdkContext: params.kendraIndexArn,
+        kendraDataSourceBucketName: params.kendraDataSourceBucketName,
+        kendraIndexScheduleEnabled: params.kendraIndexScheduleEnabled,
+        kendraIndexScheduleCreateCron: params.kendraIndexScheduleCreateCron,
+        kendraIndexScheduleDeleteCron: params.kendraIndexScheduleDeleteCron,
+        userPool: userPool as cognito.UserPool,
+        api: restApi as apigateway.RestApi,
+      });
+
+      this.dataSourceBucketName = rag.dataSourceBucketName;
+
+      if (
+        rag.dataSourceBucketName &&
+        props.getFileDownloadSignedUrlFunctionArn
+      ) {
+        const getFileDownloadSignedUrlFunction = lambda.Function.fromFunctionArn(
+          this,
+          'ImportedGetFileDownloadSignedUrlFunction',
+          props.getFileDownloadSignedUrlFunctionArn
+        );
+
+        if (getFileDownloadSignedUrlFunction.role) {
+          allowS3AccessWithSourceIpCondition(
+            rag.dataSourceBucketName,
+            getFileDownloadSignedUrlFunction.role,
+            'read',
+            {
+              ipv4: params.allowedIpV4AddressRanges,
+              ipv6: params.allowedIpV6AddressRanges,
+            }
+          );
+        }
+      }
+
+      if (rag.dataSourceBucketName) {
+        new CfnOutput(this, 'KendraDataSourceBucketName', {
+          value: rag.dataSourceBucketName,
+          exportName: `${this.stackName}-KendraDataSourceBucketName`,
+        });
+      }
+    }
+
+    if (params.ragKnowledgeBaseEnabled) {
+      const knowledgeBaseId =
+        params.ragKnowledgeBaseId || props.knowledgeBaseId;
+      if (knowledgeBaseId) {
+        new RagKnowledgeBase(this, 'RagKnowledgeBase', {
+          modelRegion: params.modelRegion,
+          crossAccountBedrockRoleArn: params.crossAccountBedrockRoleArn,
+          knowledgeBaseId: knowledgeBaseId,
+          userPool: userPool as cognito.UserPool,
+          api: restApi as apigateway.RestApi,
+        });
+
+        if (
+          props.knowledgeBaseDataSourceBucketName &&
+          props.getFileDownloadSignedUrlFunctionArn
+        ) {
+          const getFileDownloadSignedUrlFunction = lambda.Function.fromFunctionArn(
+            this,
+            'ImportedGetFileDownloadSignedUrlFunctionKB',
+            props.getFileDownloadSignedUrlFunctionArn
+          );
+
+          if (getFileDownloadSignedUrlFunction.role) {
+            allowS3AccessWithSourceIpCondition(
+              props.knowledgeBaseDataSourceBucketName,
+              getFileDownloadSignedUrlFunction.role,
+              'read',
+              {
+                ipv4: params.allowedIpV4AddressRanges,
+                ipv6: params.allowedIpV6AddressRanges,
+              }
+            );
+          }
+        }
+      }
+    }
+
+    new CfnOutput(this, 'RagEnabled', {
+      value: params.ragEnabled.toString(),
+      exportName: `${this.stackName}-RagEnabled`,
+    });
+
+    new CfnOutput(this, 'RagKnowledgeBaseEnabled', {
+      value: params.ragKnowledgeBaseEnabled.toString(),
+      exportName: `${this.stackName}-RagKnowledgeBaseEnabled`,
+    });
+  }
+}

--- a/packages/cdk/lib/stacks/common/waf-association-stack.ts
+++ b/packages/cdk/lib/stacks/common/waf-association-stack.ts
@@ -1,0 +1,48 @@
+import { Stack, StackProps } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { CfnWebACLAssociation } from 'aws-cdk-lib/aws-wafv2';
+import { CommonWebAcl } from '../../construct';
+import { ProcessedStackInput } from '../../stack-input';
+
+export interface WafAssociationStackProps extends StackProps {
+  readonly params: ProcessedStackInput;
+  readonly apiGatewayArn: string;
+  readonly userPoolArn: string;
+}
+
+export class WafAssociationStack extends Stack {
+  public readonly webAclArn: string;
+
+  constructor(scope: Construct, id: string, props: WafAssociationStackProps) {
+    super(scope, id, props);
+
+    const params = props.params;
+
+    if (
+      params.allowedIpV4AddressRanges ||
+      params.allowedIpV6AddressRanges ||
+      params.allowedCountryCodes
+    ) {
+      const regionalWaf = new CommonWebAcl(this, 'RegionalWaf', {
+        scope: 'REGIONAL',
+        allowedIpV4AddressRanges: params.allowedIpV4AddressRanges,
+        allowedIpV6AddressRanges: params.allowedIpV6AddressRanges,
+        allowedCountryCodes: params.allowedCountryCodes,
+      });
+
+      new CfnWebACLAssociation(this, 'ApiWafAssociation', {
+        resourceArn: props.apiGatewayArn,
+        webAclArn: regionalWaf.webAclArn,
+      });
+
+      new CfnWebACLAssociation(this, 'UserPoolWafAssociation', {
+        resourceArn: props.userPoolArn,
+        webAclArn: regionalWaf.webAclArn,
+      });
+
+      this.webAclArn = regionalWaf.webAclArn;
+    } else {
+      this.webAclArn = '';
+    }
+  }
+}

--- a/packages/cdk/lib/stacks/common/web-stack.ts
+++ b/packages/cdk/lib/stacks/common/web-stack.ts
@@ -1,0 +1,101 @@
+import { Stack, StackProps, CfnOutput, Fn } from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Web } from '../../construct';
+import { ICertificate } from 'aws-cdk-lib/aws-certificatemanager';
+import { ProcessedStackInput } from '../../stack-input';
+import { Flow } from 'generative-ai-use-cases';
+
+export interface WebStackProps extends StackProps {
+  readonly params: ProcessedStackInput;
+  readonly userPoolId: string;
+  readonly userPoolClientId: string;
+  readonly idPoolId: string;
+  readonly apiEndpointUrl: string;
+  readonly predictStreamFunctionArn: string;
+  readonly invokeFlowFunctionArn: string;
+  readonly optimizePromptFunctionArn: string;
+  readonly modelRegion: string;
+  readonly modelIds: any;
+  readonly imageGenerationModelIds: any;
+  readonly videoGenerationModelIds: any;
+  readonly endpointNames: any;
+  readonly agentNames: any;
+  readonly speechToSpeechNamespace: string;
+  readonly speechToSpeechEventApiEndpoint: string;
+  readonly mcpEndpoint?: string;
+  readonly webAclId?: string;
+  readonly cert?: ICertificate;
+}
+
+export class WebStack extends Stack {
+  public readonly distributionDomainName: string;
+
+  constructor(scope: Construct, id: string, props: WebStackProps) {
+    super(scope, id, props);
+
+    const params = props.params;
+
+    const selfSignUpEnabledForWeb =
+      params.samlAuthEnabled && !params.samlDefaultAuthEnabled
+        ? false
+        : params.selfSignUpEnabled;
+
+    const web = new Web(this, 'Web', {
+      userPoolId: props.userPoolId,
+      userPoolClientId: props.userPoolClientId,
+      idPoolId: props.idPoolId,
+      selfSignUpEnabled: selfSignUpEnabledForWeb,
+      samlAuthEnabled: params.samlAuthEnabled,
+      samlDefaultAuthEnabled: params.samlDefaultAuthEnabled,
+      samlCognitoDomainName: params.samlCognitoDomainName,
+      samlCognitoFederatedIdentityProviderName:
+        params.samlCognitoFederatedIdentityProviderName,
+      apiEndpointUrl: props.apiEndpointUrl,
+      predictStreamFunctionArn: props.predictStreamFunctionArn,
+      ragEnabled: params.ragEnabled,
+      ragKnowledgeBaseEnabled: params.ragKnowledgeBaseEnabled,
+      agentEnabled: params.agentEnabled || params.agents.length > 0,
+      flows: params.flows,
+      flowStreamFunctionArn: props.invokeFlowFunctionArn,
+      optimizePromptFunctionArn: props.optimizePromptFunctionArn,
+      webAclId: props.webAclId,
+      modelRegion: props.modelRegion,
+      modelIds: props.modelIds,
+      imageGenerationModelIds: props.imageGenerationModelIds,
+      videoGenerationModelIds: props.videoGenerationModelIds,
+      endpointNames: props.endpointNames,
+      agentNames: props.agentNames,
+      inlineAgents: params.inlineAgents,
+      useCaseBuilderEnabled: params.useCaseBuilderEnabled,
+      speechToSpeechNamespace: props.speechToSpeechNamespace,
+      speechToSpeechEventApiEndpoint: props.speechToSpeechEventApiEndpoint,
+      speechToSpeechModelIds: params.speechToSpeechModelIds,
+      mcpEnabled: params.mcpEnabled,
+      mcpEndpoint: props.mcpEndpoint ?? null,
+      hiddenUseCases: params.hiddenUseCases,
+      cert: props.cert,
+      hostName: params.hostName,
+      domainName: params.domainName,
+      hostedZoneId: params.hostedZoneId,
+    });
+
+    this.distributionDomainName = web.distribution.domainName;
+
+    if (params.hostName && params.domainName) {
+      new CfnOutput(this, 'WebUrl', {
+        value: `https://${params.hostName}.${params.domainName}`,
+        exportName: `${this.stackName}-WebUrl`,
+      });
+    } else {
+      new CfnOutput(this, 'WebUrl', {
+        value: `https://${web.distribution.domainName}`,
+        exportName: `${this.stackName}-WebUrl`,
+      });
+    }
+
+    new CfnOutput(this, 'DistributionDomainName', {
+      value: web.distribution.domainName,
+      exportName: `${this.stackName}-DistributionDomainName`,
+    });
+  }
+}

--- a/packages/cdk/test/generative-ai-use-cases.test.ts
+++ b/packages/cdk/test/generative-ai-use-cases.test.ts
@@ -70,7 +70,12 @@ describe('GenerativeAiUseCases', () => {
       ragKnowledgeBaseStack,
       agentStack,
       guardrail,
-      generativeAiUseCasesStack,
+      authStack,
+      databaseStack,
+      apiStack,
+      extensionStack,
+      ragStack,
+      webStack,
       dashboardStack,
     } = createStacks(app, params);
 
@@ -80,7 +85,11 @@ describe('GenerativeAiUseCases', () => {
       !ragKnowledgeBaseStack ||
       !agentStack ||
       !guardrail ||
-      !generativeAiUseCasesStack ||
+      !authStack ||
+      !databaseStack ||
+      !apiStack ||
+      !extensionStack ||
+      !webStack ||
       !dashboardStack
     ) {
       throw new Error('Not all stacks are created');
@@ -89,9 +98,11 @@ describe('GenerativeAiUseCases', () => {
     const ragKnowledgeBaseTemplate = Template.fromStack(ragKnowledgeBaseStack);
     const agentTemplate = Template.fromStack(agentStack);
     const guardrailTemplate = Template.fromStack(guardrail);
-    const generativeAiUseCasesTemplate = Template.fromStack(
-      generativeAiUseCasesStack
-    );
+    const authTemplate = Template.fromStack(authStack);
+    const databaseTemplate = Template.fromStack(databaseStack);
+    const apiTemplate = Template.fromStack(apiStack);
+    const extensionTemplate = Template.fromStack(extensionStack);
+    const webTemplate = Template.fromStack(webStack);
     const dashboardTemplate = Template.fromStack(dashboardStack);
 
     // Assert
@@ -99,7 +110,11 @@ describe('GenerativeAiUseCases', () => {
     expect(ragKnowledgeBaseTemplate.toJSON()).toMatchSnapshot();
     expect(agentTemplate.toJSON()).toMatchSnapshot();
     expect(guardrailTemplate.toJSON()).toMatchSnapshot();
-    expect(generativeAiUseCasesTemplate.toJSON()).toMatchSnapshot();
+    expect(authTemplate.toJSON()).toMatchSnapshot();
+    expect(databaseTemplate.toJSON()).toMatchSnapshot();
+    expect(apiTemplate.toJSON()).toMatchSnapshot();
+    expect(extensionTemplate.toJSON()).toMatchSnapshot();
+    expect(webTemplate.toJSON()).toMatchSnapshot();
     expect(dashboardTemplate.toJSON()).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
## 概要
CloudFormationのリソース数制限（500リソース）に対応するため、GenerativeAiUseCasesStackを複数の論理的なスタックに分割しました。

## 変更内容

### 新しいスタック構成
1. **AuthStack** - 認証関連
   - Cognito UserPool
   - UserPoolClient
   - IdentityPool

2. **DatabaseStack** - データベース関連
   - DynamoDBテーブル
   - TenantManager

3. **ApiStack** - API関連
   - API Gateway
   - Lambda関数群
   - LiteLLMプロキシ

4. **ExtensionStack** - 拡張機能
   - SpeechToSpeech
   - MCP API
   - UseCaseBuilder
   - Transcribe

5. **RagStack** - RAG機能（オプション）
   - Kendra
   - Knowledge Base関連リソース

6. **WebStack** - フロントエンド
   - CloudFront
   - S3バケット

7. **WafAssociationStack** - WAF関連（オプション）
   - Regional WAF
   - API Gateway/UserPoolへの関連付け

## メリット
- 各スタックのリソース数が大幅に削減され、制限に達するリスクが軽減
- 論理的なグループ化により、管理とメンテナンスが容易に
- スタック間の依存関係はクロススタック参照で適切に管理
- 必要に応じて個別のスタックのみをデプロイ可能

## テスト
- [ ] CDKビルドが成功することを確認
- [ ] 各スタックのデプロイが可能であることを確認
- [ ] 既存機能に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.ai/code)