### PR TITLE
:lipstick: チャットのロード中にロード画面を表示するようにした

### DIFF
--- a/packages/web/src/pages/ChatPage.tsx
+++ b/packages/web/src/pages/ChatPage.tsx
@@ -24,6 +24,7 @@ import {
 import ModelParameters from '../components/ModelParameters';
 import { AcceptedDotExtensions } from '../utils/MediaUtils';
 import { useTranslation } from 'react-i18next';
+import LoadingWave from '../components/LoadingWave';
 
 const fileLimit: FileLimit = {
   accept: AcceptedDotExtensions,
@@ -78,6 +79,7 @@ const ChatPage: React.FC = () => {
     updateSystemContext,
     retryGeneration,
     forceToStop,
+    loadingMessages,
   } = useChat(pathname, chatId);
   const { createShareId, findShareId, deleteShareId } = useChatApi();
   const { scrollableContainer, setFollowing } = useFollow();
@@ -318,7 +320,11 @@ const ChatPage: React.FC = () => {
         </h1>
 
         {/* Wrapper for messages and input to enable vertical centering when empty */}
-        {isEmpty ? (
+        {loadingMessages ? (
+          <div className="flex-1 flex flex-col justify-center items-center">
+            <LoadingWave />
+          </div>
+        ) : isEmpty ? (
           <div className="flex-1 flex flex-col justify-center">
             <InputChatContent
               className="print:hidden mx-auto"


### PR DESCRIPTION
## 変更の概要

<!-- どのような変更を行ったかを書く -->

- チャット履歴からチャットを選択して開いたときに、ローディング画面が表示されるようにしました

### Before

履歴から選択するとチャット作成と同じ画面が表示され、少し待つとチャットが表示される

<img width="1534" height="1209" alt="image" src="https://github.com/user-attachments/assets/f83a2418-c1b7-4f37-b5bb-c59fcd033017" />

### After

履歴から選択するとロード中であることがわかりやすい

<img width="1534" height="1209" alt="image" src="https://github.com/user-attachments/assets/5b9340e2-31bf-4223-be47-1cbf11d0afb8" />

## 申し送り事項

<!-- レビュワーに伝えておきたい事柄等を書く（Draftの理由など） -->

## Checklist（レビュワー用）

- [ ] `npm run lint`でエラーが出ない
- [ ] TypeScript のビルドで型エラーが出ない
- [ ] 手元でフォーマットした際に差分が出ない
