### PR TITLE
:bug: グローバルサイドバーのアクティブ判定のロジックを修正

### DIFF
--- a/packages/web/src/components/SidebarItem.tsx
+++ b/packages/web/src/components/SidebarItem.tsx
@@ -10,10 +10,17 @@ export type SidebarItemProps = BaseProps & {
 const SidebarItem: React.FC<SidebarItemProps> = (props) => {
   const location = useLocation();
 
+  // Check if the current path matches the sidebar item
+  // For root path (/), use exact match. For other paths, check if current path starts with it
+  const isActive =
+    props.to === '/'
+      ? location.pathname === props.to
+      : location.pathname.startsWith(props.to);
+
   return (
     <Link
       className={`hover:bg-aws-sky flex flex-col items-center justify-center rounded p-2 transition-colors ${
-        location.pathname === props.to && 'bg-aws-sky'
+        isActive && 'bg-aws-sky'
       } ${props.className}`}
       to={props.to}
       title={props.label}>


### PR DESCRIPTION
## 変更の概要

<!-- どのような変更を行ったかを書く -->

### Before

`{WebサイトのURL}/chat`まではチャットであることがわかるが、`{WebサイトのURL}/chat/{chatId}`だとグローバルサイドバーが沈黙する

<img width="1534" height="1209" alt="image" src="https://github.com/user-attachments/assets/fe3e6236-b643-46d7-8cd1-59f89810dfdf" />

### After

`{WebサイトのURL}/chat/{chatId}`でもチャット機能であることがわかる

<img width="1534" height="1209" alt="image" src="https://github.com/user-attachments/assets/88cf1437-d8f6-4777-8f2e-69c6cce6218a" />

## 申し送り事項

<!-- レビュワーに伝えておきたい事柄等を書く（Draftの理由など） -->

## Checklist（レビュワー用）

- [ ] `npm run lint`でエラーが出ない
- [ ] TypeScript のビルドで型エラーが出ない
- [ ] 手元でフォーマットした際に差分が出ない
