### PR TITLE
:lock: fix(assistant): アシスタント会話におけるIDOR脆弱性を修正

### DIFF
--- a/packages/cdk/lambda/assistantMessageHandler.ts
+++ b/packages/cdk/lambda/assistantMessageHandler.ts
@@ -341,7 +341,7 @@ async function handleListMessages(
     ? parseInt(event.queryStringParameters.limit)
     : undefined;
 
-  const result = await listMessages(assistantId, event, exclusiveStartKey, limit);
+  const result = await listMessages(assistantId, userId, event, exclusiveStartKey, limit);
 
   // Strip prefix from all messages
   const sanitizedResult: ListAssistantMessagesResponse = {

--- a/packages/cdk/lambda/repository/assistantMessage.ts
+++ b/packages/cdk/lambda/repository/assistantMessage.ts
@@ -55,6 +55,7 @@ export const createMessage = async (
 
 export const listMessages = async (
   _assistantId: string,
+  userId: string,
   event: APIGatewayProxyEvent,
   _exclusiveStartKey?: string,
   limit?: number
@@ -71,11 +72,14 @@ export const listMessages = async (
     new QueryCommand({
       TableName: tableName,
       KeyConditionExpression: '#assistantId = :assistantId',
+      FilterExpression: '#userId = :userId',
       ExpressionAttributeNames: {
         '#assistantId': 'assistantId',
+        '#userId': 'userId',
       },
       ExpressionAttributeValues: {
         ':assistantId': assistantId,
+        ':userId': userId,
       },
       ScanIndexForward: false,
       Limit: limit || 100,


### PR DESCRIPTION
## 変更の概要

アシスタント機能において、**他ユーザーの会話が閲覧可能なIDOR（Insecure Direct Object Reference）脆弱性**を修正しました。

### 🔴 脆弱性の詳細

**深刻度**: Critical（緊急）

**問題点**:
- `listMessages`関数が`assistantId`のみでクエリを実行していたため、同じアシスタントを使用する全ユーザーの会話が返されていました
- ユーザーAとユーザーBが同じアシスタントを使用している場合、ユーザーAがユーザーBの会話を閲覧できる状態でした
- 認証されたユーザーであれば、誰でも他ユーザーの機密情報を含む会話履歴にアクセス可能でした

### ✅ 修正内容

**修正方針**: 
DynamoDBクエリに`userId`フィルタを追加し、ユーザー自身の会話のみを返すよう修正

**変更ファイル**:
1. **packages/cdk/lambda/repository/assistantMessage.ts**
   - `listMessages`関数に`userId`パラメータを追加
   - DynamoDBクエリに`FilterExpression: '#userId = :userId'`を追加
   - ユーザー自身のメッセージのみをフィルタリング

2. **packages/cdk/lambda/assistantMessageHandler.ts**
   - `listMessages`関数呼び出し時に認証済みユーザーIDを渡すよう修正
   - `await listMessages(assistantId, userId, event, exclusiveStartKey, limit)`

### 🔒 セキュリティ影響

- ✅ **修正前**: 他ユーザーの会話が閲覧可能（IDOR脆弱性）
- ✅ **修正後**: ユーザーは自分の会話のみアクセス可能
- ✅ **影響範囲**: アシスタント機能のメッセージ取得API全体
- ✅ **スキーマ変更**: 不要（既存のテーブル構造で対応可能）

### 📋 技術的詳細

**修正前のクエリ**:
```typescript
KeyConditionExpression: '#assistantId = :assistantId',
ExpressionAttributeValues: {
  ':assistantId': assistantId,
}
```

**修正後のクエリ**:
```typescript
KeyConditionExpression: '#assistantId = :assistantId',
FilterExpression: '#userId = :userId',  // ← 追加
ExpressionAttributeNames: {
  '#assistantId': 'assistantId',
  '#userId': 'userId',  // ← 追加
},
ExpressionAttributeValues: {
  ':assistantId': assistantId,
  ':userId': userId,  // ← 追加
}
```

### 🎯 関連Issue

この修正により、アシスタント機能における重大なプライバシー侵害の可能性を完全に排除しました。

## 申し送り事項

- **緊急性**: このPRは重大なセキュリティ脆弱性の修正のため、最優先でマージを推奨します
- **デプロイ**: スキーマ変更は不要なため、即座にデプロイ可能です
- **後方互換性**: 既存のデータ構造を活用するため、後方互換性は保たれます
- **パフォーマンス**: `FilterExpression`使用によるわずかなパフォーマンス影響がありますが、セキュリティを優先しました
  - 今後、より効率的なクエリのために`userId`をパーティションキーとするGSIの追加を検討することを推奨します

## Checklist（レビュワー用）

- [x] `npm run lint`でエラーが出ない
- [x] TypeScriptのビルドで型エラーが出ない
- [x] 手元でフォーマットした際に差分が出ない
- [x] セキュリティ脆弱性が完全に修正されている
- [x] 認証されたユーザー自身の会話のみがアクセス可能になっている