### PR TITLE
:recycle: GenerativeAiUseCasesStackのリソースを減らした

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "cdk:deploy": "npm -w packages/cdk run cdk deploy -- --all",
     "cdk:deploy:quick": "npm -w packages/cdk run cdk deploy -- --all --asset-parallelism --asset-prebuild=false --concurrency 3 --method=direct --require-approval never --force",
     "cdk:deploy:quick:hotswap": "npm -w packages/cdk run cdk deploy -- --all --asset-parallelism --asset-prebuild=false --concurrency 3 --method=direct --require-approval never --force --hotswap",
+    "cdk:deploy:synth": "npm -w packages/cdk run cdk synth -- --all",
     "cdk:tenant:deploy": "npm -w packages/cdk run cdk -- --app 'npx ts-node --prefer-ts-exts bin/generative-ai-use-cases-tenant.ts' deploy --all",
     "cdk:tenant:list": "npm -w packages/cdk run cdk -- --app 'npx ts-node --prefer-ts-exts bin/generative-ai-use-cases-tenant.ts' list",
     "cdk:tenant:synth": "npm -w packages/cdk run cdk -- --app 'npx ts-node --prefer-ts-exts bin/generative-ai-use-cases-tenant.ts' synth",

--- a/packages/cdk/lib/create-stacks.ts
+++ b/packages/cdk/lib/create-stacks.ts
@@ -8,6 +8,8 @@ import { RagKnowledgeBaseStack } from './stacks/common/rag-knowledge-base-stack'
 import { GuardrailStack } from './stacks/common/guardrail-stack';
 import { ProcessedStackInput } from './stack-input';
 import { VideoTmpBucketStack } from './stacks/common/video-tmp-bucket-stack';
