### PR TITLE
:zap: perf(assistant): アシスタントCRUD操作の即時リダイレクト実装

### DIFF
--- a/packages/cdk/lib/construct/speech-to-speech.ts
+++ b/packages/cdk/lib/construct/speech-to-speech.ts
@@ -79,7 +79,7 @@ export class SpeechToSpeech extends Construct {
         CROSS_ACCOUNT_BEDROCK_ROLE_ARN: props.crossAccountBedrockRoleArn ?? '',
       },
       bundling: {
-        nodeModules: ['@aws-sdk/client-bedrock-runtime'],
+        nodeModules: ['@aws-sdk/client-bedrock-runtime', 'aws-amplify', 'ws'],
       },
       memorySize: 512,
     });

--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -99,6 +99,7 @@ assistant:
   delete: Delete
   deleteConfirmation: Are you sure you want to delete "{{assistantName}}"? This action cannot be undone.
   deleteError: Failed to delete assistant
+  deleteInitiated: Assistant deletion started. Cleaning up resources...
   deleteSuccess: Assistant deleted successfully
   deleteTitle: Delete Assistant
   deleting: Deleting...
@@ -121,6 +122,8 @@ assistant:
     saveBeforeUpload: Please save the assistant before uploading files
     saveFailed: Failed to save
     saving: Saving...
+    createInitiated: Assistant creation started. Syncing knowledge base in background...
+    updateInitiated: Assistant updated. Re-syncing knowledge base in background...
     sourceUrls: Source URLs
     title: Name
     uploadFiles: Upload Files

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -99,6 +99,7 @@ assistant:
   delete: 削除
   deleteConfirmation: '"{{assistantName}}" を削除してもよろしいですか？この操作は取り消せません。'
   deleteError: アシスタントの削除に失敗しました
+  deleteInitiated: アシスタントの削除を開始しました。リソースをクリーンアップ中...
   deleteSuccess: アシスタントを削除しました
   deleteTitle: アシスタントを削除
   deleting: 削除中...
@@ -121,6 +122,8 @@ assistant:
     saveBeforeUpload: ファイルをアップロードする前にアシスタントを保存してください
     saveFailed: 保存に失敗しました
     saving: 保存中...
+    createInitiated: アシスタントの作成を開始しました。バックグラウンドでナレッジベースを同期中...
+    updateInitiated: アシスタントを更新しました。バックグラウンドでナレッジベースを再同期中...
     sourceUrls: ソースURL
     title: 名前
     uploadFiles: ファイルをアップロード

--- a/packages/web/src/pages/AssistantFormPage.tsx
+++ b/packages/web/src/pages/AssistantFormPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
 import { PiArrowLeft, PiFloppyDisk, PiFile, PiTrash } from 'react-icons/pi';
 import useAssistantApi from '../hooks/useAssistantApi';
 import useAssistantForm from '../hooks/useAssistantForm';
