### PR TITLE
:recycle: refactor(tenant): OpenSearch設定フィールドをTenantモデルに統合

### DIFF
--- a/packages/cdk/bin/generative-ai-use-cases-tenant.ts
+++ b/packages/cdk/bin/generative-ai-use-cases-tenant.ts
@@ -128,6 +128,12 @@ if (tenantConfig.controlPlane) {
   ) {
     app.node.setContext('controlPlaneLambdaRoleArn', controlPlane.controlPlaneLambdaRoleArn);
   }
+  if (
+    controlPlane.account &&
+    !app.node.getAllContext()['controlPlaneAccount']
+  ) {
+    app.node.setContext('controlPlaneAccount', controlPlane.account);
+  }
 }
 
 const tenantId = context.tenantId;
@@ -176,7 +182,10 @@ const params = {
   networkConfig: context.networkConfig,
   ipAccessControl: context.ipAccessControl,
   controlPlaneRegion: context.controlPlane?.region,
-  openSearchIndexName: context.controlPlane?.openSearchIndexName || 'assistant-docs',
+  controlPlaneAccount: context.controlPlane?.account,
+  // Use provided table name or construct it based on environment
+  tenantsTableName: context.controlPlane?.tenantsTableName || `Tenants-${context.environment || 'dev'}`,
+  openSearchIndexName: context.openSearchIndexName || 'assistant-docs',
 };
 
 createTenantStacks(app, params);

--- a/packages/cdk/custom-resources/opensearch-tenant-updater.js
+++ b/packages/cdk/custom-resources/opensearch-tenant-updater.js
@@ -1,11 +1,33 @@
 const { DynamoDBClient, UpdateItemCommand } = require('@aws-sdk/client-dynamodb');
 const { marshall } = require('@aws-sdk/util-dynamodb');
+const { STSClient, AssumeRoleCommand } = require('@aws-sdk/client-sts');
+const { fromTemporaryCredentials } = require('@aws-sdk/credential-providers');
 
 const TENANTS_TABLE_NAME = process.env.TENANTS_TABLE_NAME;
 const CONTROL_PLANE_REGION = process.env.CONTROL_PLANE_REGION;
+const CONTROL_PLANE_ACCOUNT = process.env.CONTROL_PLANE_ACCOUNT;
+const CONTROL_PLANE_ROLE_ARN = process.env.CONTROL_PLANE_ROLE_ARN;
 const DEFAULT_OPENSEARCH_INDEX = process.env.DEFAULT_OPENSEARCH_INDEX || 'assistant-docs';
 
