### PR TITLE
🔧 WebUIをデプロイしない設定を追加

### DIFF
--- a/packages/cdk/lib/create-stacks.ts
+++ b/packages/cdk/lib/create-stacks.ts
@@ -22,13 +22,14 @@ class DeletionPolicySetter implements cdk.IAspect {
 
 export const createStacks = (app: cdk.App, params: ProcessedStackInput) => {
   // CloudFront WAF
-  // Only deploy CloudFrontWafStack if IP address range (v4 or v6) or geographic restriction is defined
+  // Only deploy CloudFrontWafStack if useWebUi is true and IP address range (v4 or v6) or geographic restriction or custom domain is defined
   // WAF v2 is only deployable in us-east-1, so the Stack is separated
   const cloudFrontWafStack =
-    params.allowedIpV4AddressRanges ||
-    params.allowedIpV6AddressRanges ||
-    params.allowedCountryCodes ||
-    params.hostName
+    params.useWebUi &&
+    (params.allowedIpV4AddressRanges ||
+      params.allowedIpV6AddressRanges ||
+      params.allowedCountryCodes ||
+      params.hostName)
       ? new CloudFrontWafStack(app, `CloudFrontWafStack${params.env}`, {
           env: {
             account: params.account,

--- a/packages/cdk/lib/stack-input.ts
+++ b/packages/cdk/lib/stack-input.ts
@@ -149,6 +149,8 @@ const baseStackInputSchema = z.object({
   litellmProxyEnabled: z.boolean().default(false),
   // Guardrail
   guardrailEnabled: z.boolean().default(false),
+  // Web UI
+  useWebUi: z.boolean().default(true),
   // Usecase builder
   useCaseBuilderEnabled: z.boolean().default(true),
   // Flows

--- a/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
@@ -198,15 +198,18 @@ export class GenerativeAiUseCasesStack extends Stack {
       mcpEndpoint = mcpApiStack.mcpApi.endpoint;
     }
 
-    new WebStack(this, 'Web', {
-      params: params,
-      auth: auth,
-      api: api,
-      speechToSpeech: speechToSpeech,
-      webAclId: props.webAclId,
-      mcpEndpoint: mcpEndpoint,
-      cert: props.cert,
-    });
+    // Web Frontend (only deploy if useWebUi is true)
+    if (params.useWebUi) {
+      new WebStack(this, 'Web', {
+        params: params,
+        auth: auth,
+        api: api,
+        speechToSpeech: speechToSpeech,
+        webAclId: props.webAclId,
+        mcpEndpoint: mcpEndpoint,
+        cert: props.cert,
+      });
+    }
 
     // RAG
     if (params.ragEnabled) {


### PR DESCRIPTION
## 変更の概要

<!-- どのような変更を行ったかを書く -->

- `cdk.json`に`useWebUi`を追加し、バックエンドのみをデプロイできるようにしました
    - `useWebUi`は、デフォルトは`true`となっており、この場合はフロントエンドと証明書を両方ともデプロイします
    - `false`に設定すると、フロントエンドと証明書をデプロイしません。

## 申し送り事項

<!-- レビュワーに伝えておきたい事柄等を書く（Draftの理由など） -->

## Checklist（レビュワー用）

- [ ] `npm run lint`でエラーが出ない
- [ ] TypeScriptのビルドで型エラーが出ない
- [ ] 手元でフォーマットした際に差分が出ない
