### PR TITLE
🚨 ESLintの`un-def`系の警告を消した

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -34,7 +34,6 @@ module.exports = defineConfig([
       '@typescript-eslint/no-namespace': 'off',
       'i18nhelper/no-jp-string': 'warn',
       'i18nhelper/no-jp-comment': 'warn',
-      'no-undef': 'off',
     },
   },
   // For web
@@ -81,7 +80,6 @@ module.exports = defineConfig([
       'i18nhelper/no-jp-string': 'warn',
       'i18nhelper/no-jp-comment': 'warn',
       '@shopify/jsx-no-hardcoded-content': 'warn',
-      'no-undef': 'off',
     },
   },
   // For yaml files
@@ -107,6 +105,14 @@ module.exports = defineConfig([
     },
     rules: {
       '@typescript-eslint/no-unused-vars': 'off',
+    },
+    languageOptions: {
+      globals: {
+        console: 'readonly',
+        fetch: 'readonly',
+        crypto: 'readonly',
+        process: 'readonly',
+      },
     },
   },
   {

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -34,6 +34,7 @@ module.exports = defineConfig([
       '@typescript-eslint/no-namespace': 'off',
       'i18nhelper/no-jp-string': 'warn',
       'i18nhelper/no-jp-comment': 'warn',
+      'no-undef': 'off',
     },
   },
   // For web
@@ -80,6 +81,7 @@ module.exports = defineConfig([
       'i18nhelper/no-jp-string': 'warn',
       'i18nhelper/no-jp-comment': 'warn',
       '@shopify/jsx-no-hardcoded-content': 'warn',
+      'no-undef': 'off',
     },
   },
   // For yaml files

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@typescript-eslint/eslint-plugin": "8.44.0",
         "@typescript-eslint/parser": "8.44.0",
         "eslint": "9.35.0",
+        "eslint-import-resolver-node": "0.3.9",
         "eslint-plugin-i18nhelper": "1.0.0",
         "eslint-plugin-react-hooks": "5.2.0",
         "eslint-plugin-react-refresh": "0.4.20",
@@ -24068,6 +24069,49 @@
         "unrs-resolver": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-import-resolver-node": {
+      "version": "0.3.9",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.9.tgz",
+      "integrity": "sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.2.7",
+        "is-core-module": "^2.13.0",
+        "resolve": "^1.22.4"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-import-resolver-node/node_modules/resolve": {
+      "version": "1.22.11",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
+      "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-core-module": "^2.16.1",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/eslint-import-resolver-typescript": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@typescript-eslint/eslint-plugin": "8.44.0",
     "@typescript-eslint/parser": "8.44.0",
     "eslint": "9.35.0",
+    "eslint-import-resolver-node": "0.3.9",
     "eslint-plugin-i18nhelper": "1.0.0",
     "eslint-plugin-react-hooks": "5.2.0",
     "eslint-plugin-react-refresh": "0.4.20",


### PR DESCRIPTION
## 変更の概要

<!-- どのような変更を行ったかを書く -->
- `console`や`fetch`など、Node.jsやブラウザの標準モジュールがimportされておらず、ESLintがエラーを吐いてくるのが煩わしかったのでoffにしました

## 申し送り事項

<!-- レビュワーに伝えておきたい事柄等を書く（Draftの理由など） -->

## Checklist（レビュワー用）

- [ ] `npm run lint`でエラーが出ない
- [ ] TypeScriptのビルドで型エラーが出ない
- [ ] 手元でフォーマットした際に差分が出ない
