### PR TITLE
:bug: 既存のチャットを開いたときに直前に使用したモデルが選択されるようにした

### DIFF
--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -731,6 +731,15 @@ const useChatState = create<{
       }
 
       initChat(id, messages, chat);
+
+      // Restore model ID from the last assistant message
+      const lastAssistantMessage = messages
+        .filter((m) => m.role === 'assistant' && m.llmType)
+        .pop();
+
+      if (lastAssistantMessage?.llmType) {
+        setModelId(id, lastAssistantMessage.llmType);
+      }
     },
     updateSystemContext: (id: string, systemContext: string) => {
       set((state) => {

--- a/packages/web/src/pages/ChatPage.tsx
+++ b/packages/web/src/pages/ChatPage.tsx
@@ -150,11 +150,13 @@ const ChatPage: React.FC = () => {
           ? params.modelId!
           : _modelId
       );
-    } else {
+    } else if (!chatId) {
+      // Only set default model for new chats (when chatId doesn't exist)
+      // For existing chats, the model will be restored from messages
       setModelId(_modelId);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [search, setContent, availableModels, pathname]);
+  }, [search, setContent, availableModels, pathname, chatId]);
 
   const onSend = useCallback(() => {
     setFollowing(true);


### PR DESCRIPTION
## 変更の概要

<!-- どのような変更を行ったかを書く -->

- 表題のとおりです

## 申し送り事項

<!-- レビュワーに伝えておきたい事柄等を書く（Draftの理由など） -->

- 手元環境が動かないので、レビュワーの方が動作確認を行ってください。

### 動作確認手順

1. デフォルトで選択されているモデル以外の任意のモデルを選択し、チャットを行う
2. チャット履歴から行ったチャットを選択し、画面上のモデル選択のドロップダウンで、使用したモデルが選択されていることを確認する

## Checklist（レビュワー用）

- [ ] `npm run lint`でエラーが出ない
- [ ] TypeScript のビルドで型エラーが出ない
- [ ] 手元でフォーマットした際に差分が出ない
