### PR TITLE
:sparkles: feat(tenant): MCP・音声認識・エージェントのテナント別表示制御を追加

### DIFF
--- a/packages/types/src/useCases.d.ts
+++ b/packages/types/src/useCases.d.ts
@@ -11,6 +11,9 @@ export type HiddenUseCases = {
   meetingMinutes?: boolean;
   voiceChat?: boolean;
   pptx?: boolean;
+  mcp?: boolean;
+  transcribe?: boolean;
+  agent?: boolean;
 };
 
 export type HiddenUseCasesKeys = keyof HiddenUseCases;

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -83,7 +83,7 @@ const App: React.FC = () => {
           display: 'usecase' as const,
         }
       : null,
-    agentEnabled && !inlineAgents
+    agentEnabled && !inlineAgents && enabled('agent')
       ? {
           label: t('navigation.agentChat'),
           to: '/agent',
@@ -91,7 +91,7 @@ const App: React.FC = () => {
           display: 'usecase' as const,
         }
       : null,
-    ...(agentEnabled && inlineAgents
+    ...(agentEnabled && inlineAgents && enabled('agent')
       ? agentNames.map((name: string) => {
           return {
             label: name,
@@ -101,7 +101,7 @@ const App: React.FC = () => {
           };
         })
       : []),
-    mcpEnabled
+    mcpEnabled && enabled('mcp')
       ? {
           label: t('mcp_chat.title'),
           to: '/mcp',
@@ -213,12 +213,14 @@ const App: React.FC = () => {
           display: 'usecase' as const,
         }
       : null,
-    {
-      label: t('navigation.speechRecognition'),
-      to: '/transcribe',
-      icon: <PiSpeakerHighBold />,
-      display: 'tool' as const,
-    },
+    enabled('transcribe')
+      ? {
+          label: t('navigation.speechRecognition'),
+          to: '/transcribe',
+          icon: <PiSpeakerHighBold />,
+          display: 'tool' as const,
+        }
+      : null,
     optimizePromptEnabled
       ? {
           label: t('navigation.promptOptimization'),

--- a/packages/web/src/components/DynamicRouter.tsx
+++ b/packages/web/src/components/DynamicRouter.tsx
@@ -195,10 +195,12 @@ const DynamicRouter: React.FC<DynamicRouterProps> = ({
           element: <OptimizePromptPage />,
         }
       : null,
-    {
-      path: '/transcribe',
-      element: <TranscribePage />,
-    },
+    enabled('transcribe')
+      ? {
+          path: '/transcribe',
+          element: <TranscribePage />,
+        }
+      : null,
     {
       path: '/flow-chat',
       element: <FlowChatPage />,
@@ -221,13 +223,13 @@ const DynamicRouter: React.FC<DynamicRouterProps> = ({
           element: <RagKnowledgeBasePage />,
         }
       : null,
-    agentEnabled && !inlineAgents
+    agentEnabled && !inlineAgents && enabled('agent')
       ? {
           path: '/agent',
           element: <AgentChatPage />,
         }
       : null,
-    agentEnabled && inlineAgents
+    agentEnabled && inlineAgents && enabled('agent')
       ? {
           path: '/agent/:agentName',
           element: <AgentChatPage />,
@@ -239,7 +241,7 @@ const DynamicRouter: React.FC<DynamicRouterProps> = ({
           element: <VoiceChatPage />,
         }
       : null,
-    mcpEnabled
+    mcpEnabled && enabled('mcp')
       ? {
           path: '/mcp',
           element: <McpChatPage />,


### PR DESCRIPTION
## 変更の概要

テナントごとにユースケースの表示/非表示を制御できる `hiddenUseCases` に、以下の3つのキーを追加しました。

| キー | 対象機能 | 説明 |
|------|----------|------|
| `mcp` | MCPチャット | MCP (Model Context Protocol) チャット機能 |
| `transcribe` | 音声認識 | 音声ファイルからのテキスト変換機能 |
| `agent` | エージェントチャット | Bedrock Agent を使用したチャット機能 |

### 変更ファイル

- `packages/types/src/useCases.d.ts` - `HiddenUseCases` 型に `mcp`, `transcribe`, `agent` キーを追加
- `packages/web/src/App.tsx` - ナビゲーションに `enabled()` チェックを追加
- `packages/web/src/components/DynamicRouter.tsx` - ルーティングに `enabled()` チェックを追加

### 使用方法

テナントの DynamoDB レコードで `hiddenUseCases` を設定することで、テナントごとに機能を非表示にできます。

```json
{
  "useCaseConfiguration": {
    "hiddenUseCases": {
      "mcp": true,        // MCPチャットを非表示
      "transcribe": true, // 音声認識を非表示
      "agent": true       // エージェントチャットを非表示
    }
  }
}
```

## 申し送り事項

- デプロイ時の設定 (`mcpEnabled`, `agentEnabled`) と組み合わせて動作します
- デプロイで無効化されている機能は、テナント設定に関わらず表示されません
- 既存のテナントはデフォルトで全機能が有効（`hiddenUseCases` が空または未設定の場合）

## Checklist（レビュワー用）

- [ ] `npm run lint`でエラーが出ない
- [ ] TypeScriptのビルドで型エラーが出ない
- [ ] 手元でフォーマットした際に差分が出ない