### PR TITLE
⚡ サイドバーのアシスタントの一覧でキャッシュを利用するように変更

### DIFF
--- a/packages/web/src/components/ChatSidebar.tsx
+++ b/packages/web/src/components/ChatSidebar.tsx
@@ -1,11 +1,10 @@
-import React, { useEffect, useState, useCallback, useRef } from 'react';
+import React from 'react';
 import { BaseProps } from '../@types/common';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { PiPlus, PiMagnifyingGlass, PiRobot } from 'react-icons/pi';
 import ChatList from './ChatList';
 import { useTranslation } from 'react-i18next';
-import useAssistantApi from '../hooks/useAssistantApi';
-import { Assistant } from 'generative-ai-use-cases';
+import useAssistantList from '../hooks/useAssistantList';
 
 type Props = BaseProps & {
   onNewChat?: () => void;
@@ -15,11 +14,9 @@ const ChatSidebar: React.FC<Props> = ({ onNewChat }) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const location = useLocation();
-  const { listAssistants } = useAssistantApi();
 
-  const [featuredAssistants, setFeaturedAssistants] = useState<Assistant[]>([]);
-  const [loading, setLoading] = useState(false);
-  const abortControllerRef = useRef<AbortController | null>(null);
+  // SWRキャッシュを利用してアシスタント一覧を取得
+  const { assistants: featuredAssistants, loading } = useAssistantList(6);
 
   const handleNewChat = () => {
     // If already on /chat page, just reset the chat
@@ -33,45 +30,6 @@ const ChatSidebar: React.FC<Props> = ({ onNewChat }) => {
 
   // Check if assistants page is active
   const isAssistantsActive = location.pathname.startsWith('/chat/assistants');
-
-  // Fetch featured assistants (max 6)
-  const fetchFeaturedAssistants = useCallback(async () => {
-    // Cancel previous request if it exists
-    if (abortControllerRef.current) {
-      abortControllerRef.current.abort();
-    }
-
-    // Create new AbortController for this request
-    abortControllerRef.current = new AbortController();
-
-    setLoading(true);
-    try {
-      const response = await listAssistants({ limit: 6 });
-      // Featured assistants: first 6 assistants
-      setFeaturedAssistants(response.assistants || []);
-    } catch (error) {
-      console.error('Failed to fetch featured assistants:', error);
-      setFeaturedAssistants([]);
-    } finally {
-      setLoading(false);
-    }
-  }, [listAssistants]);
-
-  // Fetch featured assistants on mount (but not on assistants list page to avoid duplicate requests)
-  useEffect(() => {
-    // Skip fetching only if we're on the main assistants list page (AssistantsPage will handle it)
-    // Still fetch for edit/chat/history pages
-    const isAssistantsListPage = location.pathname === '/chat/assistants';
-    if (!isAssistantsListPage) {
-      fetchFeaturedAssistants();
-    }
-    // Cleanup AbortController on unmount
-    return () => {
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort();
-      }
-    };
-  }, [fetchFeaturedAssistants, location.pathname]);
 
   const handleAssistantClick = (assistantId: string) => {
     navigate(`/chat/assistants/chat/${assistantId}`);

--- a/packages/web/src/hooks/useAssistantApi.ts
+++ b/packages/web/src/hooks/useAssistantApi.ts
@@ -40,100 +40,123 @@ function buildQueryString(params?: {
 const useAssistantApi = () => {
   const http = useHttp();
 
-  return useMemo(
-    () => ({
-      listAssistants: async (
-        params?: ListAssistantsQueryParams,
-        signal?: AbortSignal
-      ): Promise<ListAssistantsResponse> => {
-        const queryString = buildQueryString(params);
-        const url = queryString ? `assistant?${queryString}` : 'assistant';
-        const res = await http.api.get<ListAssistantsResponse>(url, { signal });
-        return res.data;
-      },
+  return {
+    /**
+     * SWR版 listAssistants - キャッシュ付きでアシスタント一覧を取得
+     * サイドバーなど、ページ遷移時にキャッシュを活用したい場合に使用
+     */
+    listAssistantsSWR: (limit: number = 100) => {
+      const getKey = (
+        pageIndex: number,
+        previousPageData: ListAssistantsResponse
+      ) => {
+        if (previousPageData && !previousPageData.nextToken) return null;
+        if (pageIndex === 0) return `assistant?limit=${limit}`;
+        return `assistant?limit=${limit}&nextToken=${previousPageData.nextToken}`;
+      };
+      // eslint-disable-next-line react-hooks/rules-of-hooks
+      return http.getPagination<ListAssistantsResponse>(getKey, {
+        revalidateIfStale: false,
+      });
+    },
 
-      getAssistant: async (assistantId: string): Promise<Assistant> => {
-        const res = await http.api.get<Assistant>(`assistant/${assistantId}`);
-        return res.data;
-      },
+    ...useMemo(
+      () => ({
+        listAssistants: async (
+          params?: ListAssistantsQueryParams,
+          signal?: AbortSignal
+        ): Promise<ListAssistantsResponse> => {
+          const queryString = buildQueryString(params);
+          const url = queryString ? `assistant?${queryString}` : 'assistant';
+          const res = await http.api.get<ListAssistantsResponse>(url, {
+            signal,
+          });
+          return res.data;
+        },
 
-      createAssistant: async (
-        request: CreateAssistantRequest
-      ): Promise<Assistant> => {
-        const res = await http.post<Assistant, CreateAssistantRequest>(
-          'assistant',
-          request
-        );
-        return res.data;
-      },
+        getAssistant: async (assistantId: string): Promise<Assistant> => {
+          const res = await http.api.get<Assistant>(`assistant/${assistantId}`);
+          return res.data;
+        },
 
-      updateAssistant: async (
-        assistantId: string,
-        request: UpdateAssistantRequest
-      ): Promise<Assistant> => {
-        const res = await http.put<Assistant, UpdateAssistantRequest>(
-          `assistant/${assistantId}`,
-          request
-        );
-        return res.data;
-      },
+        createAssistant: async (
+          request: CreateAssistantRequest
+        ): Promise<Assistant> => {
+          const res = await http.post<Assistant, CreateAssistantRequest>(
+            'assistant',
+            request
+          );
+          return res.data;
+        },
 
-      deleteAssistant: async (assistantId: string): Promise<void> => {
-        await http.delete<void>(`assistant/${assistantId}`);
-      },
+        updateAssistant: async (
+          assistantId: string,
+          request: UpdateAssistantRequest
+        ): Promise<Assistant> => {
+          const res = await http.put<Assistant, UpdateAssistantRequest>(
+            `assistant/${assistantId}`,
+            request
+          );
+          return res.data;
+        },
 
-      updateAssistantVisibility: async (
-        assistantId: string,
-        visibility: 'private' | 'public'
-      ): Promise<Assistant> => {
-        const res = await http.put<
-          Assistant,
-          { visibility: 'private' | 'public' }
-        >(`assistant/${assistantId}`, { visibility });
-        return res.data;
-      },
+        deleteAssistant: async (assistantId: string): Promise<void> => {
+          await http.delete<void>(`assistant/${assistantId}`);
+        },
 
-      listMessages: async (
-        assistantId: string,
-        params?: ListAssistantMessagesQueryParams & { chatId?: string }
-      ): Promise<ListAssistantMessagesResponse> => {
-        const queryString = buildQueryString(params);
-        const url = queryString
-          ? `assistant/${assistantId}/messages?${queryString}`
-          : `assistant/${assistantId}/messages`;
-        const res = await http.api.get<ListAssistantMessagesResponse>(url);
-        return res.data;
-      },
+        updateAssistantVisibility: async (
+          assistantId: string,
+          visibility: 'private' | 'public'
+        ): Promise<Assistant> => {
+          const res = await http.put<
+            Assistant,
+            { visibility: 'private' | 'public' }
+          >(`assistant/${assistantId}`, { visibility });
+          return res.data;
+        },
 
-      createMessage: async (
-        assistantId: string,
-        request: CreateAssistantMessageRequest & { chatId?: string }
-      ): Promise<AssistantMessage> => {
-        // Extract chatId from request if present and add to query params
-        const { chatId, ...messageRequest } = request;
-        const url = chatId
-          ? `assistant/${assistantId}/messages?chatId=${encodeURIComponent(chatId)}`
-          : `assistant/${assistantId}/messages`;
-        const res = await http.post<
-          AssistantMessage,
-          CreateAssistantMessageRequest
-        >(url, messageRequest);
-        return res.data;
-      },
+        listMessages: async (
+          assistantId: string,
+          params?: ListAssistantMessagesQueryParams & { chatId?: string }
+        ): Promise<ListAssistantMessagesResponse> => {
+          const queryString = buildQueryString(params);
+          const url = queryString
+            ? `assistant/${assistantId}/messages?${queryString}`
+            : `assistant/${assistantId}/messages`;
+          const res = await http.api.get<ListAssistantMessagesResponse>(url);
+          return res.data;
+        },
 
-      requestUploadUrl: async (
-        request: RequestUploadUrlRequest
-      ): Promise<RequestUploadUrlResponse> => {
-        const res = await http.post<
-          RequestUploadUrlResponse,
-          RequestUploadUrlRequest
-        >('assistant/upload-url', request);
-        return res.data;
-      },
-    }),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [] // http.api is stable - created once at module level in useHttp.ts
-  );
+        createMessage: async (
+          assistantId: string,
+          request: CreateAssistantMessageRequest & { chatId?: string }
+        ): Promise<AssistantMessage> => {
+          // Extract chatId from request if present and add to query params
+          const { chatId, ...messageRequest } = request;
+          const url = chatId
+            ? `assistant/${assistantId}/messages?chatId=${encodeURIComponent(chatId)}`
+            : `assistant/${assistantId}/messages`;
+          const res = await http.post<
+            AssistantMessage,
+            CreateAssistantMessageRequest
+          >(url, messageRequest);
+          return res.data;
+        },
+
+        requestUploadUrl: async (
+          request: RequestUploadUrlRequest
+        ): Promise<RequestUploadUrlResponse> => {
+          const res = await http.post<
+            RequestUploadUrlResponse,
+            RequestUploadUrlRequest
+          >('assistant/upload-url', request);
+          return res.data;
+        },
+      }),
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [] // http.api is stable - created once at module level in useHttp.ts
+    ),
+  };
 };
 
 export default useAssistantApi;

--- a/packages/web/src/hooks/useAssistantList.ts
+++ b/packages/web/src/hooks/useAssistantList.ts
@@ -1,0 +1,56 @@
+import { produce } from 'immer';
+import useAssistantApi from './useAssistantApi';
+import { Assistant } from 'generative-ai-use-cases';
+
+const useAssistantList = (limit: number = 100) => {
+  const { listAssistantsSWR, deleteAssistant: deleteAssistantApi } =
+    useAssistantApi();
+  const { data, mutate, size, setSize, error, isValidating } =
+    listAssistantsSWR(limit);
+
+  // フラット化: assistants プロパティを使用
+  const assistants: Assistant[] = data
+    ? data.flatMap((page) => page.assistants ?? [])
+    : [];
+
+  const isLoading = !data && !error;
+  const isEmpty = data?.[0]?.assistants?.length === 0;
+  const isReachingEnd = isEmpty || (data && !data[data.length - 1]?.nextToken);
+  const canLoadMore = !isReachingEnd;
+
+  const deleteAssistant = async (assistantId: string) => {
+    // 楽観的更新
+    mutate(
+      produce(data, (draft) => {
+        if (draft) {
+          for (const page of draft) {
+            const idx = page.assistants.findIndex(
+              (a) => a.assistantId === assistantId
+            );
+            if (idx > -1) {
+              page.assistants.splice(idx, 1);
+              break;
+            }
+          }
+        }
+      }),
+      { revalidate: false }
+    );
+
+    return deleteAssistantApi(assistantId).finally(() => {
+      mutate();
+    });
+  };
+
+  return {
+    loading: isLoading,
+    assistants,
+    mutate,
+    deleteAssistant,
+    canLoadMore,
+    loadMore: () => setSize(size + 1),
+    isValidating,
+  };
+};
+
+export default useAssistantList;


### PR DESCRIPTION
## 変更の概要

<!-- どのような変更を行ったかを書く -->

- チャット画面のサイドバーで、ページ遷移の度にアシスタント一覧の取得が走っていたので、チャット履歴と同じ実装に変更しました。

## 申し送り事項

<!-- レビュワーに伝えておきたい事柄等を書く（Draftの理由など） -->

## Checklist（レビュワー用）

- [ ] `npm run lint`でエラーが出ない
- [ ] TypeScriptのビルドで型エラーが出ない
- [ ] 手元でフォーマットした際に差分が出ない
