### PR TITLE
:bug: :lipstick: 幅を狭くしたときにチャットの吹き出しが隠れて見えない問題を修正

### DIFF
--- a/packages/web/src/components/ChatMessage.tsx
+++ b/packages/web/src/components/ChatMessage.tsx
@@ -226,7 +226,7 @@ const ChatMessage: React.FC<Props> = (props) => {
 
               {/* Message bubble */}
               <div
-                className={`rounded-2xl px-4 py-3 ${
+                className={`rounded-2xl px-4 py-3 overflow-x-auto ${
                   chatContent?.role === 'user'
                     ? 'bg-aws-sky text-white'
                     : 'bg-gray-100'

--- a/packages/web/src/pages/ChatPage.tsx
+++ b/packages/web/src/pages/ChatPage.tsx
@@ -281,7 +281,7 @@ const ChatPage: React.FC = () => {
       {/* Main Content */}
       <div
         onDragOver={fileUpload ? handleDragOver : undefined}
-        className="relative h-screen flex flex-col">
+        className="relative h-screen flex flex-col px-4 md:px-6 lg:px-8">
         {isOver && fileUpload && (
           <div
             onDragLeave={handleDragLeave}


### PR DESCRIPTION
## 変更の概要

<!-- どのような変更を行ったかを書く -->

- 幅を極端に狭くしたときに吹き出しがサイドバーの下に潜らないようにした
- 幅が極端に狭くなったときにコードブロックにスクロールバーを表示するようにした

## 申し送り事項

<!-- レビュワーに伝えておきたい事柄等を書く（Draftの理由など） -->

## Checklist（レビュワー用）

- [ ] `npm run lint`でエラーが出ない
- [ ] TypeScript のビルドで型エラーが出ない
- [ ] 手元でフォーマットした際に差分が出ない
