### PR TITLE
:recycle: refactor(assistant): Bedrock/LiteLLM統合によるマルチモデル対応

### DIFF
--- a/packages/cdk/lambda/assistantMessageHandler.ts
+++ b/packages/cdk/lambda/assistantMessageHandler.ts
@@ -266,11 +266,22 @@ async function handleCreateMessage(
     ? `${assistant.instruction}\n\nRelevant context from documents:\n${ragContext}`
     : assistant.instruction;
 
-  // Determine model type: if modelId exists in modelMetadata → bedrock, else → liteLlm
-  const modelType = modelMetadata[assistant.modelId] ? 'bedrock' : 'liteLlm';
+  // Determine model type:
+  // - If modelId exists in modelMetadata → bedrock
+  // - If modelId starts with 'openai:' → liteLlm (strip prefix, use LiteLLM proxy which has API keys)
+  // - Otherwise → liteLlm
+  const isOpenAiPrefixed = assistant.modelId.startsWith('openai:');
+  const modelType: 'bedrock' | 'liteLlm' = modelMetadata[assistant.modelId]
+    ? 'bedrock'
+    : 'liteLlm';
+
+  // For openai: prefixed models, strip the prefix since LiteLLM config uses bare model names
+  const effectiveModelId = isOpenAiPrefixed
+    ? assistant.modelId.replace('openai:', '')
+    : assistant.modelId;
 
   const model: Model = {
-    modelId: assistant.modelId,
+    modelId: effectiveModelId,
     type: modelType,
     ...(modelType === 'bedrock' && {
       region: process.env.MODEL_REGION || 'us-east-1',
@@ -278,7 +289,7 @@ async function handleCreateMessage(
   };
 
   console.log(
-    `Using ${modelType} model: ${assistant.modelId} for assistant chat`
+    `Using ${modelType} model: ${effectiveModelId} (original: ${assistant.modelId}) for assistant chat`
   );
 
   // Call LLM with assistant configuration
@@ -321,7 +332,7 @@ async function handleCreateMessage(
       totalTokens: response.usage?.totalTokens || 0,
     };
   } else {
-    // Use LiteLLM API
+    // Use LiteLLM or LangChain API
     const messages = [
       {
         role: 'system' as const,
@@ -333,13 +344,10 @@ async function handleCreateMessage(
       },
     ];
 
-    assistantResponse = await api.liteLlm.invoke(
-      model,
-      messages,
-      cleanChatId
-    );
+    // Route to LiteLLM API (handles both native LiteLLM models and openai: prefixed models)
+    assistantResponse = await api.liteLlm.invoke(model, messages, cleanChatId);
 
-    // LiteLLM doesn't provide detailed usage stats in non-streaming mode
+    // LiteLLM/LangChain don't provide detailed usage stats in non-streaming mode
     // Set basic usage info
     usage = {
       inputTokens: 0,

--- a/packages/cdk/lambda/assistantMessageHandler.ts
+++ b/packages/cdk/lambda/assistantMessageHandler.ts
@@ -13,6 +13,7 @@ import {
   AssistantMessage,
   AssistantMessageSource,
   ListAssistantMessagesResponse,
+  Model,
 } from 'generative-ai-use-cases';
 import {
   BedrockRuntimeClient,
@@ -29,6 +30,8 @@ import {
   notFound404Response,
   ok200Response,
 } from './utils/apiResponse';
+import api from './utils/api';
+import { modelMetadata } from '@generative-ai-use-cases/common';
 
 const bedrockClient = new BedrockRuntimeClient({
   region: process.env.MODEL_REGION || process.env.AWS_REGION,
@@ -263,36 +266,87 @@ async function handleCreateMessage(
     ? `${assistant.instruction}\n\nRelevant context from documents:\n${ragContext}`
     : assistant.instruction;
 
-  // Call Bedrock with assistant configuration
-  const response = await bedrockClient.send(
-    new ConverseCommand({
-      modelId: assistant.modelId,
-      messages: [
-        {
-          role: 'user',
-          content: [
-            {
-              text: body.content,
-            },
-          ],
-        },
-      ],
-      system: [
-        {
-          text: systemMessage,
-        },
-      ],
-    })
+  // Determine model type: if modelId exists in modelMetadata → bedrock, else → liteLlm
+  const modelType = modelMetadata[assistant.modelId] ? 'bedrock' : 'liteLlm';
+
+  const model: Model = {
+    modelId: assistant.modelId,
+    type: modelType,
+    ...(modelType === 'bedrock' && {
+      region: process.env.MODEL_REGION || 'us-east-1',
+    }),
+  };
+
+  console.log(
+    `Using ${modelType} model: ${assistant.modelId} for assistant chat`
   );
 
-  const assistantResponse =
-    response.output?.message?.content?.[0]?.text || 'No response';
-
-  const usage = {
-    inputTokens: response.usage?.inputTokens || 0,
-    outputTokens: response.usage?.outputTokens || 0,
-    totalTokens: response.usage?.totalTokens || 0,
+  // Call LLM with assistant configuration
+  let assistantResponse = '';
+  let usage = {
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
   };
+
+  if (modelType === 'bedrock') {
+    // Use Bedrock API
+    const response = await bedrockClient.send(
+      new ConverseCommand({
+        modelId: assistant.modelId,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                text: body.content,
+              },
+            ],
+          },
+        ],
+        system: [
+          {
+            text: systemMessage,
+          },
+        ],
+      })
+    );
+
+    assistantResponse =
+      response.output?.message?.content?.[0]?.text || 'No response';
+
+    usage = {
+      inputTokens: response.usage?.inputTokens || 0,
+      outputTokens: response.usage?.outputTokens || 0,
+      totalTokens: response.usage?.totalTokens || 0,
+    };
+  } else {
+    // Use LiteLLM API
+    const messages = [
+      {
+        role: 'system' as const,
+        content: systemMessage,
+      },
+      {
+        role: 'user' as const,
+        content: body.content,
+      },
+    ];
+
+    assistantResponse = await api.liteLlm.invoke(
+      model,
+      messages,
+      cleanChatId
+    );
+
+    // LiteLLM doesn't provide detailed usage stats in non-streaming mode
+    // Set basic usage info
+    usage = {
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+    };
+  }
 
   // Store assistant response with sources
   const assistantMessage = await createAssistantMessage(

--- a/packages/cdk/lib/construct/api/assistant.ts
+++ b/packages/cdk/lib/construct/api/assistant.ts
@@ -87,9 +87,19 @@ class AssistantApi extends Construct {
           ASSISTANT_TABLE_NAME: ASSISTANT_TABLE_PREFIX,
           DEFAULT_ASSISTANT_TABLE_NAME: assistantTable.tableName,
           MODEL_REGION: props.modelRegion,
+          MODEL_IDS: JSON.stringify(props.modelIds),
+          IMAGE_GENERATION_MODEL_IDS: JSON.stringify(
+            props.imageGenerationModelIds
+          ),
+          VIDEO_GENERATION_MODEL_IDS: JSON.stringify(
+            props.videoGenerationModelIds
+          ),
           OPENSEARCH_INDEX: 'assistant-docs',
           TENANTS_TABLE_NAME: tenantManager?.tenantsTable.tableName || '',
           LITELLM_ENDPOINT: props.litellmEndpoint ?? '',
+          ...(props.openai?.apiKey
+            ? { OPENAI_API_KEY: props.openai.apiKey }
+            : {}),
         }),
       }
     );

--- a/packages/cdk/lib/construct/api/assistant.ts
+++ b/packages/cdk/lib/construct/api/assistant.ts
@@ -89,6 +89,7 @@ class AssistantApi extends Construct {
           MODEL_REGION: props.modelRegion,
           OPENSEARCH_INDEX: 'assistant-docs',
           TENANTS_TABLE_NAME: tenantManager?.tenantsTable.tableName || '',
+          LITELLM_ENDPOINT: props.litellmEndpoint ?? '',
         }),
       }
     );
@@ -229,6 +230,11 @@ class AssistantApi extends Construct {
     if (tenantManager) {
       tenantManager.tenantsTable.grantReadData(assistantHandler);
       tenantManager.tenantsTable.grantReadData(assistantMessageHandler);
+    }
+
+    // Grant LiteLLM proxy invocation permissions
+    if (props.litellmProxy) {
+      props.litellmProxy.grantInvokeUrl(assistantMessageHandler);
     }
 
     // TODO: Add OpenSearch permissions when BotStore is integrated

--- a/packages/cdk/lib/stacks/common/assistant-api-stack.ts
+++ b/packages/cdk/lib/stacks/common/assistant-api-stack.ts
@@ -11,6 +11,7 @@ import {
   CognitoUserPoolsAuthorizer,
 } from 'aws-cdk-lib/aws-apigateway';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+import { LitellmProxyServer } from '../../construct/litellm-proxy-server';
 
 interface AssistantApiStackProps extends StackProps {
   params: ProcessedStackInput;
@@ -23,6 +24,8 @@ interface AssistantApiStackProps extends StackProps {
   videoBucketRegionMap?: Record<string, string>;
   guardrailIdentifier?: string;
   guardrailVersion?: string;
+  litellmEndpoint?: string | null;
+  litellmProxy?: LitellmProxyServer | null;
 }
 
 class AssistantApiStack extends NestedStack {
@@ -42,6 +45,8 @@ class AssistantApiStack extends NestedStack {
       videoBucketRegionMap,
       guardrailIdentifier,
       guardrailVersion,
+      litellmEndpoint,
+      litellmProxy,
     } = props;
 
     // Create authorizer for the nested stack
@@ -75,8 +80,8 @@ class AssistantApiStack extends NestedStack {
       crossAccountBedrockRoleArn: params.crossAccountBedrockRoleArn,
       allowedIpV4AddressRanges: params.allowedIpV4AddressRanges,
       allowedIpV6AddressRanges: params.allowedIpV6AddressRanges,
-      litellmEndpoint: null,
-      litellmProxy: null,
+      litellmEndpoint: litellmEndpoint ?? null,
+      litellmProxy: litellmProxy ?? null,
       environment: params.env,
       selfSignUpTenantMap: params.selfSignUpTenantMap,
 

--- a/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
@@ -184,6 +184,8 @@ export class GenerativeAiUseCasesStack extends Stack {
       videoBucketRegionMap: props.videoBucketRegionMap,
       guardrailIdentifier: props.guardrailIdentifier,
       guardrailVersion: props.guardrailVersion,
+      litellmEndpoint: litellmEndpoint,
+      litellmProxy: litellmProxy,
     });
 
     // MCP


### PR DESCRIPTION
## 📋 変更概要

アシスタント機能において、Bedrock専用の実装からBedrockとLiteLLMの両方に対応する統合実装にリファクタリングし、柔軟なモデル選択を可能にしました。

## 🏗️ アーキテクチャ変更

```
変更前:                                    変更後:
┌──────────────────┐                      ┌──────────────────┐
│  Assistant API   │                      │  Assistant API   │
└────────┬─────────┘                      └────────┬─────────┘
         │                                          │
         │ modelId                                  │ modelId
         ▼                                          ▼
┌──────────────────┐                      ┌──────────────────┐
│  Bedrock Client  │                      │  Model Router    │◄── 新規追加
└──────────────────┘                      └────────┬─────────┘
         │                                          │
         │                               ┌─────────┴──────────┐
         ▼                               ▼                    ▼
┌──────────────────┐              ┌────────────┐     ┌────────────┐
│  Converse API    │              │  Bedrock   │     │  LiteLLM   │
└──────────────────┘              │  Client    │     │  API       │
                                  └────────────┘     └────────────┘
```

モデルタイプの自動判定ロジックを追加し、`modelMetadata`の存在チェックによりBedrockモデルとLiteLLMモデルを動的に振り分ける仕組みを実装しました。これにより、単一のAPIエンドポイントで複数のモデルプロバイダーに対応できるようになりました。

## 📊 変更内容詳細

### 変更 🔄
- **packages/cdk/lambda/assistantMessageHandler.ts** (+81/-27 行)
  
  **追加されたインポート:**
  - \`Model\` 型定義 (generative-ai-use-cases)
  - \`api\` ユーティリティ (./utils/api)
  - \`modelMetadata\` (common パッケージ)
  
  **変更前:**
  - Bedrock専用の直接的な実装
  - \`bedrockClient.send(new ConverseCommand(...))\`を直接呼び出し
  - モデルタイプの判定なし
  
  **変更後:**
  - モデルタイプの動的判定ロジック追加
    \`\`\`typescript
    const modelType = modelMetadata[assistant.modelId] ? 'bedrock' : 'liteLlm';
    \`\`\`
  - Bedrock/LiteLLMの分岐処理を実装
  - \`Model\`オブジェクトの構築により型安全性を確保
  - LiteLLM用のメッセージ形式変換を追加
  
  **理由:**
  - 複数のLLMプロバイダーに対応することで、モデル選択の柔軟性を向上
  - 既存のBedrockモデルとの後方互換性を維持しつつ、新しいモデルへの拡張を容易に
  - コードの保守性向上(モデルプロバイダーごとの分岐が明確)
  
  **影響:**
  - Bedrockモデルを使用する既存のアシスタントは引き続き動作
  - LiteLLM経由でOpenAI、Anthropic等の外部モデルが使用可能に
  - usage統計の取得方法がモデルタイプにより異なる(LiteLLMでは現在0として設定)

## 🔀 データフロー変更

```
リクエストフロー:
                                    ┌──────────────┐
                                    │   Request    │
                                    └──────┬───────┘
                                           │
                                           ▼
                              ┌────────────────────────┐
                              │ handleCreateMessage    │
                              └────────────┬───────────┘
                                           │
                                           ▼
                              ┌────────────────────────┐
                              │ Model Type Detection   │◄── modelMetadata check
                              └──────┬────────┬────────┘
                                     │        │
                   ┌─────────────────┘        └─────────────────┐
                   ▼                                            ▼
          ┌────────────────┐                         ┌────────────────┐
          │ Bedrock Branch │                         │ LiteLLM Branch │
          └────────┬───────┘                         └────────┬───────┘
                   │                                           │
                   │ ConverseCommand                           │ api.liteLlm.invoke
                   ▼                                           ▼
          ┌────────────────┐                         ┌────────────────┐
          │ Bedrock API    │                         │ LiteLLM Proxy  │
          └────────┬───────┘                         └────────┬───────┘
                   │                                           │
                   └───────────────┬───────────────────────────┘
                                   │
                                   ▼
                        ┌──────────────────┐
                        │ assistantResponse │
                        └──────────┬───────┘
                                   │
                                   ▼
                        ┌──────────────────┐
                        │ DynamoDB Storage │
                        └──────────────────┘
```

## 🔗 依存関係の変更

```
新規依存:
┌─────────────────────┐
│ assistantMessage    │
│    Handler.ts       │
└──────┬──────────────┘
       │
       ├─────> api.liteLlm.invoke (新規)
       │
       └─────> modelMetadata (新規)
               (@generative-ai-use-cases/common)
```

### 追加された依存
- **api.liteLlm.invoke** - LiteLLMプロキシ経由でのLLM呼び出しを提供
- **modelMetadata** - Bedrockモデルのメタデータ辞書(モデルタイプ判定に使用)

## 🧪 テスト

- [ ] 単体テスト: Bedrock/LiteLLM分岐ロジックのテストが必要
- [ ] 統合テスト: 実際のBedrockモデルおよびLiteLLMモデルでの動作確認が必要
- [ ] E2Eテスト: アシスタント会話フロー全体の検証が必要

## ⚠️ 破壊的変更

なし - Bedrockモデルの動作は既存と同等に保たれています

## 📝 注意事項

1. **LiteLLMのusage統計について**
   - 現在の実装では、LiteLLMモード時のusage統計は0として記録されます
   - 将来的にLiteLLM APIのレスポンスからusage情報を取得する改善が必要です

2. **モデルタイプ判定ロジック**
   - \`modelMetadata\`に存在するモデル→Bedrock
   - 存在しないモデル→LiteLLM
   - この判定ロジックが正しく機能するため、\`modelMetadata\`の最新性が重要です

3. **環境変数**
   - \`MODEL_REGION\`がBedrockモデル使用時に参照されます
   - LiteLLM使用時は不要ですが、設定されていても問題ありません

4. **エラーハンドリング**
   - 現在の実装では、LiteLLM接続エラー時の詳細なエラーハンドリングが不足している可能性があります
   - プロダクション環境では追加のエラー処理を検討してください

## Checklist(レビュワー用)

- [ ] \`npm run lint\`でエラーが出ない
- [ ] TypeScriptのビルドで型エラーが出ない
- [ ] 手元でフォーマットした際に差分が出ない
- [ ] Bedrockモデルでの動作確認
- [ ] LiteLLMモデルでの動作確認
- [ ] モデル切り替え時の挙動確認