### PR TITLE
:bug: fix(api): チャット未存在時に404を返却

### DIFF
--- a/packages/cdk/lambda/createMessages.ts
+++ b/packages/cdk/lambda/createMessages.ts
@@ -9,8 +9,8 @@ import {
 import { getTenant } from './tenantManager';
 import {
   badRequest400Response,
-  forbidden403Response,
   internalServerError500Response,
+  notFound404Response,
   ok200Response,
 } from './utils/apiResponse';
 
@@ -37,8 +37,8 @@ export const handler = async (
     // Authorization check: Verify if the specified chat belongs to the user
     const chat = await findChatById(userId, chatId, event);
     if (chat === null) {
-      return forbidden403Response({
-        message: 'You do not have permission to post messages in the chat.',
+      return notFound404Response({
+        message: 'Chat not found',
       });
     }
 

--- a/packages/cdk/lambda/createShareId.ts
+++ b/packages/cdk/lambda/createShareId.ts
@@ -2,8 +2,8 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { createShareId, findChatById } from './repository';
 import { getUsername } from './utils/tenantUtils';
 import {
-  forbidden403Response,
   internalServerError500Response,
+  notFound404Response,
   ok200Response,
 } from './utils/apiResponse';
 
@@ -17,8 +17,8 @@ export const handler = async (
     // Authorization check: Verify if the specified chat belongs to the user
     const chat = await findChatById(userId, chatId, event);
     if (chat === null) {
-      return forbidden403Response({
-        message: 'You do not have permission to share this chat.',
+      return notFound404Response({
+        message: 'Chat not found',
       });
     }
 

--- a/packages/cdk/lambda/listMessages.ts
+++ b/packages/cdk/lambda/listMessages.ts
@@ -2,8 +2,8 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { findChatById, listMessages } from './repository';
 import { getUsername } from './utils/tenantUtils';
 import {
-  forbidden403Response,
   internalServerError500Response,
+  notFound404Response,
   ok200Response,
 } from './utils/apiResponse';
 
@@ -16,7 +16,7 @@ export const handler = async (
     const chat = await findChatById(userId, chatId, event);
 
     if (chat === null) {
-      return forbidden403Response({ message: 'Forbidden' });
+      return notFound404Response({ message: 'Chat not found' });
     }
 
     const messages = await listMessages(chatId, event);


### PR DESCRIPTION
## 📋 変更概要

存在しないチャットIDへのアクセス時のHTTPステータスコードを403 (Forbidden)から404 (Not Found)に変更し、RESTful APIの適切なセマンティクスに準拠しました。

## 🏗️ アーキテクチャ変更

```
変更前:                                   変更後:
┌─────────────────┐                      ┌─────────────────┐
│  API Gateway    │                      │  API Gateway    │
└────────┬────────┘                      └────────┬────────┘
         │                                        │
         ▼                                        ▼
┌─────────────────┐                      ┌─────────────────┐
│ Lambda Handler  │                      │ Lambda Handler  │
└────────┬────────┘                      └────────┬────────┘
         │                                        │
         ▼                                        ▼
┌─────────────────┐                      ┌─────────────────┐
│  findChatById   │                      │  findChatById   │
└────────┬────────┘                      └────────┬────────┘
         │                                        │
         ▼                                        ▼
    chat == null?                            chat == null?
         │                                        │
         ├─ Yes                                   ├─ Yes
         │   └─> 403 Forbidden ❌                 │   └─> 404 Not Found ✅
         │                                        │
         └─ No                                    └─ No
             └─> Continue...                          └─> Continue...
```

**変更の理由:**
- 403 Forbiddenは「認証済みだが権限不足」を示すステータスコード
- リソースが存在しない場合は404 Not Foundが適切
- RESTful APIのベストプラクティスに準拠

**影響:**
- クライアント側でエラーハンドリングの精度が向上
- セキュリティ上の情報漏洩リスクを軽減(リソースの有無を認証前に露呈しない)

## 📊 変更内容詳細

### 変更 🔄

#### **packages/cdk/lambda/createMessages.ts** (+3/-3 行)
- **変更前:** 
  - `forbidden403Response()` を使用
  - メッセージ: "You do not have permission to post messages in the chat."
- **変更後:** 
  - `notFound404Response()` を使用
  - メッセージ: "Chat not found"
- **理由:** チャットが存在しない場合、権限の問題ではなくリソース未検出として扱うべき
- **影響:** メッセージ投稿API (`POST /messages`) が404を返却

#### **packages/cdk/lambda/createShareId.ts** (+3/-3 行)
- **変更前:** 
  - `forbidden403Response()` を使用
  - メッセージ: "You do not have permission to share this chat."
- **変更後:** 
  - `notFound404Response()` を使用
  - メッセージ: "Chat not found"
- **理由:** 共有対象のチャットが存在しない場合、権限の問題ではなくリソース未検出として扱うべき
- **影響:** 共有ID生成API (`POST /share`) が404を返却

#### **packages/cdk/lambda/listMessages.ts** (+2/-2 行)
- **変更前:** 
  - `forbidden403Response()` を使用
  - メッセージ: "Forbidden"
- **変更後:** 
  - `notFound404Response()` を使用
  - メッセージ: "Chat not found"
- **理由:** メッセージ一覧取得時にチャットが存在しない場合、権限の問題ではなくリソース未検出として扱うべき
- **影響:** メッセージ一覧取得API (`GET /messages`) が404を返却

## 🔀 データフロー変更

```
リクエストフロー: (変更なし)
[Client] ──> [API Gateway] ──> [Lambda] ──> [DynamoDB]
   │                                │
   │                                ▼
   │                         findChatById()
   │                                │
   ▼                                ▼
変更前: 403 Forbidden          変更後: 404 Not Found
   (chat not found)              (chat not found)
```

## 🔗 依存関係の変更

```
各Lambda関数:
┌──────────────────────┐
│ createMessages.ts    │
│ createShareId.ts     │
│ listMessages.ts      │
└──────────┬───────────┘
           │
           │ import変更
           ▼
┌──────────────────────┐
│ utils/apiResponse.ts │
├──────────────────────┤
│ - forbidden403       │◄── 削除
│ + notFound404        │◄── 追加
└──────────────────────┘
```

### 削除された依存
- `forbidden403Response` - 理由: 不適切なセマンティクスのため使用中止

### 追加された依存
- `notFound404Response` - 理由: RESTful APIの適切なステータスコードを返却

## 🧪 テスト

- [ ] 単体テスト: 既存のテストで403→404のステータスコード変更を確認
- [ ] 統合テスト: 存在しないチャットIDへのアクセスで404が返ることを確認
- [ ] E2Eテスト: フロントエンドのエラーハンドリングが正常に動作することを確認

## ⚠️ 破壊的変更

**あり**

APIレスポンスのステータスコードが変更されるため、クライアント側で403に依存している処理がある場合は修正が必要です。

**影響範囲:**
- `POST /chats/{chatId}/messages` - 403 → 404
- `POST /chats/{chatId}/share` - 403 → 404
- `GET /chats/{chatId}/messages` - 403 → 404

**移行ガイド:**
フロントエンドのエラーハンドリングで、チャット未存在を検出する際は403ではなく404をチェックしてください。

## 📝 注意事項

1. **セマンティクスの正確性**: この変更により、HTTPステータスコードがリソースの状態を正しく表現するようになります
2. **セキュリティ向上**: 認証前にリソースの有無を推測しにくくなります
3. **フロントエンド対応**: エラーメッセージも簡潔な"Chat not found"に統一されています
4. **一貫性**: 3つのLambda関数すべてで同じエラーハンドリングパターンを適用しています

## 🔗 関連Issue

(関連Issueがあれば記載してください)