### PR TITLE
:lock: DynamoDBの暗号化を明示的に指定

### DIFF
--- a/packages/cdk/lib/construct/database.ts
+++ b/packages/cdk/lib/construct/database.ts
@@ -24,6 +24,8 @@ export class Database extends Construct {
         type: ddb.AttributeType.STRING,
       },
       billingMode: ddb.BillingMode.PAY_PER_REQUEST,
+      encryption: ddb.TableEncryption.AWS_MANAGED,
+      removalPolicy: RemovalPolicy.DESTROY,
     });
 
     table.addGlobalSecondaryIndex({
@@ -45,6 +47,8 @@ export class Database extends Construct {
         type: ddb.AttributeType.STRING,
       },
       billingMode: ddb.BillingMode.PAY_PER_REQUEST,
+      encryption: ddb.TableEncryption.AWS_MANAGED,
+      removalPolicy: RemovalPolicy.DESTROY,
     });
 
     // Assistant table for storing assistant configurations
@@ -59,6 +63,7 @@ export class Database extends Construct {
         type: ddb.AttributeType.STRING,
       },
       billingMode: ddb.BillingMode.PAY_PER_REQUEST,
+      encryption: ddb.TableEncryption.AWS_MANAGED,
       pointInTimeRecovery: true,
       removalPolicy: RemovalPolicy.DESTROY,
     });
@@ -83,6 +88,7 @@ export class Database extends Construct {
         type: ddb.AttributeType.STRING,
       },
       billingMode: ddb.BillingMode.PAY_PER_REQUEST,
+      encryption: ddb.TableEncryption.AWS_MANAGED,
       pointInTimeRecovery: true,
       removalPolicy: RemovalPolicy.DESTROY,
     });

--- a/packages/cdk/lib/construct/tenant-dynamodb.ts
+++ b/packages/cdk/lib/construct/tenant-dynamodb.ts
@@ -148,6 +148,7 @@ export class TenantDynamoDB extends Construct {
         type: dynamodb.AttributeType.STRING,
       },
       billingMode: props.billingMode || dynamodb.BillingMode.PAY_PER_REQUEST,
+      encryption: dynamodb.TableEncryption.AWS_MANAGED,
       removalPolicy: removalPolicy,
     });
 
@@ -179,6 +180,7 @@ export class TenantDynamoDB extends Construct {
           type: dynamodb.AttributeType.STRING,
         },
         billingMode: props.billingMode || dynamodb.BillingMode.PAY_PER_REQUEST,
+        encryption: dynamodb.TableEncryption.AWS_MANAGED,
         removalPolicy: removalPolicy,
       }
     );
@@ -212,6 +214,7 @@ export class TenantDynamoDB extends Construct {
         type: dynamodb.AttributeType.STRING,
       },
       billingMode: props.billingMode || dynamodb.BillingMode.PAY_PER_REQUEST,
+      encryption: dynamodb.TableEncryption.AWS_MANAGED,
       removalPolicy: removalPolicy,
     });
 
@@ -245,6 +248,7 @@ export class TenantDynamoDB extends Construct {
         type: dynamodb.AttributeType.STRING,
       },
       billingMode: props.billingMode || dynamodb.BillingMode.PAY_PER_REQUEST,
+      encryption: dynamodb.TableEncryption.AWS_MANAGED,
       pointInTimeRecovery: true,
       removalPolicy: removalPolicy,
     });
@@ -278,6 +282,7 @@ export class TenantDynamoDB extends Construct {
           type: dynamodb.AttributeType.STRING,
         },
         billingMode: props.billingMode || dynamodb.BillingMode.PAY_PER_REQUEST,
+        encryption: dynamodb.TableEncryption.AWS_MANAGED,
         pointInTimeRecovery: true,
         removalPolicy: removalPolicy,
       }
@@ -384,6 +389,7 @@ export class TenantDynamoDB extends Construct {
       partitionKey,
       sortKey,
       billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      encryption: dynamodb.TableEncryption.AWS_MANAGED,
       removalPolicy: removalPolicy,
     });
 

--- a/packages/cdk/lib/construct/use-case-builder.ts
+++ b/packages/cdk/lib/construct/use-case-builder.ts
@@ -40,6 +40,7 @@ export class UseCaseBuilder extends Construct {
         type: ddb.AttributeType.STRING,
       },
       billingMode: ddb.BillingMode.PAY_PER_REQUEST,
+      encryption: ddb.TableEncryption.AWS_MANAGED,
     });
 
     useCaseBuilderTable.addGlobalSecondaryIndex({


### PR DESCRIPTION
## 変更の概要

<!-- どのような変更を行ったかを書く -->

- DynamoDB テーブルの作成時に暗号化設定が明示的に指定されていなかったので、明示的に指定するように変更しました。

## 申し送り事項

<!-- レビュワーに伝えておきたい事柄等を書く（Draftの理由など） -->

## Checklist（レビュワー用）

- [ ] `npm run lint`でエラーが出ない
- [ ] TypeScript のビルドで型エラーが出ない
- [ ] 手元でフォーマットした際に差分が出ない
