### PR TITLE
🐛 `npm run web:devw`時にセットアップされていない環境変数があったので修正

### DIFF
--- a/setup-env.sh
+++ b/setup-env.sh
@@ -40,6 +40,7 @@ export VITE_APP_IMAGE_MODEL_IDS=$(extract_value "$stack_output" ImageGenerateMod
 export VITE_APP_VIDEO_MODEL_IDS=$(extract_value "$stack_output" VideoGenerateModelIds)
 export VITE_APP_ENDPOINT_NAMES=$(extract_value "$stack_output" EndpointNames)
 export VITE_APP_SAMLAUTH_ENABLED=$(extract_value "$stack_output" SamlAuthEnabled)
+export VITE_APP_SAML_DEFAULT_AUTH_ENABLED=$(extract_value "$stack_output" SamlDefaultAuthEnabled)
 export VITE_APP_SAML_COGNITO_DOMAIN_NAME=$(extract_value "$stack_output" SamlCognitoDomainName)
 export VITE_APP_SAML_COGNITO_FEDERATED_IDENTITY_PROVIDER_NAME=$(extract_value "$stack_output" SamlCognitoFederatedIdentityProviderName)
 export VITE_APP_AGENT_NAMES=$(extract_value "$stack_output" AgentNames | base64 -d)


### PR DESCRIPTION
## 変更の概要

<!-- どのような変更を行ったかを書く -->
- `npm run web:devw`を行うときに実行される`setup-env.sh`で、環境変数`VITE_APP_SAML_DEFAULT_AUTH_ENABLED`が設定されていないため、ローカル環境でログインできない事象が発生していたので修正しました。

## 申し送り事項

<!-- レビュワーに伝えておきたい事柄等を書く（Draftの理由など） -->

## Checklist（レビュワー用）

- [ ] `npm run lint`でエラーが出ない
- [ ] TypeScriptのビルドで型エラーが出ない
- [ ] 手元でフォーマットした際に差分が出ない
