### PR TITLE
:ambulance: 不要なDynamoDBのremovalPolicyを削除

### DIFF
--- a/packages/cdk/lib/construct/database.ts
+++ b/packages/cdk/lib/construct/database.ts
@@ -1,6 +1,5 @@
 import { Construct } from 'constructs';
 import * as ddb from 'aws-cdk-lib/aws-dynamodb';
-import { RemovalPolicy } from 'aws-cdk-lib';
 
 export class Database extends Construct {
   public readonly table: ddb.Table;
@@ -25,7 +24,6 @@ export class Database extends Construct {
       },
       billingMode: ddb.BillingMode.PAY_PER_REQUEST,
       encryption: ddb.TableEncryption.AWS_MANAGED,
-      removalPolicy: RemovalPolicy.DESTROY,
     });
 
     table.addGlobalSecondaryIndex({
@@ -48,7 +46,6 @@ export class Database extends Construct {
       },
       billingMode: ddb.BillingMode.PAY_PER_REQUEST,
       encryption: ddb.TableEncryption.AWS_MANAGED,
-      removalPolicy: RemovalPolicy.DESTROY,
     });
 
     // Assistant table for storing assistant configurations
@@ -65,7 +62,6 @@ export class Database extends Construct {
       billingMode: ddb.BillingMode.PAY_PER_REQUEST,
       encryption: ddb.TableEncryption.AWS_MANAGED,
       pointInTimeRecovery: true,
-      removalPolicy: RemovalPolicy.DESTROY,
     });
 
     assistantTable.addGlobalSecondaryIndex({
@@ -90,7 +86,6 @@ export class Database extends Construct {
       billingMode: ddb.BillingMode.PAY_PER_REQUEST,
       encryption: ddb.TableEncryption.AWS_MANAGED,
       pointInTimeRecovery: true,
-      removalPolicy: RemovalPolicy.DESTROY,
     });
 
     this.table = table;


### PR DESCRIPTION
## 変更の概要

<!-- どのような変更を行ったかを書く -->

- [先程の PR](https://github.com/fixer-github/generative-ai-use-cases/pull/128)の[Codex のレビュー](https://github.com/fixer-github/generative-ai-use-cases/pull/128#pullrequestreview-3451871357)に気になる指摘があったので、修正しました。
  - 内容：DynamoDB の`removalPolicy`が`DESTROY`に設定されているが、これは関係のない設定なので削除すべき

## 申し送り事項

<!-- レビュワーに伝えておきたい事柄等を書く（Draftの理由など） -->

## Checklist（レビュワー用）

- [ ] `npm run lint`でエラーが出ない
- [ ] TypeScript のビルドで型エラーが出ない
- [ ] 手元でフォーマットした際に差分が出ない
