### PR TITLE
:bug: OpenSearchのアクセスポリシーを修正

### DIFF
--- a/packages/cdk/lambda/assistantHandler.ts
+++ b/packages/cdk/lambda/assistantHandler.ts
@@ -188,9 +188,31 @@ async function handleCreate(
           error
         );
 
-        // Update status to FAILED with error message
-        const errorMessage =
-          error instanceof Error ? error.message : 'Unknown error';
+        // Update status to FAILED with detailed error message
+        let errorMessage = 'Unknown error';
+        if (error instanceof Error) {
+          errorMessage = error.message;
+
+          // Extract additional details from OpenSearch ResponseError
+          if ('meta' in error && error.meta) {
+            const meta = error.meta as any;
+            if (meta.statusCode) {
+              errorMessage = `${error.message} (HTTP ${meta.statusCode})`;
+            }
+            if (meta.body && meta.body.Message) {
+              // AWS IAM error message format
+              errorMessage += `: ${meta.body.Message}`;
+            } else if (meta.body && meta.body.error) {
+              // OpenSearch error format
+              if (typeof meta.body.error === 'string') {
+                errorMessage += `: ${meta.body.error}`;
+              } else if (meta.body.error.reason) {
+                errorMessage += `: ${meta.body.error.reason}`;
+              }
+            }
+          }
+        }
+
         await updateKnowledgeSourceStatus(
           assistant,
           source.id,

--- a/packages/cdk/lib/create-tenant-stacks.ts
+++ b/packages/cdk/lib/create-tenant-stacks.ts
@@ -128,11 +128,13 @@ export const createTenantStacks = (app: cdk.App, params: TenantStackInput) => {
       removalPolicy: params.removalPolicy
         ? cdk.RemovalPolicy.DESTROY
         : cdk.RemovalPolicy.RETAIN,
+      tenantRoleArn: tenantIAMStack.tenantRole.role.roleArn,
     }
   );
 
-  // Add dependency to ensure VPC is created before OpenSearch
+  // Add dependencies to ensure IAM and VPC are created before OpenSearch
   tenantOpenSearchStack.addDependency(tenantVpcStack);
+  tenantOpenSearchStack.addDependency(tenantIAMStack);
 
   // Tenant PPTX Stack (optional)
   let tenantPptxStack;

--- a/packages/cdk/lib/stacks/tenant/tenant-iam-stack.ts
+++ b/packages/cdk/lib/stacks/tenant/tenant-iam-stack.ts
@@ -46,7 +46,7 @@ export class TenantIAMStack extends cdk.Stack {
   /**
    * The tenant role construct
    */
-  private readonly tenantRole: TenantRole;
+  public readonly tenantRole: TenantRole;
 
   /**
    * The tenant ID

--- a/packages/cdk/lib/stacks/tenant/tenant-opensearch-stack.ts
+++ b/packages/cdk/lib/stacks/tenant/tenant-opensearch-stack.ts
@@ -54,6 +54,12 @@ export interface TenantOpenSearchStackProps extends cdk.StackProps {
    * Removal policy for the domain
    */
   readonly removalPolicy: cdk.RemovalPolicy;
+
+  /**
+   * The tenant IAM role ARN for accessing OpenSearch
+   * This role is assumed by Lambda functions to access tenant-specific resources
+   */
+  readonly tenantRoleArn: string;
 }
 
 /**
@@ -212,11 +218,13 @@ export class TenantOpenSearchStack extends cdk.Stack {
       })
     );
 
-    // Grant access to the domain from CodeBuild role and Bedrock service
+    // Grant access to the domain from CodeBuild role, Tenant role, and Bedrock service
+    // Note: Tenant role is used by Lambda functions to access OpenSearch for assistant RAG functionality
     const accessPolicy = new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
       principals: [
         this.opensearchIndexCreationRole,
+        iam.ArnPrincipal.fromArnString(props.tenantRoleArn), // Add tenant role for Lambda access
         new iam.ServicePrincipal('bedrock.amazonaws.com'),
       ],
       actions: [

--- a/packages/cdk/lib/stacks/tenant/tenant-opensearch-stack.ts
+++ b/packages/cdk/lib/stacks/tenant/tenant-opensearch-stack.ts
@@ -224,7 +224,7 @@ export class TenantOpenSearchStack extends cdk.Stack {
       effect: iam.Effect.ALLOW,
       principals: [
         this.opensearchIndexCreationRole,
-        iam.ArnPrincipal.fromArnString(props.tenantRoleArn), // Add tenant role for Lambda access
+        new iam.ArnPrincipal(props.tenantRoleArn), // Add tenant role for Lambda access
         new iam.ServicePrincipal('bedrock.amazonaws.com'),
       ],
       actions: [


### PR DESCRIPTION
## 変更の概要

<!-- どのような変更を行ったかを書く -->

- Lambda 関数がテナントロールで OpenSearch にアクセス可能にした
- 他のスタックから`tenantRole.role.roleArn`を参照できるようにした
- IAM ロール作成後に OpenSearch ドメインをデプロイするように変更
- アシスタントのエラーハンドリングを改修

## 申し送り事項

<!-- レビュワーに伝えておきたい事柄等を書く（Draftの理由など） -->

## Checklist（レビュワー用）

- [ ] `npm run lint`でエラーが出ない
- [ ] TypeScript のビルドで型エラーが出ない
- [ ] 手元でフォーマットした際に差分が出ない