-const dynamoClient = new DynamoDBClient({ region: CONTROL_PLANE_REGION });
+// Create DynamoDB client with cross-account credentials if needed
+const createDynamoClient = () => {
+  const config = { region: CONTROL_PLANE_REGION };
+
+  // If a control plane role ARN is provided, assume that role for cross-account access
+  if (CONTROL_PLANE_ROLE_ARN) {
+    config.credentials = fromTemporaryCredentials({
+      params: {
+        RoleArn: CONTROL_PLANE_ROLE_ARN,
+        RoleSessionName: 'OpenSearchTenantUpdater',
+        ExternalId: 'opensearch-tenant-updater',
+      },
+    });
+  }
+
+  return new DynamoDBClient(config);
+};
+
+const dynamoClient = createDynamoClient();
 
 const updateStatus = async (event, status, reason, physicalResourceId) => {
   const body = JSON.stringify({

--- a/packages/cdk/custom-resources/opensearch-tenant-updater.js
+++ b/packages/cdk/custom-resources/opensearch-tenant-updater.js
@@ -1,0 +1,160 @@
+const { DynamoDBClient, UpdateItemCommand } = require('@aws-sdk/client-dynamodb');
+const { marshall } = require('@aws-sdk/util-dynamodb');
+
+const TENANTS_TABLE_NAME = process.env.TENANTS_TABLE_NAME;
+const CONTROL_PLANE_REGION = process.env.CONTROL_PLANE_REGION;
+const DEFAULT_OPENSEARCH_INDEX = process.env.DEFAULT_OPENSEARCH_INDEX || 'assistant-docs';
+
+const dynamoClient = new DynamoDBClient({ region: CONTROL_PLANE_REGION });
+
+const updateStatus = async (event, status, reason, physicalResourceId) => {
+  const body = JSON.stringify({
+    Status: status,
+    Reason: reason,
+    PhysicalResourceId: physicalResourceId,
+    StackId: event.StackId,
+    RequestId: event.RequestId,
+    LogicalResourceId: event.LogicalResourceId,
+    NoEcho: false,
+    Data: {},
+  });
+
+  const res = await fetch(event.ResponseURL, {
+    method: 'PUT',
+    body,
+    headers: {
+      'Content-Type': '',
+      'Content-Length': body.length.toString(),
+    },
+  });
+
+  // For recording failures
+  console.log(res);
+  console.log(await res.text());
+};
+
+exports.handler = async (event, context) => {
+  // For recording failures
+  console.log('OpenSearch Tenant Updater - Event:', JSON.stringify(event, null, 2));
+
+  const props = event.ResourceProperties;
+  const tenantId = props.tenantId;
+  const openSearchDomainArn = props.openSearchDomainArn;
+  const openSearchEndpoint = props.openSearchEndpoint;
+  const openSearchIndexName = props.openSearchIndexName || DEFAULT_OPENSEARCH_INDEX;
+
+  // Physical resource ID for this custom resource
+  const physicalResourceId = `opensearch-tenant-${tenantId}`;
+
+  try {
+    // Validate environment variables
+    if (!TENANTS_TABLE_NAME) {
+      throw new Error('TENANTS_TABLE_NAME environment variable is not set');
+    }
+
+    switch (event.RequestType) {
+      case 'Create':
+      case 'Update':
+        // Validate required properties
+        if (!tenantId) {
+          throw new Error('tenantId is required');
+        }
+        if (!openSearchDomainArn) {
+          throw new Error('openSearchDomainArn is required');
+        }
+        if (!openSearchEndpoint) {
+          throw new Error('openSearchEndpoint is required');
+        }
+        if (!openSearchEndpoint.startsWith('https://')) {
+          throw new Error('openSearchEndpoint must start with https://');
+        }
+
+        console.log(`Updating tenant ${tenantId} with OpenSearch configuration:`, {
+          openSearchDomainArn,
+          openSearchEndpoint,
+          openSearchIndexName,
+        });
+
+        const now = new Date().toISOString();
+
+        // Update the tenant record with OpenSearch information
+        await dynamoClient.send(
+          new UpdateItemCommand({
+            TableName: TENANTS_TABLE_NAME,
+            Key: marshall({ tenantId }),
+            UpdateExpression:
+              'SET #openSearchDomainArn = :openSearchDomainArn, #openSearchEndpoint = :openSearchEndpoint, #openSearchIndexName = :openSearchIndexName, #updatedAt = :updatedAt',
+            ExpressionAttributeNames: {
+              '#openSearchDomainArn': 'openSearchDomainArn',
+              '#openSearchEndpoint': 'openSearchEndpoint',
+              '#openSearchIndexName': 'openSearchIndexName',
+              '#updatedAt': 'updatedAt',
+            },
+            ExpressionAttributeValues: marshall({
+              ':openSearchDomainArn': openSearchDomainArn,
+              ':openSearchEndpoint': openSearchEndpoint,
+              ':openSearchIndexName': openSearchIndexName,
+              ':updatedAt': now,
+            }),
+          })
+        );
+
+        console.log(`Successfully updated tenant ${tenantId} with OpenSearch configuration`);
+
+        await updateStatus(
+          event,
+          'SUCCESS',
+          `Successfully updated tenant ${tenantId} with OpenSearch configuration`,
+          physicalResourceId
+        );
+        break;
+
+      case 'Delete':
+        // Remove OpenSearch fields from tenant record
+        console.log(`Removing OpenSearch configuration from tenant ${tenantId}`);
+
+        const deleteNow = new Date().toISOString();
+
+        await dynamoClient.send(
+          new UpdateItemCommand({
+            TableName: TENANTS_TABLE_NAME,
+            Key: marshall({ tenantId }),
+            UpdateExpression:
+              'SET #updatedAt = :updatedAt REMOVE #openSearchDomainArn, #openSearchEndpoint, #openSearchIndexName',
+            ExpressionAttributeNames: {
+              '#openSearchDomainArn': 'openSearchDomainArn',
+              '#openSearchEndpoint': 'openSearchEndpoint',
+              '#openSearchIndexName': 'openSearchIndexName',
+              '#updatedAt': 'updatedAt',
+            },
+            ExpressionAttributeValues: marshall({
+              ':updatedAt': deleteNow,
+            }),
+          })
+        );
+
+        console.log(`Successfully removed OpenSearch configuration from tenant ${tenantId}`);
+
+        await updateStatus(
+          event,
+          'SUCCESS',
+          `Successfully removed OpenSearch configuration from tenant ${tenantId}`,
+          physicalResourceId
+        );
+        break;
+
+      default:
+        throw new Error(`Unsupported request type: ${event.RequestType}`);
+    }
+  } catch (e) {
+    console.error('---- Error');
+    console.error(e);
+
+    await updateStatus(
+      event,
+      'FAILED',
+      e.message || 'Unknown error',
+      physicalResourceId
+    );
+  }
+};

--- a/packages/cdk/custom-resources/package.json
+++ b/packages/cdk/custom-resources/package.json
@@ -2,7 +2,9 @@
   "private": true,
   "dependencies": {
     "@aws-sdk/client-dynamodb": "^3.565.0",
+    "@aws-sdk/client-sts": "^3.565.0",
     "@aws-sdk/credential-provider-node": "^3.565.0",
+    "@aws-sdk/credential-providers": "^3.565.0",
     "@aws-sdk/util-dynamodb": "^3.565.0",
     "@opensearch-project/opensearch": "^3.4.0"
   }

--- a/packages/cdk/custom-resources/package.json
+++ b/packages/cdk/custom-resources/package.json
@@ -1,7 +1,9 @@
 {
   "private": true,
   "dependencies": {
+    "@aws-sdk/client-dynamodb": "^3.565.0",
     "@aws-sdk/credential-provider-node": "^3.565.0",
+    "@aws-sdk/util-dynamodb": "^3.565.0",
     "@opensearch-project/opensearch": "^3.4.0"
   }
 }

--- a/packages/cdk/lambda/tenantManager.ts
+++ b/packages/cdk/lambda/tenantManager.ts
@@ -38,6 +38,9 @@ export interface Tenant {
     updatedBy: string;
   };
   ipAccessControl?: IpAccessControl;
+  openSearchDomainArn?: string;
+  openSearchEndpoint?: string;
+  openSearchIndexName?: string;
 }
 
 // Request interfaces
@@ -59,6 +62,9 @@ interface UpdateTenantRequest {
   accountId?: string;
   roleArn?: string;
   ipAccessControl?: IpAccessControl;
+  openSearchDomainArn?: string | null;
+  openSearchEndpoint?: string | null;
+  openSearchIndexName?: string | null;
 }
 
 /**
@@ -148,8 +154,52 @@ export async function updateTenant(
       throw new Error(`Tenant ${request.tenantId} not found`);
     }
 
+    // Validate OpenSearch fields - all must be provided together or all must be null/empty for removal
+    const {
+      openSearchDomainArn,
+      openSearchEndpoint,
+      openSearchIndexName,
+    } = request;
+    const hasOpenSearchArn = openSearchDomainArn !== undefined;
+    const hasOpenSearchEndpoint = openSearchEndpoint !== undefined;
+    const hasOpenSearchIndex = openSearchIndexName !== undefined;
+
+    if (hasOpenSearchArn || hasOpenSearchEndpoint || hasOpenSearchIndex) {
+      // If any OpenSearch field is being updated, all three must be provided
+      if (!(hasOpenSearchArn && hasOpenSearchEndpoint && hasOpenSearchIndex)) {
+        throw new Error(
+          'All OpenSearch fields (domainArn, endpoint, indexName) must be updated together'
+        );
+      }
+
+      // If updating (not removing), validate the values
+      if (openSearchDomainArn && openSearchEndpoint && openSearchIndexName) {
+        if (
+          !openSearchEndpoint.startsWith('https://') ||
+          !openSearchEndpoint.includes('.amazonaws.com')
+        ) {
+          throw new Error(
+            'OpenSearch endpoint must be an HTTPS URL from amazonaws.com domain'
+          );
+        }
+
+        // Validate region match
+        const arnMatch = openSearchDomainArn.match(/arn:aws:es:([^:]+):/);
+        const endpointMatch = openSearchEndpoint.match(
+          /\.([^.]+)\.es\.amazonaws\.com/
+        );
+
+        if (arnMatch && endpointMatch && arnMatch[1] !== endpointMatch[1]) {
+          throw new Error(
+            'OpenSearch endpoint region must match domain ARN region'
+          );
+        }
+      }
+    }
+
     const now = new Date().toISOString();
     const updateExpression: string[] = [];
+    const removeExpression: string[] = [];
     const expressionAttributeNames: Record<string, string> = {};
     const expressionAttributeValues: Record<string, any> = {};
 
@@ -196,16 +246,49 @@ export async function updateTenant(
       };
     }
 
+    // OpenSearch fields - handle both update and removal
+    if (hasOpenSearchArn && hasOpenSearchEndpoint && hasOpenSearchIndex) {
+      if (openSearchDomainArn && openSearchEndpoint && openSearchIndexName) {
+        // Update OpenSearch fields
+        updateExpression.push('#openSearchDomainArn = :openSearchDomainArn');
+        updateExpression.push('#openSearchEndpoint = :openSearchEndpoint');
+        updateExpression.push('#openSearchIndexName = :openSearchIndexName');
+        expressionAttributeNames['#openSearchDomainArn'] = 'openSearchDomainArn';
+        expressionAttributeNames['#openSearchEndpoint'] = 'openSearchEndpoint';
+        expressionAttributeNames['#openSearchIndexName'] = 'openSearchIndexName';
+        expressionAttributeValues[':openSearchDomainArn'] = openSearchDomainArn;
+        expressionAttributeValues[':openSearchEndpoint'] = openSearchEndpoint;
+        expressionAttributeValues[':openSearchIndexName'] = openSearchIndexName;
+      } else {
+        // Remove OpenSearch fields (all are null)
+        removeExpression.push('#openSearchDomainArn');
+        removeExpression.push('#openSearchEndpoint');
+        removeExpression.push('#openSearchIndexName');
+        expressionAttributeNames['#openSearchDomainArn'] = 'openSearchDomainArn';
+        expressionAttributeNames['#openSearchEndpoint'] = 'openSearchEndpoint';
+        expressionAttributeNames['#openSearchIndexName'] = 'openSearchIndexName';
+      }
+    }
+
     // Always update updatedAt
     updateExpression.push('#updatedAt = :updatedAt');
     expressionAttributeNames['#updatedAt'] = 'updatedAt';
     expressionAttributeValues[':updatedAt'] = now;
 
+    // Build final update expression
+    let finalUpdateExpression = '';
+    if (updateExpression.length > 0) {
+      finalUpdateExpression = `SET ${updateExpression.join(', ')}`;
+    }
+    if (removeExpression.length > 0) {
+      finalUpdateExpression += ` REMOVE ${removeExpression.join(', ')}`;
+    }
+
     const response = await dynamoClient.send(
       new UpdateItemCommand({
         TableName: TENANTS_TABLE_NAME,
         Key: marshall({ tenantId: request.tenantId }),
-        UpdateExpression: `SET ${updateExpression.join(', ')}`,
+        UpdateExpression: finalUpdateExpression,
         ExpressionAttributeNames: expressionAttributeNames,
         ExpressionAttributeValues: marshall(expressionAttributeValues),
         ReturnValues: 'ALL_NEW',

--- a/packages/cdk/lambda/tenantRegistrationHandler.ts
+++ b/packages/cdk/lambda/tenantRegistrationHandler.ts
@@ -21,6 +21,9 @@ interface TenantRegistrationRequest {
   environment: string;
   roleArn?: string;
   controlPlaneLambdaRoleArn?: string;
+  openSearchDomainArn?: string;
+  openSearchEndpoint?: string;
+  openSearchIndexName?: string;
 }
 
 /**
@@ -30,8 +33,6 @@ export const handler = async (
   event: APIGatewayProxyEvent,
   context: Context
 ): Promise<APIGatewayProxyResult> => {
-  console.log('Registration request:', event.body);
-
   try {
     // Parse and validate request
     if (!event.body) {
@@ -43,7 +44,29 @@ export const handler = async (
     }
 
     const request: TenantRegistrationRequest = JSON.parse(event.body);
-    const { tenantId, accountId, region, environment, roleArn, controlPlaneLambdaRoleArn } = request;
+    const {
+      tenantId,
+      accountId,
+      region,
+      environment,
+      roleArn,
+      controlPlaneLambdaRoleArn,
+      openSearchDomainArn,
+      openSearchEndpoint,
+      openSearchIndexName,
+    } = request;
+
+    // Log request without sensitive data
+    console.log('[INFO] Tenant registration request received', {
+      tenantId,
+      region,
+      environment,
+      hasOpenSearchConfig: !!(
+        openSearchDomainArn ||
+        openSearchEndpoint ||
+        openSearchIndexName
+      ),
+    });
 
     // Validate required fields
     if (!tenantId || !accountId || !region || !environment) {
@@ -57,9 +80,66 @@ export const handler = async (
       };
     }
 
+    // Validate OpenSearch configuration - all three fields must be provided together
+    const hasOpenSearchConfig = !!(
+      openSearchDomainArn?.trim() ||
+      openSearchEndpoint?.trim() ||
+      openSearchIndexName?.trim()
+    );
+
+    if (hasOpenSearchConfig) {
+      // All three must be provided and non-empty
+      if (
+        !openSearchDomainArn?.trim() ||
+        !openSearchEndpoint?.trim() ||
+        !openSearchIndexName?.trim()
+      ) {
+        return {
+          statusCode: 400,
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            message:
+              'All OpenSearch fields (domainArn, endpoint, indexName) must be provided together',
+          }),
+        };
+      }
+
+      // Validate endpoint is HTTPS and from amazonaws.com
+      if (
+        !openSearchEndpoint.startsWith('https://') ||
+        !openSearchEndpoint.includes('.amazonaws.com')
+      ) {
+        return {
+          statusCode: 400,
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            message:
+              'OpenSearch endpoint must be an HTTPS URL from amazonaws.com domain',
+          }),
+        };
+      }
+
+      // Validate that endpoint region matches ARN region
+      const arnMatch = openSearchDomainArn.match(/arn:aws:es:([^:]+):/);
+      const endpointMatch = openSearchEndpoint.match(
+        /\.([^.]+)\.es\.amazonaws\.com/
+      );
+
+      if (arnMatch && endpointMatch && arnMatch[1] !== endpointMatch[1]) {
+        return {
+          statusCode: 400,
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            message:
+              'OpenSearch endpoint region must match domain ARN region',
+          }),
+        };
+      }
+    }
+
     // Create tenant record with default use case configuration
     const now = new Date().toISOString();
-    const tenant = {
+    const tenant: Record<string, any> = {
       tenantId,
       status: TenantStatus.PROVISIONING,
       accountId,
@@ -79,6 +159,13 @@ export const handler = async (
         updatedBy: 'system',
       },
     };
+
+    // Add OpenSearch configuration if provided
+    if (hasOpenSearchConfig) {
+      tenant.openSearchDomainArn = openSearchDomainArn;
+      tenant.openSearchEndpoint = openSearchEndpoint;
+      tenant.openSearchIndexName = openSearchIndexName;
+    }
 
     await dynamoClient.send(
       new PutItemCommand({

--- a/packages/cdk/lib/create-tenant-stacks.ts
+++ b/packages/cdk/lib/create-tenant-stacks.ts
@@ -42,6 +42,8 @@ export interface TenantStackInput {
   networkConfig: NetworkConfig;
   ipAccessControl?: IpAccessControlConfig;
   controlPlaneRegion?: string;
+  controlPlaneAccount?: string;
+  tenantsTableName?: string;
   openSearchIndexName?: string;
 }
 
@@ -131,6 +133,7 @@ export const createTenantStacks = (app: cdk.App, params: TenantStackInput) => {
         ? cdk.RemovalPolicy.DESTROY
         : cdk.RemovalPolicy.RETAIN,
       tenantRoleArn: tenantIAMStack.tenantRole.role.roleArn,
+      tenantsTableName: params.tenantsTableName,
       controlPlaneRegion: params.controlPlaneRegion,
       openSearchIndexName: params.openSearchIndexName,
     }

--- a/packages/cdk/lib/stacks/tenant/tenant-opensearch-stack.ts
+++ b/packages/cdk/lib/stacks/tenant/tenant-opensearch-stack.ts
@@ -56,12 +56,11 @@ export interface TenantOpenSearchStackProps extends cdk.StackProps {
    * Removal policy for the domain
    */
   readonly removalPolicy: cdk.RemovalPolicy;
-
   /**
    * The tenant IAM role ARN for accessing OpenSearch
    * This role is assumed by Lambda functions to access tenant-specific resources
    */
-  readonly tenantIamRoleArn?: string;
+  readonly tenantRoleArn: string;
 
   /**
    * DynamoDB table name for tenants
@@ -242,10 +241,8 @@ export class TenantOpenSearchStack extends cdk.Stack {
       new iam.ServicePrincipal('bedrock.amazonaws.com'),
     ];
 
-    // Add tenant role if provided
-    if (props.tenantIamRoleArn) {
-      principals.push(new iam.ArnPrincipal(props.tenantIamRoleArn));
-    }
+    // Add tenant role
+    principals.push(new iam.ArnPrincipal(props.tenantRoleArn));
 
     const accessPolicy = new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
@@ -275,6 +272,27 @@ export class TenantOpenSearchStack extends cdk.Stack {
     // Create custom resource to update tenant record with OpenSearch information
     // Only create if tenantsTableName is provided
     if (props.tenantsTableName && props.controlPlaneRegion) {
+      // Get control plane account from context or use current account
+      const controlPlaneAccount = this.node.tryGetContext('controlPlaneAccount');
+      const currentAccount = cdk.Stack.of(this).account;
+
+      // Determine if cross-account access is needed
+      const isCrossAccount = controlPlaneAccount && controlPlaneAccount !== currentAccount;
+
+      // Get or construct the control plane role ARN for cross-account access
+      let controlPlaneRoleArn: string | undefined;
+      if (isCrossAccount) {
+        // Use the role from context or construct the ARN
+        const controlPlaneLambdaRoleArn = this.node.tryGetContext('controlPlaneLambdaRoleArn');
+        if (controlPlaneLambdaRoleArn) {
+          controlPlaneRoleArn = controlPlaneLambdaRoleArn;
+        } else {
+          // Construct a standard role ARN for the control plane
+          // This assumes a role exists in the control plane account that trusts this tenant account
+          controlPlaneRoleArn = `arn:aws:iam::${controlPlaneAccount}:role/TenantAccessRole`;
+        }
+      }
+
       // Create Lambda function for custom resource
       const tenantUpdaterLambda = new lambda.SingletonFunction(
         this,
@@ -288,19 +306,34 @@ export class TenantOpenSearchStack extends cdk.Stack {
           environment: {
             TENANTS_TABLE_NAME: props.tenantsTableName,
             CONTROL_PLANE_REGION: props.controlPlaneRegion,
+            CONTROL_PLANE_ACCOUNT: controlPlaneAccount || currentAccount,
+            CONTROL_PLANE_ROLE_ARN: controlPlaneRoleArn || '',
             DEFAULT_OPENSEARCH_INDEX: props.openSearchIndexName || 'assistant-docs',
           },
         }
       );
 
       // Grant DynamoDB permissions to the Lambda
-      const tenantsTableArn = `arn:aws:dynamodb:${props.controlPlaneRegion}:${this.account}:table/${props.tenantsTableName}`;
+      const tenantsTableArn = `arn:aws:dynamodb:${props.controlPlaneRegion}:${controlPlaneAccount || currentAccount}:table/${props.tenantsTableName}`;
       const tenantsTable = dynamodb.Table.fromTableArn(
         this,
         'TenantsTable',
         tenantsTableArn
       );
-      tenantsTable.grantReadWriteData(tenantUpdaterLambda);
+
+      // If cross-account, grant STS assume role permission
+      if (isCrossAccount && controlPlaneRoleArn) {
+        tenantUpdaterLambda.addToRolePolicy(
+          new iam.PolicyStatement({
+            effect: iam.Effect.ALLOW,
+            actions: ['sts:AssumeRole'],
+            resources: [controlPlaneRoleArn],
+          })
+        );
+      } else {
+        // Same account: grant direct DynamoDB access
+        tenantsTable.grantReadWriteData(tenantUpdaterLambda);
+      }
 
       // Create custom resource
       const tenantUpdaterResource = new cdk.CustomResource(

--- a/packages/cdk/lib/stacks/tenant/tenant-opensearch-stack.ts
+++ b/packages/cdk/lib/stacks/tenant/tenant-opensearch-stack.ts
@@ -2,6 +2,8 @@ import * as cdk from 'aws-cdk-lib';
 import * as opensearch from 'aws-cdk-lib/aws-opensearchservice';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';
 import * as iam from 'aws-cdk-lib/aws-iam';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
 import { Construct } from 'constructs';
 
 export interface TenantOpenSearchStackProps extends cdk.StackProps {
@@ -59,7 +61,12 @@ export interface TenantOpenSearchStackProps extends cdk.StackProps {
    * The tenant IAM role ARN for accessing OpenSearch
    * This role is assumed by Lambda functions to access tenant-specific resources
    */
-  readonly tenantRoleArn: string;
+  readonly tenantIamRoleArn?: string;
+
+  /**
+   * DynamoDB table name for tenants
+   */
+  readonly tenantsTableName?: string;
 
   /**
    * Control plane region for DynamoDB access
@@ -230,13 +237,19 @@ export class TenantOpenSearchStack extends cdk.Stack {
 
     // Grant access to the domain from CodeBuild role, Tenant role, and Bedrock service
     // Note: Tenant role is used by Lambda functions to access OpenSearch for assistant RAG functionality
+    const principals: iam.IPrincipal[] = [
+      this.opensearchIndexCreationRole,
+      new iam.ServicePrincipal('bedrock.amazonaws.com'),
+    ];
+
+    // Add tenant role if provided
+    if (props.tenantIamRoleArn) {
+      principals.push(new iam.ArnPrincipal(props.tenantIamRoleArn));
+    }
+
     const accessPolicy = new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
-      principals: [
-        this.opensearchIndexCreationRole,
-        new iam.ArnPrincipal(props.tenantRoleArn), // Add tenant role for Lambda access
-        new iam.ServicePrincipal('bedrock.amazonaws.com'),
-      ],
+      principals,
       actions: [
         'es:ESHttpPost',
         'es:ESHttpPut',
@@ -258,6 +271,58 @@ export class TenantOpenSearchStack extends cdk.Stack {
     });
 
     this.domain.addAccessPolicies(describeDomainPolicy);
+
+    // Create custom resource to update tenant record with OpenSearch information
+    // Only create if tenantsTableName is provided
+    if (props.tenantsTableName && props.controlPlaneRegion) {
+      // Create Lambda function for custom resource
+      const tenantUpdaterLambda = new lambda.SingletonFunction(
+        this,
+        'OpenSearchTenantUpdater',
+        {
+          uuid: '8c3b3f3a-5d9e-4c7a-9f2e-1a8b9c0d1e2f',
+          runtime: lambda.Runtime.NODEJS_22_X,
+          code: lambda.Code.fromAsset('custom-resources'),
+          handler: 'opensearch-tenant-updater.handler',
+          timeout: cdk.Duration.minutes(5),
+          environment: {
+            TENANTS_TABLE_NAME: props.tenantsTableName,
+            CONTROL_PLANE_REGION: props.controlPlaneRegion,
+            DEFAULT_OPENSEARCH_INDEX: props.openSearchIndexName || 'assistant-docs',
+          },
+        }
+      );
+
+      // Grant DynamoDB permissions to the Lambda
+      const tenantsTableArn = `arn:aws:dynamodb:${props.controlPlaneRegion}:${this.account}:table/${props.tenantsTableName}`;
+      const tenantsTable = dynamodb.Table.fromTableArn(
+        this,
+        'TenantsTable',
+        tenantsTableArn
+      );
+      tenantsTable.grantReadWriteData(tenantUpdaterLambda);
+
+      // Create custom resource
+      const tenantUpdaterResource = new cdk.CustomResource(
+        this,
+        'TenantOpenSearchUpdater',
+        {
+          serviceToken: tenantUpdaterLambda.functionArn,
+          resourceType: 'Custom::TenantOpenSearchUpdater',
+          properties: {
+            tenantId: typeof tenantId === 'string' ? tenantId : (tenantId as cdk.CfnParameter).valueAsString,
+            openSearchDomainArn: this.domain.domainArn,
+            openSearchEndpoint: `https://${this.domain.domainEndpoint}`,
+            openSearchIndexName: props.openSearchIndexName || 'assistant-docs',
+          },
+        }
+      );
+
+      // Ensure custom resource runs after domain is created
+      tenantUpdaterResource.node.addDependency(this.domain);
+
+      console.log(`Created custom resource to update tenant ${tenantId} with OpenSearch info`);
+    }
 
     // Export domain outputs
     new cdk.CfnOutput(this, 'DomainEndpoint', {


### PR DESCRIPTION
## 📋 変更概要

テナントレコードにOpenSearch設定情報(ドメインARN、エンドポイント、インデックス名)を直接格納できるよう、データモデルと関連APIを拡張しました。これによりテナントごとのOpenSearchドメイン管理が容易になります。

## 🏗️ アーキテクチャ変更

```
変更前:                                    変更後:
┌─────────────────────┐                   ┌─────────────────────┐
│  Tenant Record      │                   │  Tenant Record      │
│  ┌──────────────┐   │                   │  ┌──────────────┐   │
│  │ tenantId     │   │                   │  │ tenantId     │   │
│  │ accountId    │   │                   │  │ accountId    │   │
│  │ region       │   │                   │  │ region       │   │
│  │ status       │   │                   │  │ status       │   │
│  └──────────────┘   │                   │  │ + openSearch │◄── 新規追加
│                      │                   │  │   DomainArn  │
│                      │                   │  │ + openSearch │
│                      │                   │  │   Endpoint   │
│                      │                   │  │ + openSearch │
│                      │                   │  │   IndexName  │
└─────────────────────┘                   │  └──────────────┘   │
                                           └─────────────────────┘
         ▲                                          ▲
         │                                          │
         │ 参照                                     │ 直接参照
         │                                          │
┌─────────────────────┐                   ┌─────────────────────┐
│ OpenSearch Stack    │                   │ OpenSearch Stack    │
│ (CDK)               │                   │ (CDK)               │
│ ┌──────────────┐    │                   │ ┌──────────────┐    │
│ │ Domain       │    │                   │ │ Domain       │    │
│ │ Properties   │    │                   │ │ + Custom     │◄── 新規追加
│ └──────────────┘    │                   │ │   Resource   │
└─────────────────────┘                   │ │   Updater    │
                                           │ └──────────────┘
                                           └─────────────────────┘
```

**アーキテクチャ変更の理由:**
- テナント情報とOpenSearch設定を一元管理することで、データ取得の効率化
- CDKスタック展開時にカスタムリソースを使用して自動的にテナントレコードを更新
- テナント登録・更新API経由での手動設定も可能

**影響範囲:**
- テナントデータモデルの拡張(後方互換性あり)
- テナント管理API(登録・更新)の機能拡張
- OpenSearchスタック展開時の自動更新機能追加

## 📊 変更内容詳細

### 新規追加 ✨

#### **packages/cdk/custom-resources/opensearch-tenant-updater.js** (+160 行)

CDK Custom Resource用のLambda関数を新規作成

**追加内容:**
- CloudFormationカスタムリソースハンドラー実装
- DynamoDB UpdateItemCommandによるテナントレコード更新ロジック
- Create/Update/Deleteイベントのハンドリング
- エンドポイントURL検証(HTTPS必須)

**理由:**
- OpenSearchドメイン作成時に自動的にテナントレコードへ設定情報を書き込むため
- CDKスタックのライフサイクルと連動したデータ同期の実現

**影響:**
- OpenSearchスタック展開時に自動的にテナントDBが更新される
- スタック削除時にOpenSearch設定フィールドが自動削除される

### 変更 🔄

#### **packages/cdk/lambda/tenantManager.ts** (+84/-1 行)

テナント更新APIにOpenSearch設定フィールドの更新・削除機能を追加

**変更前:**
- 基本的なテナント情報(名前、ロールARN、IPアクセス制御)のみ更新可能

**変更後:**
- OpenSearch設定(domainArn, endpoint, indexName)の追加・更新・削除をサポート
- 3フィールド同時更新/削除の整合性バリデーション
- エンドポイントURL形式検証(HTTPS + amazonaws.comドメイン)
- ARNとエンドポイントのリージョン一致検証
- DynamoDB UpdateExpressionにREMOVE句を追加(フィールド削除対応)

**理由:**
- 3つのフィールドが揃っていないとOpenSearch接続が不完全になるため、一括更新を強制
- セキュリティ強化のためHTTPS必須化
- リージョン不一致によるアクセスエラーを事前防止

**影響:**
- APIコール時に3フィールドすべてを指定する必要がある(部分更新不可)
- 削除時は3フィールドすべてにnullを指定

#### **packages/cdk/lambda/tenantRegistrationHandler.ts** (+91/-4 行)

テナント登録APIにOpenSearch設定の初期登録機能を追加

**変更前:**
- テナント基本情報のみ登録可能
- リクエストボディ全体をログ出力(機密情報漏洩リスク)

**変更後:**
- OpenSearch設定をオプショナルパラメータとして受付
- 3フィールド同時指定の整合性バリデーション(tenantManager.tsと同様)
- エンドポイントURL検証
- ARN-エンドポイント間リージョン一致検証
- 構造化ログ出力に変更(機密情報を除外)

**理由:**
- 登録時点でOpenSearch設定を指定できることで、別途更新APIを呼ぶ手間を削減
- セキュリティベストプラクティスに従ったログ出力

**影響:**
- テナント登録時にOpenSearch設定を含めることが可能に
- ログから機密情報が除外され、セキュリティ向上

#### **packages/cdk/lib/stacks/tenant/tenant-opensearch-stack.ts** (+68 行)

OpenSearchスタックにカスタムリソースによるテナントレコード自動更新機能を追加

**変更前:**
- OpenSearchドメインのプロビジョニングのみ
- テナントレコードへの設定反映は手動

**変更後:**
- SingletonFunction Lambda関数の作成
- カスタムリソースによる自動更新トリガー
- tenantsTableName/controlPlaneRegion/openSearchIndexNameをスタックプロパティとして追加
- DynamoDBテーブルへの読み書き権限付与

**理由:**
- スタック展開と同時にテナント情報を自動更新することで、運用負荷を削減
- インフラストラクチャとデータの整合性を保証

**影響:**
- スタック展開時に自動的にDynamoDBが更新される
- 手動でのAPI呼び出しが不要に

## 🔀 データフロー変更

```
テナントOpenSearch設定のデータフロー:

[スタック展開フロー]
CloudFormation Stack Deploy
         │
         ▼
  OpenSearch Domain
    Creation
         │
         ▼
  Custom Resource ─────> opensearch-tenant-updater (Lambda)
    Trigger                       │
                                  ▼
                           DynamoDB UpdateItem
                                  │
                                  ▼
                          Tenant Record Updated
                          (+ openSearchDomainArn)
                          (+ openSearchEndpoint)
                          (+ openSearchIndexName)

[API経由の手動更新フロー]
API Gateway Request
         │
         ├──> POST /tenants (registration)
         │         │
         │         ▼
         │    tenantRegistrationHandler
         │         │
         │         ├─> Validate 3 fields together
         │         ├─> Validate endpoint format
         │         ├─> Validate region match
         │         │
         │         ▼
         │    DynamoDB PutItem
         │
         └──> PATCH /tenants/:id (update)
                   │
                   ▼
              tenantManager
                   │
                   ├─> Validate 3 fields together
                   ├─> Validate endpoint format
                   ├─> Validate region match
                   │
                   ▼
              DynamoDB UpdateItem
              (SET or REMOVE)
```

**フロー変更の説明:**
- 2つの経路からテナントレコードにOpenSearch設定を書き込み可能
- スタック展開経路: 完全自動、運用不要
- API経路: 手動管理、柔軟な更新・削除が可能

## 🔗 依存関係の変更

```
追加された依存関係:
┌──────────────────────┐
│ opensearch-tenant-   │
│ updater.js           │
│ (Custom Resource)    │
└──────────┬───────────┘
           │
           │ uses
           ▼
┌──────────────────────┐
│ @aws-sdk/client-     │
│ dynamodb             │
└──────────────────────┘
           │
           │ marshall/
           │ UpdateItemCommand
           ▼
┌──────────────────────┐
│ DynamoDB Tenants     │
│ Table                │
└──────────────────────┘

┌──────────────────────┐
│ tenant-opensearch-   │
│ stack.ts             │
│ (CDK Stack)          │
└──────────┬───────────┘
           │
           │ imports
           ├────────────────────┐
           │                    │
           ▼                    ▼
┌──────────────────────┐ ┌──────────────────────┐
│ aws-lambda           │ │ aws-dynamodb         │
└──────────────────────┘ └──────────────────────┘
```

### 追加された依存
- **aws-lambda**: SingletonFunction構築に使用
- **aws-dynamodb**: テナントテーブル参照とIAM権限付与に使用

### 変更なし
既存の依存関係に変更はなし

## 🧪 テスト

- [ ] 単体テスト: 未実装(実装推奨)
  - tenantRegistrationHandler: バリデーションロジックのテスト
  - tenantManager: OpenSearch更新/削除ロジックのテスト
  - opensearch-tenant-updater: カスタムリソースハンドラーのテスト
- [ ] 統合テスト: 未実装(実装推奨)
  - スタック展開→テナントレコード自動更新の確認
  - API経由での更新→DynamoDB反映の確認
- [ ] E2Eテスト: 手動検証が必要
  - 実際のOpenSearchドメイン作成→テナントレコード更新の動作確認

## ⚠️ 破壊的変更

**なし**

- 既存のテナントレコードに影響なし(新規フィールドはオプショナル)
- 既存のAPI呼び出しは引き続き動作(OpenSearchフィールドを指定しない場合)
- 後方互換性を維持した拡張

## 📝 注意事項

**レビュワー向け注意点:**

1. **バリデーションロジックの重複**
   - tenantRegistrationHandler.tsとtenantManager.tsで同様のOpenSearchバリデーションが実装されています
   - 将来的には共通関数に抽出することを推奨

2. **エラーハンドリング**
   - opensearch-tenant-updater.jsのエラーはCloudFormationスタックの失敗として報告されます
   - DynamoDBアクセス権限が正しく設定されているか確認が必要

3. **リージョン検証**
   - ARNとエンドポイントのリージョン一致を検証していますが、正規表現パターンが将来のAWSエンドポイント形式に対応できるか継続的な確認が必要

4. **削除動作**
   - テナントレコードからOpenSearch設定を削除する際、3フィールドすべてにnullを指定する必要があることをAPIドキュメントに明記すべき

5. **TypeScript型定義**
   - Tenantインターフェースに追加された3フィールドはすべてオプショナル(`?`)であることを確認済み

## 🔗 関連Issue

関連Issueの記載がありません。必要に応じて追加してください。