+import TranscribeStack from './stacks/common/transcribe-stack';
+import * as process from 'process';
 
 class DeletionPolicySetter implements cdk.IAspect {
   constructor(private readonly policy: cdk.RemovalPolicy) {}

--- a/packages/cdk/lib/create-stacks.ts
+++ b/packages/cdk/lib/create-stacks.ts
@@ -8,7 +8,6 @@ import { RagKnowledgeBaseStack } from './stacks/common/rag-knowledge-base-stack'
 import { GuardrailStack } from './stacks/common/guardrail-stack';
 import { ProcessedStackInput } from './stack-input';
 import { VideoTmpBucketStack } from './stacks/common/video-tmp-bucket-stack';
-import TranscribeStack from './stacks/common/transcribe-stack';
 import * as process from 'process';
 
 class DeletionPolicySetter implements cdk.IAspect {

--- a/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
@@ -7,7 +7,6 @@ import {
   Rag,
   RagKnowledgeBase,
   CommonWebAcl,
-  SpeechToSpeech,
   McpApi,
   LitellmProxyServer,
   TenantManager,
@@ -25,6 +24,7 @@ import { IdentityPool } from 'aws-cdk-lib/aws-cognito-identitypool';
 import { RestApi } from 'aws-cdk-lib/aws-apigateway';
 import TranscribeStack from './transcribe-stack';
 import WebStack from './web-stack';
+import SpeechToSpeechStack from './speech-to-speech-stack';
 
 export interface GenerativeAiUseCasesStackProps extends StackProps {
   readonly params: ProcessedStackInput;
@@ -152,13 +152,16 @@ export class GenerativeAiUseCasesStack extends Stack {
     }
 
     // SpeechToSpeech (for bidirectional communication)
-    const speechToSpeech = new SpeechToSpeech(this, 'SpeechToSpeech', {
-      envSuffix: params.env,
-      api: api.restApi,
-      userPool: auth.userPool,
-      speechToSpeechModelIds: params.speechToSpeechModelIds,
-      crossAccountBedrockRoleArn: params.crossAccountBedrockRoleArn,
-    });
+    const speechToSpeechStack = new SpeechToSpeechStack(
+      this,
+      'SpeechToSpeech',
+      {
+        params: params,
+        api: api,
+        auth: auth,
+      }
+    );
+    const speechToSpeech = speechToSpeechStack.speechToSpeech;
 
     // MCP
     let mcpEndpoint: string | null = null;

--- a/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
@@ -7,7 +7,6 @@ import {
   Rag,
   RagKnowledgeBase,
   CommonWebAcl,
-  McpApi,
   LitellmProxyServer,
   TenantManager,
 } from '../../construct';
@@ -25,6 +24,7 @@ import { RestApi } from 'aws-cdk-lib/aws-apigateway';
 import TranscribeStack from './transcribe-stack';
 import WebStack from './web-stack';
 import SpeechToSpeechStack from './speech-to-speech-stack';
+import McpApiStack from './mcp-api-stack';
 
 export interface GenerativeAiUseCasesStackProps extends StackProps {
   readonly params: ProcessedStackInput;
@@ -166,12 +166,13 @@ export class GenerativeAiUseCasesStack extends Stack {
     // MCP
     let mcpEndpoint: string | null = null;
     if (params.mcpEnabled) {
-      const mcpApi = new McpApi(this, 'McpApi', {
-        idPool: auth.idPool,
+      const mcpApiStack = new McpApiStack(this, 'McpApi', {
+        auth: auth,
         isSageMakerStudio: props.isSageMakerStudio,
-        fileBucket: api.fileBucket,
+        api: api,
       });
-      mcpEndpoint = mcpApi.endpoint;
+
+      mcpEndpoint = mcpApiStack.mcpApi.endpoint;
     }
 
     new WebStack(this, 'Web', {

--- a/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
@@ -3,7 +3,6 @@ import { Construct } from 'constructs';
 import {
   Auth,
   Api,
-  Web,
   Database,
   Rag,
   RagKnowledgeBase,
@@ -25,6 +24,7 @@ import { Buffer } from 'buffer';
 import { IdentityPool } from 'aws-cdk-lib/aws-cognito-identitypool';
 import { RestApi } from 'aws-cdk-lib/aws-apigateway';
 import TranscribeStack from './transcribe-stack';
+import WebStack from './web-stack';
 
 export interface GenerativeAiUseCasesStackProps extends StackProps {
   readonly params: ProcessedStackInput;
@@ -171,52 +171,14 @@ export class GenerativeAiUseCasesStack extends Stack {
       mcpEndpoint = mcpApi.endpoint;
     }
 
-    // Web Frontend
-    const selfSignUpEnabledForWeb =
-      params.samlAuthEnabled && !params.samlDefaultAuthEnabled
-        ? false
-        : params.selfSignUpEnabled;
-
-    const web = new Web(this, 'Api', {
-      // Auth
-      userPoolId: auth.userPool.userPoolId,
-      userPoolClientId: auth.client.userPoolClientId,
-      idPoolId: auth.idPool.identityPoolId,
-      selfSignUpEnabled: selfSignUpEnabledForWeb,
-      samlAuthEnabled: params.samlAuthEnabled,
-      samlDefaultAuthEnabled: params.samlDefaultAuthEnabled,
-      samlCognitoDomainName: params.samlCognitoDomainName,
-      samlCognitoFederatedIdentityProviderName:
-        params.samlCognitoFederatedIdentityProviderName,
-      // Backend
-      apiEndpointUrl: api.restApi.url,
-      predictStreamFunctionArn: api.predictStreamFunction.functionArn,
-      ragEnabled: params.ragEnabled,
-      ragKnowledgeBaseEnabled: params.ragKnowledgeBaseEnabled,
-      agentEnabled: params.agentEnabled || params.agents.length > 0,
-      flows: params.flows,
-      flowStreamFunctionArn: api.invokeFlowFunction.functionArn,
-      optimizePromptFunctionArn: api.optimizePromptFunction.functionArn,
+    new WebStack(this, 'Web', {
+      params: params,
+      auth: auth,
+      api: apiStack.api,
+      speechToSpeech: speechToSpeech,
       webAclId: props.webAclId,
-      modelRegion: api.modelRegion,
-      modelIds: api.modelIds,
-      imageGenerationModelIds: api.imageGenerationModelIds,
-      videoGenerationModelIds: api.videoGenerationModelIds,
-      endpointNames: api.endpointNames,
-      agentNames: api.agentNames,
-      inlineAgents: params.inlineAgents,
-      useCaseBuilderEnabled: params.useCaseBuilderEnabled,
-      speechToSpeechNamespace: speechToSpeech.namespace,
-      speechToSpeechEventApiEndpoint: speechToSpeech.eventApiEndpoint,
-      speechToSpeechModelIds: params.speechToSpeechModelIds,
-      mcpEnabled: params.mcpEnabled,
-      mcpEndpoint,
-      // Frontend
-      // Custom Domain
+      mcpEndpoint: mcpEndpoint,
       cert: props.cert,
-      hostName: params.hostName,
-      domainName: params.domainName,
-      hostedZoneId: params.hostedZoneId,
     });
 
     // RAG
@@ -309,16 +271,6 @@ export class GenerativeAiUseCasesStack extends Stack {
     new CfnOutput(this, 'Region', {
       value: this.region,
     });
-
-    if (params.hostName && params.domainName) {
-      new CfnOutput(this, 'WebUrl', {
-        value: `https://${params.hostName}.${params.domainName}`,
-      });
-    } else {
-      new CfnOutput(this, 'WebUrl', {
-        value: `https://${web.distribution.domainName}`,
-      });
-    }
 
     new CfnOutput(this, 'ApiEndpoint', {
       value: api.restApi.url,

--- a/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
@@ -7,7 +7,6 @@ import {
   Database,
   Rag,
   RagKnowledgeBase,
-  Transcribe,
   CommonWebAcl,
   SpeechToSpeech,
   McpApi,
@@ -21,6 +20,11 @@ import { Agent } from 'generative-ai-use-cases';
 import { UseCaseBuilderStack } from '../nested/use-case-builder-stack';
 import { ProcessedStackInput } from '../../stack-input';
 import { allowS3AccessWithSourceIpCondition } from '../../utils/s3-access-policy';
+import { env } from 'process';
+import { Buffer } from 'buffer';
+import { IdentityPool } from 'aws-cdk-lib/aws-cognito-identitypool';
+import { RestApi } from 'aws-cdk-lib/aws-apigateway';
+import TranscribeStack from './transcribe-stack';
 
 export interface GenerativeAiUseCasesStackProps extends StackProps {
   readonly params: ProcessedStackInput;
@@ -45,6 +49,9 @@ export interface GenerativeAiUseCasesStackProps extends StackProps {
 export class GenerativeAiUseCasesStack extends Stack {
   public readonly userPool: cognito.UserPool;
   public readonly userPoolClient: cognito.UserPoolClient;
+  public readonly idPool: IdentityPool;
+  public readonly restApi: RestApi;
+  public readonly tenantManager: TenantManager;
 
   constructor(
     scope: Construct,
@@ -52,7 +59,7 @@ export class GenerativeAiUseCasesStack extends Stack {
     props: GenerativeAiUseCasesStackProps
   ) {
     super(scope, id, props);
-    process.env.overrideWarningsEnabled = 'false';
+    env.overrideWarningsEnabled = 'false';
 
     const params = props.params;
 
@@ -286,16 +293,21 @@ export class GenerativeAiUseCasesStack extends Stack {
       });
     }
 
-    // Transcribe
-    new Transcribe(this, 'Transcribe', {
-      userPool: auth.userPool,
-      idPool: auth.idPool,
-      api: api.restApi,
-      allowedIpV4AddressRanges: params.allowedIpV4AddressRanges,
-      allowedIpV6AddressRanges: params.allowedIpV6AddressRanges,
-      tenantManager: tenantManager,
-      environment: params.env,
-    });
+    const transcribeStack = new TranscribeStack(
+      this,
+      `TranscribeStack${params.env}`,
+      {
+        env: {
+          account: params.account,
+          region: params.region,
+        },
+        params: params,
+        userPool: auth.userPool,
+        idPool: auth.idPool,
+        restApi: api.restApi,
+        tenantManager: tenantManager,
+      }
+    );
 
     // Cfn Outputs
     new CfnOutput(this, 'Region', {

--- a/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
@@ -293,21 +293,17 @@ export class GenerativeAiUseCasesStack extends Stack {
       });
     }
 
-    const transcribeStack = new TranscribeStack(
-      this,
-      `TranscribeStack${params.env}`,
-      {
-        env: {
-          account: params.account,
-          region: params.region,
-        },
-        params: params,
-        userPool: auth.userPool,
-        idPool: auth.idPool,
-        restApi: api.restApi,
-        tenantManager: tenantManager,
-      }
-    );
+    new TranscribeStack(this, `TranscribeStack${params.env}`, {
+      env: {
+        account: params.account,
+        region: params.region,
+      },
+      params: params,
+      userPool: auth.userPool,
+      idPool: auth.idPool,
+      restApi: api.restApi,
+      tenantManager: tenantManager,
+    });
 
     // Cfn Outputs
     new CfnOutput(this, 'Region', {

--- a/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
@@ -174,7 +174,7 @@ export class GenerativeAiUseCasesStack extends Stack {
     new WebStack(this, 'Web', {
       params: params,
       auth: auth,
-      api: apiStack.api,
+      api: api,
       speechToSpeech: speechToSpeech,
       webAclId: props.webAclId,
       mcpEndpoint: mcpEndpoint,

--- a/packages/cdk/lib/stacks/common/mcp-api-stack.ts
+++ b/packages/cdk/lib/stacks/common/mcp-api-stack.ts
@@ -1,0 +1,29 @@
+import { NestedStack, StackProps } from 'aws-cdk-lib';
+import { Api, Auth, McpApi } from '../../construct';
+import { Construct } from 'constructs';
+
+interface McpApiStackProps extends StackProps {
+  auth: Auth;
+  isSageMakerStudio: boolean;
+  api: Api;
+}
+
+class McpApiStack extends NestedStack {
+  readonly mcpApi: McpApi;
+
+  constructor(scope: Construct, id: string, props: McpApiStackProps) {
+    super(scope, id, props);
+
+    const { auth, api } = props;
+
+    const mcpApi = new McpApi(this, 'McpApi', {
+      idPool: auth.idPool,
+      isSageMakerStudio: props.isSageMakerStudio,
+      fileBucket: api.fileBucket,
+    });
+
+    this.mcpApi = mcpApi;
+  }
+}
+
+export default McpApiStack;

--- a/packages/cdk/lib/stacks/common/speech-to-speech-stack.ts
+++ b/packages/cdk/lib/stacks/common/speech-to-speech-stack.ts
@@ -1,0 +1,32 @@
+import { NestedStack, StackProps } from 'aws-cdk-lib';
+import { ProcessedStackInput } from '../../stack-input';
+import { Api, Auth, SpeechToSpeech } from '../../construct';
+import { Construct } from 'constructs';
+
+interface SpeechToSpeechStackProps extends StackProps {
+  params: ProcessedStackInput;
+  api: Api;
+  auth: Auth;
+}
+
+class SpeechToSpeechStack extends NestedStack {
+  readonly speechToSpeech: SpeechToSpeech;
+
+  constructor(scope: Construct, id: string, props: SpeechToSpeechStackProps) {
+    super(scope, id, props);
+
+    const { params, api, auth } = props;
+
+    const speechToSpeech = new SpeechToSpeech(this, 'SpeechToSpeech', {
+      envSuffix: params.env,
+      api: api.restApi,
+      userPool: auth.userPool,
+      speechToSpeechModelIds: params.speechToSpeechModelIds,
+      crossAccountBedrockRoleArn: params.crossAccountBedrockRoleArn,
+    });
+
+    this.speechToSpeech = speechToSpeech;
+  }
+}
+
+export default SpeechToSpeechStack;

--- a/packages/cdk/lib/stacks/common/transcribe-stack.ts
+++ b/packages/cdk/lib/stacks/common/transcribe-stack.ts
@@ -1,0 +1,40 @@
+import { NestedStack, StackProps } from 'aws-cdk-lib';
+import { ProcessedStackInput } from '../../stack-input';
+import { Construct } from 'constructs';
+import { TenantManager, Transcribe } from '../../construct';
+import { UserPool } from 'aws-cdk-lib/aws-cognito';
+import { RestApi } from 'aws-cdk-lib/aws-apigateway';
+import { IdentityPool } from 'aws-cdk-lib/aws-cognito-identitypool';
+
+interface TranscribeStackProps extends StackProps {
+  readonly params: ProcessedStackInput;
+  readonly userPool: UserPool;
+  readonly idPool: IdentityPool;
+  readonly restApi: RestApi;
+  readonly tenantManager: TenantManager;
+}
+
+class TranscribeStack extends NestedStack {
+  readonly transcribe: Transcribe;
+
+  constructor(scope: Construct, id: string, props: TranscribeStackProps) {
+    super(scope, id, props);
+
+    const { params, userPool, idPool, restApi, tenantManager } = props;
+
+    // Transcribe
+    const transcribe = new Transcribe(this, 'Transcribe', {
+      userPool: userPool,
+      idPool: idPool,
+      api: restApi,
+      allowedIpV4AddressRanges: params.allowedIpV4AddressRanges,
+      allowedIpV6AddressRanges: params.allowedIpV6AddressRanges,
+      tenantManager: tenantManager,
+      environment: params.env,
+    });
+
+    this.transcribe = transcribe;
+  }
+}
+
+export default TranscribeStack;

--- a/packages/cdk/lib/stacks/common/web-stack.ts
+++ b/packages/cdk/lib/stacks/common/web-stack.ts
@@ -1,0 +1,84 @@
+import { CfnOutput, NestedStack, StackProps } from 'aws-cdk-lib';
+import { Api, Auth, SpeechToSpeech, Web } from '../../construct';
+import { ProcessedStackInput } from '../../stack-input';
+import { ICertificate } from 'aws-cdk-lib/aws-certificatemanager';
+import { Construct } from 'constructs';
+
+interface WebStackProps extends StackProps {
+  readonly params: ProcessedStackInput;
+  readonly auth: Auth;
+  readonly api: Api;
+  readonly speechToSpeech: SpeechToSpeech;
+  readonly webAclId?: string;
+  readonly mcpEndpoint: string | null;
+  readonly cert?: ICertificate;
+}
+
+class WebStack extends NestedStack {
+  constructor(scope: Construct, id: string, props: WebStackProps) {
+    super(scope, id, props);
+
+    const { params, auth, api, speechToSpeech, webAclId, mcpEndpoint, cert } =
+      props;
+
+    // Web Frontend
+    const selfSignUpEnabledForWeb =
+      params.samlAuthEnabled && !params.samlDefaultAuthEnabled
+        ? false
+        : params.selfSignUpEnabled;
+
+    const web = new Web(this, 'Api', {
+      // Auth
+      userPoolId: auth.userPool.userPoolId,
+      userPoolClientId: auth.client.userPoolClientId,
+      idPoolId: auth.idPool.identityPoolId,
+      selfSignUpEnabled: selfSignUpEnabledForWeb,
+      samlAuthEnabled: params.samlAuthEnabled,
+      samlDefaultAuthEnabled: params.samlDefaultAuthEnabled,
+      samlCognitoDomainName: params.samlCognitoDomainName,
+      samlCognitoFederatedIdentityProviderName:
+        params.samlCognitoFederatedIdentityProviderName,
+      // Backend
+      apiEndpointUrl: api.restApi.url,
+      predictStreamFunctionArn: api.predictStreamFunction.functionArn,
+      ragEnabled: params.ragEnabled,
+      ragKnowledgeBaseEnabled: params.ragKnowledgeBaseEnabled,
+      agentEnabled: params.agentEnabled || params.agents.length > 0,
+      flows: params.flows,
+      flowStreamFunctionArn: api.invokeFlowFunction.functionArn,
+      optimizePromptFunctionArn: api.optimizePromptFunction.functionArn,
+      webAclId: webAclId,
+      modelRegion: api.modelRegion,
+      modelIds: api.modelIds,
+      imageGenerationModelIds: api.imageGenerationModelIds,
+      videoGenerationModelIds: api.videoGenerationModelIds,
+      endpointNames: api.endpointNames,
+      agentNames: api.agentNames,
+      inlineAgents: params.inlineAgents,
+      useCaseBuilderEnabled: params.useCaseBuilderEnabled,
+      speechToSpeechNamespace: speechToSpeech.namespace,
+      speechToSpeechEventApiEndpoint: speechToSpeech.eventApiEndpoint,
+      speechToSpeechModelIds: params.speechToSpeechModelIds,
+      mcpEnabled: params.mcpEnabled,
+      mcpEndpoint,
+      // Frontend
+      // Custom Domain
+      cert: cert,
+      hostName: params.hostName,
+      domainName: params.domainName,
+      hostedZoneId: params.hostedZoneId,
+    });
+
+    if (params.hostName && params.domainName) {
+      new CfnOutput(this, 'WebUrl', {
+        value: `https://${params.hostName}.${params.domainName}`,
+      });
+    } else {
+      new CfnOutput(this, 'WebUrl', {
+        value: `https://${web.distribution.domainName}`,
+      });
+    }
+  }
+}
+
+export default WebStack;


### PR DESCRIPTION
## 変更の概要

<!-- どのような変更を行ったかを書く -->
- 下記のリソースの定義を`NestedStack`として分離することで、リソース数に少しだけ余裕をもたせた
  - Transcribe
  - Web
  - SpeechToSpeech
  - McpApi
- 結果、GenerativeAiUseCasesStackのリソース数を474個から421個まで減らした

## 申し送り事項

<!-- レビュワーに伝えておきたい事柄等を書く（Draftの理由など） -->

## Checklist（レビュワー用）

- [ ] `npm run lint`でエラーが出ない
- [ ] TypeScriptのビルドで型エラーが出ない
- [ ] 手元でフォーマットした際に差分が出ない
