### PR TITLE
:bug: fix(auth): SAML/OIDCログインユーザーのメールアドレス表示を修正

### DIFF
--- a/packages/web/src/hooks/useUserInfo.ts
+++ b/packages/web/src/hooks/useUserInfo.ts
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { getCurrentUser } from 'aws-amplify/auth';
+import { getCurrentUser, fetchAuthSession } from 'aws-amplify/auth';
 import useHttp from './useHttp';
 
 export interface UserInfo {
@@ -25,12 +25,26 @@ const useUserInfo = () => {
         // Get current user from Amplify
         const user = await getCurrentUser();
 
+        // Get email from ID token claims (works for both SAML/OIDC and direct Cognito users)
+        // This avoids the "required scopes" error with fetchUserAttributes for federated users
+        let emailFromToken: string | undefined;
+        try {
+          const session = await fetchAuthSession();
+          const idToken = session.tokens?.idToken;
+          emailFromToken = idToken?.payload?.email as string | undefined;
+        } catch (tokenError) {
+          console.warn('Failed to fetch auth session, falling back to loginId:', tokenError);
+        }
+
+        // Determine email with fallback chain: ID token email → loginId → username
+        const email = emailFromToken || user.signInDetails?.loginId || user.username;
+
         // Get additional info from API if needed
         try {
           const response = await api.get('/admin/status');
           setUserInfo({
             username: user.username,
-            email: user.signInDetails?.loginId || user.username,
+            email,
             tenantId: response.data.tenantId,
             tenantName: response.data.tenantName || response.data.tenantId,
           });
@@ -38,7 +52,7 @@ const useUserInfo = () => {
           // If admin status fails, just use basic user info
           setUserInfo({
             username: user.username,
-            email: user.signInDetails?.loginId || user.username,
+            email,
           });
         }
       } catch (err) {


### PR DESCRIPTION
## 概要
SAML/OIDCで認証されたユーザーがCognitoのユーザー名（連携ID）ではなく、メールアドレスが表示されるように修正しました。

## 問題
- SAML/OIDCログインユーザー: Cognitoの連携ユーザー名が表示される（例: `GoogleWorkspace_xxx`）❌
- 直接Cognitoログインユーザー: メールアドレスが正しく表示される ✅

## 原因
`getCurrentUser()` はSAML/OIDCユーザーに対して連携IDを返すが、メールアドレス属性は返さない。`fetchUserAttributes()` を使用しようとしたが、連携ユーザーには必要なスコープがアクセストークンに含まれていないためエラーが発生。

## 解決策
IDトークンのクレームからメールアドレスを取得する方法に変更:
- `fetchAuthSession()` を使用してIDトークンを取得
- `idToken.payload.email` からメールアドレスを抽出
- フォールバックチェーン: IDトークンのemail → loginId → username

## 変更内容
- **ファイル**: `packages/web/src/hooks/useUserInfo.ts`
- `fetchAuthSession` をインポート
- IDトークンクレームからメールアドレスを取得するロジックを実装
- エラーハンドリングとフォールバックロジックを追加

## テスト
- [x] SAML/OIDCログインでメールアドレスが表示されることを確認
- [x] 直接Cognitoログインでメールアドレスが表示されることを確認（後方互換性）
- [x] TypeScriptコンパイル成功

## 備考
この修正は、SAML、OIDC、直接Cognitoログインのすべての認証タイプに対応しており、追加のOAuthスコープを必要としません。

Generated with Claude Code