@@ -22,9 +23,7 @@ const AssistantFormPage: React.FC = () => {
   const { getAssistant, createAssistant, updateAssistant, deleteAssistant } = useAssistantApi();
 
   const [loading, setLoading] = useState(false);
-  const [saving, setSaving] = useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
-  const [deleting, setDeleting] = useState(false);
 
   const {
     formData,
@@ -66,56 +65,62 @@ const AssistantFormPage: React.FC = () => {
     }
   };
 
-  const handleSave = async () => {
+  const handleSave = () => {
     if (!isValid()) {
-      alert(t('assistant.edit.requiredFields'));
+      toast.error(t('assistant.edit.requiredFields'));
       return;
     }
 
-    setSaving(true);
-    try {
-      const requestData: CreateAssistantRequest | UpdateAssistantRequest = {
-        name: formData.name,
-        description: formData.description,
-        instruction: formData.instruction,
-        modelId: formData.modelId,
-        ragEnabled: formData.ragEnabled,
-        knowledgeSources: formData.knowledgeSources,
-      };
+    const requestData: CreateAssistantRequest | UpdateAssistantRequest = {
+      name: formData.name,
+      description: formData.description,
+      instruction: formData.instruction,
+      modelId: formData.modelId,
+      ragEnabled: formData.ragEnabled,
+      knowledgeSources: formData.knowledgeSources,
+    };
 
-      if (assistantId) {
-        await updateAssistant(assistantId, requestData as UpdateAssistantRequest);
-        navigate('/chat/assistants');
-      } else {
-        const assistant = await createAssistant(requestData as CreateAssistantRequest);
-        navigate(`/chat/assistants/chat/${assistant.assistantId}`);
+    // Show toast and navigate immediately - fire and forget
+    toast.success(t(assistantId ? 'assistant.edit.updateInitiated' : 'assistant.edit.createInitiated'));
+    navigate('/chat/assistants');
+
+    // Fire API call in background without blocking navigation
+    (async () => {
+      try {
+        if (assistantId) {
+          await updateAssistant(assistantId, requestData as UpdateAssistantRequest);
+        } else {
+          await createAssistant(requestData as CreateAssistantRequest);
+        }
+      } catch (error) {
+        console.error(`Failed to ${assistantId ? 'update' : 'create'} assistant:`, error);
+        toast.error(t('assistant.edit.saveFailed'));
       }
-    } catch (error) {
-      console.error(`Failed to ${assistantId ? 'update' : 'create'} assistant:`, error);
-      alert(t('assistant.edit.saveFailed'));
-    } finally {
-      setSaving(false);
-    }
+    })();
   };
 
   const handleCancel = () => {
     navigate('/chat/assistants');
   };
 
-  const handleDelete = async () => {
+  const handleDelete = () => {
     if (!assistantId) return;
 
-    setDeleting(true);
-    try {
-      await deleteAssistant(assistantId);
-      navigate('/chat/assistants');
-    } catch (error) {
-      console.error('Failed to delete assistant:', error);
-      alert(t('assistant.deleteError'));
-    } finally {
-      setDeleting(false);
-      setIsDeleteModalOpen(false);
-    }
+    setIsDeleteModalOpen(false);
+
+    // Show toast and navigate immediately - fire and forget
+    toast.success(t('assistant.deleteInitiated'));
+    navigate('/chat/assistants');
+
+    // Fire API call in background without blocking navigation
+    (async () => {
+      try {
+        await deleteAssistant(assistantId);
+      } catch (error) {
+        console.error('Failed to delete assistant:', error);
+        toast.error(t('assistant.deleteError'));
+      }
+    })();
   };
 
   if (loading) {
@@ -177,7 +182,6 @@ const AssistantFormPage: React.FC = () => {
           <Button
             outlined
             onClick={() => setIsDeleteModalOpen(true)}
-            disabled={deleting}
             className="flex items-center gap-1 border-red-600 text-red-600 hover:bg-red-50">
             <PiTrash />
             {t('assistant.delete')}
@@ -189,10 +193,10 @@ const AssistantFormPage: React.FC = () => {
           </Button>
           <Button
             onClick={handleSave}
-            disabled={saving || uploadingFiles}
+            disabled={uploadingFiles}
             className="flex items-center gap-1">
             <PiFloppyDisk />
-            {saving ? t('assistant.edit.saving') : t('assistant.edit.save')}
+            {t('assistant.edit.save')}
           </Button>
         </div>
       </div>
@@ -201,7 +205,7 @@ const AssistantFormPage: React.FC = () => {
       <ModalDialogDeleteAssistant
         isOpen={isDeleteModalOpen}
         assistantName={formData.name}
-        deleting={deleting}
+        deleting={false}
         onDelete={handleDelete}
         onClose={() => setIsDeleteModalOpen(false)}
       />


### PR DESCRIPTION
## 📋 変更概要

アシスタントの作成・更新・削除時にAPI完了を待たずに即座に画面遷移する「Fire-and-Forget」パターンを実装し、UIレスポンスを改善。

## 🏗️ アーキテクチャ変更

```
変更前:                              変更後:
[User Action]                       [User Action]
     │                                   │
     ▼                                   ├──> [Toast] ──┐
[Wait for API]                          │              │
     │                                   ├──> [Navigate]│
     ▼                                   │              │
[Navigate]                              └──> [API (Background)]
```

## 📊 変更内容

### **packages/web/src/pages/AssistantFormPage.tsx** (+47/-43)
- `handleSave`/`handleDelete` を同期的に変更
- Toast表示 → 即座にnavigate → APIを背景で実行
- `saving`/`deleting` ステートを削除
- `alert()` → `toast` に統一

### **packages/web/public/locales/translation/{en,ja}.yaml** (+3)
- `deleteInitiated`: 削除開始メッセージ
- `createInitiated`: 作成開始メッセージ  
- `updateInitiated`: 更新開始メッセージ

### **packages/cdk/lib/construct/speech-to-speech.ts** (+1/-1)
- Lambda bundling に `aws-amplify`, `ws` を追加

## 🧪 テスト

- [ ] fire-and-forgetパターンの動作確認
- [ ] エラー時のtoast表示確認
- [ ] 即時リダイレクトの動作確認

## ⚠️ 破壊的変更

なし

## 📝 注意事項

- APIエラー時、ユーザーは既に別画面に遷移済み
- エラーはtoastで通知されるが、見逃される可能性あり