### PR TITLE
:sparkles: feat(assistant): アシスタントチャットにストリーミングレスポンスを実装

### DIFF
--- a/packages/cdk/lambda/assistantMessageStreamHandler.ts
+++ b/packages/cdk/lambda/assistantMessageStreamHandler.ts
@@ -14,6 +14,7 @@ import {
 } from 'generative-ai-use-cases';
 import { similaritySearch } from './repository/assistantSearch';
 import { streamingChunk } from './utils/streamingChunk';
+import { canAccessAssistant } from './utils/assistantAccessControl';
 import api from './utils/api';
 import { modelMetadata } from '@generative-ai-use-cases/common';
 
@@ -128,6 +129,18 @@ export const handler = awslambda.streamifyResponse(
         responseStream.write(
           streamingChunk({
             text: 'Assistant not found',
+            stopReason: 'error',
+          })
+        );
+        responseStream.end();
+        return;
+      }
+
+      // Check access: owner OR (public AND same tenant)
+      if (!canAccessAssistant(assistant, userId, requestContext)) {
+        responseStream.write(
+          streamingChunk({
+            text: 'Access denied to this assistant',
             stopReason: 'error',
           })
         );

--- a/packages/cdk/lambda/assistantMessageStreamHandler.ts
+++ b/packages/cdk/lambda/assistantMessageStreamHandler.ts
@@ -1,0 +1,342 @@
+import { Handler, Context, APIGatewayProxyEvent } from 'aws-lambda';
+import * as crypto from 'crypto';
+import { getAssistant } from './repository/assistant';
+import {
+  createAssistantChat,
+  createAssistantMessage,
+  findChatById,
+  updateChatUpdatedDate,
+} from './repository/chat';
+import {
+  AssistantMessageSource,
+  Model,
+  UnrecordedMessage,
+} from 'generative-ai-use-cases';
+import { similaritySearch } from './repository/assistantSearch';
+import { streamingChunk } from './utils/streamingChunk';
+import api from './utils/api';
+import { modelMetadata } from '@generative-ai-use-cases/common';
+
+// Request type for streaming assistant messages
+interface AssistantMessageStreamRequest {
+  assistantId: string;
+  content: string;
+  chatId?: string;
+  idToken: string;
+}
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace awslambda {
+    function streamifyResponse(
+      f: (
+        event: AssistantMessageStreamRequest,
+        responseStream: NodeJS.WritableStream,
+        context: Context
+      ) => Promise<void>
+    ): Handler;
+  }
+}
+
+export const handler = awslambda.streamifyResponse(
+  async (
+    event: AssistantMessageStreamRequest,
+    responseStream: NodeJS.WritableStream,
+    context: Context
+  ) => {
+    context.callbackWaitsForEmptyEventLoop = false;
+
+    const { assistantId, content, chatId: inputChatId, idToken } = event;
+
+    // Extract userId from idToken
+    const tokenPayload = JSON.parse(
+      Buffer.from(idToken.split('.')[1], 'base64').toString()
+    );
+    const userId = tokenPayload['cognito:username'];
+
+    try {
+      // Get or create chatId
+      let chatId = inputChatId;
+      const isNewConversation = !chatId;
+      if (!chatId) {
+        chatId = crypto.randomUUID();
+      }
+      const cleanChatId = chatId.replace('chat#', '');
+
+      // Note: custom:tenant_id (with underscore) is the correct claim name
+      const tenantId =
+        tokenPayload['custom:tenant_id'] ||
+        tokenPayload['custom:tenantId'] ||
+        '';
+
+      // Create request context for repository functions
+      // Repository functions expect APIGatewayProxyEvent format for auth context extraction
+      const requestContext = {
+        body: null,
+        headers: {
+          Authorization: idToken,
+        },
+        multiValueHeaders: {},
+        httpMethod: 'POST',
+        isBase64Encoded: false,
+        path: '',
+        pathParameters: null,
+        queryStringParameters: null,
+        multiValueQueryStringParameters: null,
+        stageVariables: null,
+        resource: '',
+        requestContext: {
+          accountId: '',
+          apiId: '',
+          authorizer: {
+            claims: {
+              'cognito:username': userId,
+              'custom:tenant_id': tenantId,
+            },
+          },
+          protocol: 'HTTP/1.1',
+          httpMethod: 'POST',
+          identity: {
+            accessKey: null,
+            accountId: null,
+            apiKey: null,
+            apiKeyId: null,
+            caller: null,
+            clientCert: null,
+            cognitoAuthenticationProvider: null,
+            cognitoAuthenticationType: null,
+            cognitoIdentityId: null,
+            cognitoIdentityPoolId: null,
+            principalOrgId: null,
+            sourceIp: '',
+            user: null,
+            userAgent: null,
+            userArn: null,
+          },
+          path: '',
+          stage: '',
+          requestId: '',
+          requestTimeEpoch: 0,
+          resourceId: '',
+          resourcePath: '',
+        },
+      } satisfies APIGatewayProxyEvent;
+
+      const assistant = await getAssistant(assistantId, requestContext);
+
+      if (!assistant) {
+        responseStream.write(
+          streamingChunk({
+            text: 'Assistant not found',
+            stopReason: 'error',
+          })
+        );
+        responseStream.end();
+        return;
+      }
+
+      if (!assistant.modelId) {
+        responseStream.write(
+          streamingChunk({
+            text: 'Assistant has no model configured',
+            stopReason: 'error',
+          })
+        );
+        responseStream.end();
+        return;
+      }
+
+      // Check sync status for RAG-enabled assistants
+      if (
+        assistant.ragEnabled &&
+        (assistant.syncStatus === 'QUEUED' || assistant.syncStatus === 'SYNCING')
+      ) {
+        responseStream.write(
+          streamingChunk({
+            text: 'Assistant is currently indexing documents. Please wait until indexing completes.',
+            stopReason: 'error',
+          })
+        );
+        responseStream.end();
+        return;
+      }
+
+      if (!assistant.instruction) {
+        responseStream.write(
+          streamingChunk({
+            text: 'Assistant has no system prompt configured',
+            stopReason: 'error',
+          })
+        );
+        responseStream.end();
+        return;
+      }
+
+      // Store user message before streaming
+      await createAssistantMessage(
+        cleanChatId,
+        userId,
+        'user',
+        content,
+        undefined,
+        undefined,
+        requestContext
+      );
+
+      // Create chat history entry for new conversations
+      if (isNewConversation) {
+        await createAssistantChat(
+          userId,
+          assistantId,
+          cleanChatId,
+          assistant.name,
+          requestContext
+        );
+      }
+
+      // Send chatId to frontend early
+      responseStream.write(
+        streamingChunk({
+          text: '',
+          sessionId: cleanChatId,
+        })
+      );
+
+      // RAG context retrieval
+      let ragContext = '';
+      let sources: AssistantMessageSource[] = [];
+
+      const hasKnowledgeSources =
+        assistant.knowledgeSources && assistant.knowledgeSources.length > 0;
+      const hasLegacyS3Urls = assistant.s3Urls && assistant.s3Urls.length > 0;
+
+      if (assistant.ragEnabled && (hasKnowledgeSources || hasLegacyS3Urls)) {
+        try {
+          const relevantDocs = await similaritySearch(
+            assistantId.replace('assistant#', ''),
+            content,
+            requestContext,
+            5
+          );
+
+          ragContext = relevantDocs
+            .map((doc, idx) => `[Source ${idx + 1}]\n${doc.pageContent}`)
+            .join('\n\n');
+
+          sources = relevantDocs.map((doc) => {
+            const sourceId = doc.metadata.sourceId || '';
+            const sourceType = doc.metadata.sourceType || 'file';
+
+            const source: AssistantMessageSource = {
+              sourceId,
+              sourceType,
+              content: doc.pageContent,
+              contentType: doc.metadata.contentType || 'text/plain',
+              excerpt: doc.pageContent.substring(0, 200),
+            };
+
+            if (sourceType === 'web' && doc.metadata.sourceUrl) {
+              source.sourceUrl = doc.metadata.sourceUrl;
+            } else if (sourceType === 'file' && doc.metadata.storageKey) {
+              source.storageKey = doc.metadata.storageKey;
+            }
+
+            if (doc.metadata.s3Url) {
+              source.s3Url = doc.metadata.s3Url;
+            }
+
+            return source;
+          });
+        } catch {
+          // RAG retrieval failed, continue without context
+        }
+      }
+
+      const systemMessage = ragContext
+        ? `${assistant.instruction}\n\nRelevant context from documents:\n${ragContext}`
+        : assistant.instruction;
+
+      // Determine model type:
+      // - If modelId exists in modelMetadata → bedrock
+      // - If modelId starts with 'openai:' → liteLlm (strip prefix, use LiteLLM proxy which has API keys)
+      // - Otherwise → liteLlm
+      const isOpenAiPrefixed = assistant.modelId.startsWith('openai:');
+      const modelType: 'bedrock' | 'liteLlm' = modelMetadata[assistant.modelId]
+        ? 'bedrock'
+        : 'liteLlm';
+
+      // For openai: prefixed models, strip the prefix since LiteLLM config uses bare model names
+      const effectiveModelId = isOpenAiPrefixed
+        ? assistant.modelId.replace('openai:', '')
+        : assistant.modelId;
+
+      const model: Model = {
+        modelId: effectiveModelId,
+        type: modelType,
+        ...(modelType === 'bedrock' && {
+          region: process.env.MODEL_REGION || 'us-east-1',
+        }),
+      };
+
+      // Prepare messages for LLM
+      const messages: UnrecordedMessage[] = [
+        { role: 'system', content: systemMessage },
+        { role: 'user', content: content },
+      ];
+
+      // Accumulate response for storage
+      let fullResponse = '';
+
+      // Stream response using appropriate API based on model type
+      const streamApi = modelType === 'bedrock' ? api.bedrock : api.liteLlm;
+      for await (const token of streamApi.invokeStream?.(
+        model,
+        messages,
+        `/assistant/${assistantId}`
+      ) ?? []) {
+        responseStream.write(token);
+
+        // Parse token to accumulate text
+        try {
+          const parsed = JSON.parse(token.trim());
+          if (parsed.text) {
+            fullResponse += parsed.text;
+          }
+        } catch {
+          // Ignore parse errors for partial chunks
+        }
+      }
+
+      // Store assistant message after streaming completes
+      await createAssistantMessage(
+        cleanChatId,
+        userId,
+        'assistant',
+        fullResponse,
+        sources,
+        undefined,
+        requestContext
+      );
+
+      // Update chat updatedDate
+      const chatRecord = await findChatById(userId, cleanChatId, requestContext);
+      if (chatRecord) {
+        await updateChatUpdatedDate(
+          chatRecord.id,
+          chatRecord.createdDate,
+          requestContext
+        );
+      }
+
+      responseStream.end();
+    } catch {
+      responseStream.write(
+        streamingChunk({
+          text: 'An error occurred during streaming',
+          stopReason: 'error',
+        })
+      );
+      responseStream.end();
+    }
+  }
+);

--- a/packages/cdk/lib/construct/api/assistant.ts
+++ b/packages/cdk/lib/construct/api/assistant.ts
@@ -17,6 +17,8 @@ export type AssistantApiProps = GenericApiProps;
  * - assistantMessageHandler: Routes message operations (POST/{id}/messages, GET/{id}/messages)
  */
 class AssistantApi extends Construct {
+  readonly assistantMessageStreamFunction: NodejsFunction;
+
   constructor(scope: Construct, id: string, props: AssistantApiProps) {
     super(scope, id);
 
@@ -27,6 +29,10 @@ class AssistantApi extends Construct {
       table,
       tenantManager,
       fileBucket,
+      idPool,
+      userPool,
+      userPoolClient,
+      modelRegion,
     } = props;
 
     const assistantResource = api.root.addResource('assistant');
@@ -127,6 +133,70 @@ class AssistantApi extends Construct {
         resources: ['*'], // Wildcard needed for multi-tenant cross-account access
       })
     );
+
+    // Streaming handler for assistant messages (direct Lambda invocation)
+    const assistantMessageStreamFunction = new NodejsFunction(
+      this,
+      'AssistantMessageStreamHandler',
+      {
+        runtime: LAMBDA_RUNTIME_NODEJS,
+        entry: './lambda/assistantMessageStreamHandler.ts',
+        timeout: Duration.minutes(15),
+        memorySize: 256,
+        environment: getBaseEnvironment(this, props, {
+          ASSISTANT_TABLE_NAME: ASSISTANT_TABLE_PREFIX,
+          DEFAULT_ASSISTANT_TABLE_NAME: assistantTable.tableName,
+          MODEL_REGION: modelRegion,
+          MODEL_IDS: JSON.stringify(props.modelIds),
+          OPENSEARCH_INDEX: 'assistant-docs',
+          USER_POOL_ID: userPool.userPoolId,
+          USER_POOL_CLIENT_ID: userPoolClient.userPoolClientId,
+          TENANTS_TABLE_NAME: tenantManager?.tenantsTable.tableName || '',
+          LITELLM_ENDPOINT: props.litellmEndpoint ?? '',
+        }),
+      }
+    );
+
+    // Grant permissions for streaming handler
+    assistantTable.grantReadData(assistantMessageStreamFunction);
+    table.grantReadWriteData(assistantMessageStreamFunction);
+
+    // Grant Bedrock permissions for LLM streaming calls
+    if (props.bedrockPolicy) {
+      assistantMessageStreamFunction.role?.addToPrincipalPolicy(
+        props.bedrockPolicy
+      );
+    }
+
+    // Grant OpenSearch permissions for RAG retrieval
+    assistantMessageStreamFunction.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: [
+          'es:ESHttpGet',
+          'es:ESHttpPost',
+          'es:ESHttpPut',
+          'es:ESHttpDelete',
+          'es:ESHttpHead',
+        ],
+        resources: ['*'],
+      })
+    );
+
+    // Grant invoke permission to authenticated users (for direct Lambda invocation)
+    assistantMessageStreamFunction.grantInvoke(idPool.authenticatedRole);
+
+    // Grant tenant table read permissions
+    if (tenantManager) {
+      tenantManager.tenantsTable.grantReadData(assistantMessageStreamFunction);
+    }
+
+    // Grant LiteLLM proxy invocation permissions for streaming handler
+    if (props.litellmProxy) {
+      props.litellmProxy.grantInvokeUrl(assistantMessageStreamFunction);
+    }
+
+    this.assistantMessageStreamFunction = assistantMessageStreamFunction;
 
     // API Gateway routes - All route to consolidated handlers
     // POST: /assistant → assistantHandler (create)

--- a/packages/cdk/lib/construct/web.ts
+++ b/packages/cdk/lib/construct/web.ts
@@ -29,6 +29,7 @@ export interface WebProps {
   readonly userPoolClientId: string;
   readonly idPoolId: string;
   readonly predictStreamFunctionArn: string;
+  readonly assistantMessageStreamFunctionArn: string;
   readonly ragEnabled: boolean;
   readonly ragKnowledgeBaseEnabled: boolean;
   readonly agentEnabled: boolean;
@@ -235,6 +236,8 @@ export class Web extends Construct {
         VITE_APP_USER_POOL_CLIENT_ID: props.userPoolClientId,
         VITE_APP_IDENTITY_POOL_ID: props.idPoolId,
         VITE_APP_PREDICT_STREAM_FUNCTION_ARN: props.predictStreamFunctionArn,
+        VITE_APP_ASSISTANT_MESSAGE_STREAM_FUNCTION_ARN:
+          props.assistantMessageStreamFunctionArn,
         VITE_APP_RAG_ENABLED: props.ragEnabled.toString(),
         VITE_APP_RAG_KNOWLEDGE_BASE_ENABLED:
           props.ragKnowledgeBaseEnabled.toString(),

--- a/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
@@ -173,7 +173,7 @@ export class GenerativeAiUseCasesStack extends Stack {
     const speechToSpeech = speechToSpeechStack.speechToSpeech;
 
     // Assistant API (moved to nested stack to reduce main stack resource count)
-    new AssistantApiStack(this, 'AssistantApi', {
+    const assistantApiStack = new AssistantApiStack(this, 'AssistantApi', {
       params: params,
       api: api,
       auth: auth,
@@ -210,6 +210,9 @@ export class GenerativeAiUseCasesStack extends Stack {
         webAclId: props.webAclId,
         mcpEndpoint: mcpEndpoint,
         cert: props.cert,
+        assistantMessageStreamFunctionArn:
+          assistantApiStack.assistantApi.assistantMessageStreamFunction
+            .functionArn,
       });
     }
 

--- a/packages/cdk/lib/stacks/common/web-stack.ts
+++ b/packages/cdk/lib/stacks/common/web-stack.ts
@@ -12,14 +12,23 @@ interface WebStackProps extends StackProps {
   readonly webAclId?: string;
   readonly mcpEndpoint: string | null;
   readonly cert?: ICertificate;
+  readonly assistantMessageStreamFunctionArn: string;
 }
 
 class WebStack extends NestedStack {
   constructor(scope: Construct, id: string, props: WebStackProps) {
     super(scope, id, props);
 
-    const { params, auth, api, speechToSpeech, webAclId, mcpEndpoint, cert } =
-      props;
+    const {
+      params,
+      auth,
+      api,
+      speechToSpeech,
+      webAclId,
+      mcpEndpoint,
+      cert,
+      assistantMessageStreamFunctionArn,
+    } = props;
 
     // Web Frontend
     const selfSignUpEnabledForWeb =
@@ -41,6 +50,7 @@ class WebStack extends NestedStack {
       // Backend
       apiEndpointUrl: api.restApi.url,
       predictStreamFunctionArn: api.predictStreamFunction.functionArn,
+      assistantMessageStreamFunctionArn: assistantMessageStreamFunctionArn,
       ragEnabled: params.ragEnabled,
       ragKnowledgeBaseEnabled: params.ragKnowledgeBaseEnabled,
       agentEnabled: params.agentEnabled || params.agents.length > 0,

--- a/packages/web/src/hooks/useAssistantApi.ts
+++ b/packages/web/src/hooks/useAssistantApi.ts
@@ -13,6 +13,13 @@ import {
   UpdateAssistantRequest,
 } from 'generative-ai-use-cases';
 import useHttp from './useHttp';
+import {
+  LambdaClient,
+  InvokeWithResponseStreamCommand,
+} from '@aws-sdk/client-lambda';
+import { fromCognitoIdentityPool } from '@aws-sdk/credential-provider-cognito-identity';
+import { CognitoIdentityClient } from '@aws-sdk/client-cognito-identity';
+import { fetchAuthSession } from 'aws-amplify/auth';
 
 /**
  * Build query string from parameters
@@ -141,6 +148,69 @@ const useAssistantApi = () => {
             CreateAssistantMessageRequest
           >(url, messageRequest);
           return res.data;
+        },
+
+        // Streaming message creation
+        streamMessage: async function* (
+          assistantId: string,
+          request: CreateAssistantMessageRequest & { chatId?: string }
+        ) {
+          const token = (await fetchAuthSession()).tokens?.idToken?.toString();
+          if (!token) {
+            throw new Error('Not authenticated');
+          }
+
+          const functionArn = import.meta.env
+            .VITE_APP_ASSISTANT_MESSAGE_STREAM_FUNCTION_ARN;
+
+          if (!functionArn) {
+            throw new Error(
+              'VITE_APP_ASSISTANT_MESSAGE_STREAM_FUNCTION_ARN is not configured'
+            );
+          }
+
+          const region = import.meta.env.VITE_APP_REGION;
+          const userPoolId = import.meta.env.VITE_APP_USER_POOL_ID;
+          const idPoolId = import.meta.env.VITE_APP_IDENTITY_POOL_ID;
+          const cognito = new CognitoIdentityClient({ region });
+          const providerName = `cognito-idp.${region}.amazonaws.com/${userPoolId}`;
+          const lambda = new LambdaClient({
+            region,
+            credentials: fromCognitoIdentityPool({
+              client: cognito,
+              identityPoolId: idPoolId,
+              logins: {
+                [providerName]: token,
+              },
+            }),
+          });
+
+          const res = await lambda.send(
+            new InvokeWithResponseStreamCommand({
+              FunctionName: functionArn,
+              Payload: JSON.stringify({
+                assistantId,
+                content: request.content,
+                chatId: request.chatId,
+                idToken: token,
+              }),
+            })
+          );
+
+          const events = res.EventStream!;
+
+          for await (const event of events) {
+            if (event.PayloadChunk) {
+              const chunk = new TextDecoder('utf-8').decode(
+                event.PayloadChunk.Payload
+              );
+              yield chunk;
+            }
+
+            if (event.InvokeComplete) {
+              break;
+            }
+          }
         },
 
         requestUploadUrl: async (

--- a/packages/web/src/pages/AssistantChatPage.tsx
+++ b/packages/web/src/pages/AssistantChatPage.tsx
@@ -44,7 +44,7 @@ const AssistantChatPage: React.FC = () => {
     conversationId?: string;
   }>();
 
-  const { getAssistant, listMessages, createMessage } = useAssistantApi();
+  const { getAssistant, listMessages, streamMessage } = useAssistantApi();
   const { predictTitle, updateTitle } = useChatApi();
   const http = useHttp();
 
@@ -53,6 +53,8 @@ const AssistantChatPage: React.FC = () => {
   const [inputMessage, setInputMessage] = useState('');
   const [loading, setLoading] = useState(false);
   const [sending, setSending] = useState(false);
+  const [writing, setWriting] = useState(false);
+  const [streamingContent, setStreamingContent] = useState('');
   const [showAssistantInfo, setShowAssistantInfo] = useState(false);
   const [isComposing, setIsComposing] = useState(false);
   const [currentChatId, setCurrentChatId] = useState<string | undefined>(
@@ -61,6 +63,8 @@ const AssistantChatPage: React.FC = () => {
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const streamChatIdRef = useRef<string | undefined>(undefined);
+  const accumulatedContentRef = useRef('');
 
   // Derive status info
   const statusInfo = useMemo(() => {
@@ -83,7 +87,7 @@ const AssistantChatPage: React.FC = () => {
 
   useEffect(() => {
     scrollToBottom();
-  }, [messages]);
+  }, [messages, streamingContent]);
 
   // Polling for assistant with non-final sync status
   useEffect(() => {
@@ -248,38 +252,88 @@ const AssistantChatPage: React.FC = () => {
     const isFirstMessage = !currentChatId;
     setInputMessage('');
     setSending(true);
+    setWriting(true);
+    setStreamingContent('');
+
+    // Add user message to local state immediately
+    const tempMessageId = `temp-user-${Date.now()}`;
+    const tempUserMessage: AssistantMessage = {
+      id: tempMessageId,
+      messageId: tempMessageId,
+      assistantId: assistantId,
+      chatId: currentChatId || 'temp-chat',
+      userId: 'temp-user',
+      role: 'user',
+      content: userMessageContent,
+      createdDate: Date.now().toString(),
+    };
+    setMessages((prev) => [...prev, tempUserMessage]);
+
+    // Reset refs for new stream
+    streamChatIdRef.current = undefined;
+    accumulatedContentRef.current = '';
 
     try {
-      // Send message and get response
-      const response = await createMessage(assistantId, {
+      // Use streaming API
+      const stream = streamMessage(assistantId, {
         content: userMessageContent,
         chatId: currentChatId,
       });
 
-      // If this was a new conversation (no currentChatId), update state and navigate
-      if (!currentChatId && response.chatId) {
-        const newChatId = response.chatId;
-        setCurrentChatId(newChatId);
-        // Navigate to the conversation URL
-        navigate(`/chat/assistants/chat/${assistantId}/${newChatId}`, {
-          replace: true,
-        });
+      for await (const chunk of stream) {
+        // Parse JSONL chunks - each line is a JSON object
+        chunk
+          .split('\n')
+          .filter((line) => line.trim())
+          .forEach((line) => {
+            try {
+              const parsed = JSON.parse(line);
+              if (parsed.text && parsed.text.length > 0) {
+                accumulatedContentRef.current += parsed.text;
+                setStreamingContent(accumulatedContentRef.current);
+              }
+              // Capture chatId (sessionId) from the stream
+              if (parsed.sessionId && !streamChatIdRef.current) {
+                streamChatIdRef.current = parsed.sessionId;
+              }
+            } catch {
+              // Ignore parse errors for partial chunks
+            }
+          });
       }
 
-      // Refresh messages to get both user and assistant messages
+      setWriting(false);
+      setSending(false);
+
+      // If this was a new conversation, update state and navigate
+      if (!currentChatId && streamChatIdRef.current) {
+        setCurrentChatId(streamChatIdRef.current);
+        navigate(
+          `/chat/assistants/chat/${assistantId}/${streamChatIdRef.current}`,
+          {
+            replace: true,
+          }
+        );
+      }
+
+      // Refresh messages to get the persisted messages from server
       await fetchMessages();
 
       // Generate title for the first message
-      if (isFirstMessage && response.chatId) {
-        await generateChatTitle(response.chatId);
+      if (isFirstMessage && streamChatIdRef.current) {
+        await generateChatTitle(streamChatIdRef.current);
       }
-
-      setSending(false);
     } catch (error) {
       console.error('Failed to send message:', error);
+      setWriting(false);
       setSending(false);
       toast.error(t('assistant.chatPage.sendError'));
+      // Remove the temporary user message on error
+      setMessages((prev) =>
+        prev.filter((m) => m.messageId !== tempUserMessage.messageId)
+      );
     } finally {
+      setStreamingContent('');
       inputRef.current?.focus();
     }
   };
@@ -562,13 +616,21 @@ const AssistantChatPage: React.FC = () => {
                 {renderMessage(message)}
               </React.Fragment>
             ))}
-            {sending && (
+            {writing && (
               <div className="mb-4 flex gap-3">
-                <div className="flex h-8 w-8 items-center justify-center rounded-full bg-blue-100">
-                  <PiRobot className="text-blue-600" />
+                <div className="shrink-0">
+                  <div className="flex h-8 w-8 items-center justify-center rounded-full bg-blue-100">
+                    <PiRobot className="text-blue-600" />
+                  </div>
                 </div>
-                <div className="rounded-r-lg rounded-bl-lg bg-gray-100 p-3">
-                  <LoadingWave />
+                <div className="flex max-w-[70%] flex-col gap-2">
+                  <div className="rounded-r-lg rounded-bl-lg bg-gray-100 p-3 text-gray-900">
+                    {streamingContent ? (
+                      <Markdown>{streamingContent}</Markdown>
+                    ) : (
+                      <LoadingWave />
+                    )}
+                  </div>
                 </div>
               </div>
             )}
@@ -592,13 +654,17 @@ const AssistantChatPage: React.FC = () => {
                 ? t('assistant.chatPage.syncingPlaceholder')
                 : t('assistant.chatPage.inputPlaceholder')
             }
-            disabled={sending || !assistantId || isBlocked}
+            disabled={sending || writing || !assistantId || isBlocked}
             className="flex-1 rounded border border-black/30 p-1.5 outline-none disabled:bg-gray-100 disabled:text-gray-500"
           />
           <Button
             onClick={handleSendMessage}
             disabled={
-              !inputMessage.trim() || sending || !assistantId || isBlocked
+              !inputMessage.trim() ||
+              sending ||
+              writing ||
+              !assistantId ||
+              isBlocked
             }
             className="flex items-center gap-1">
             <PiPaperPlaneTilt />

--- a/packages/web/src/pages/AssistantChatPage.tsx
+++ b/packages/web/src/pages/AssistantChatPage.tsx
@@ -149,13 +149,14 @@ const AssistantChatPage: React.FC = () => {
     }
   };
 
-  const fetchMessages = async () => {
+  const fetchMessages = async (chatIdOverride?: string) => {
     if (!assistantId) return;
 
+    const targetChatId = chatIdOverride ?? currentChatId;
     try {
       const response = await listMessages(assistantId, {
         limit: 100,
-        chatId: currentChatId,
+        chatId: targetChatId,
       });
       // Sort messages chronologically (oldest first)
       // Backend returns newest first (ScanIndexForward: false), so we reverse
@@ -317,7 +318,8 @@ const AssistantChatPage: React.FC = () => {
       }
 
       // Refresh messages to get the persisted messages from server
-      await fetchMessages();
+      // Use streamChatIdRef.current for new conversations since state update is async
+      await fetchMessages(streamChatIdRef.current ?? currentChatId);
 
       // Generate title for the first message
       if (isFirstMessage && streamChatIdRef.current) {

--- a/packages/web/src/pages/AssistantChatPage.tsx
+++ b/packages/web/src/pages/AssistantChatPage.tsx
@@ -65,6 +65,7 @@ const AssistantChatPage: React.FC = () => {
   const inputRef = useRef<HTMLInputElement>(null);
   const streamChatIdRef = useRef<string | undefined>(undefined);
   const accumulatedContentRef = useRef('');
+  const streamBufferRef = useRef('');
 
   // Derive status info
   const statusInfo = useMemo(() => {
@@ -273,6 +274,7 @@ const AssistantChatPage: React.FC = () => {
     // Reset refs for new stream
     streamChatIdRef.current = undefined;
     accumulatedContentRef.current = '';
+    streamBufferRef.current = '';
 
     try {
       // Use streaming API
@@ -282,25 +284,51 @@ const AssistantChatPage: React.FC = () => {
       });
 
       for await (const chunk of stream) {
-        // Parse JSONL chunks - each line is a JSON object
-        chunk
-          .split('\n')
-          .filter((line) => line.trim())
-          .forEach((line) => {
-            try {
-              const parsed = JSON.parse(line);
-              if (parsed.text && parsed.text.length > 0) {
-                accumulatedContentRef.current += parsed.text;
-                setStreamingContent(accumulatedContentRef.current);
-              }
-              // Capture chatId (sessionId) from the stream
-              if (parsed.sessionId && !streamChatIdRef.current) {
-                streamChatIdRef.current = parsed.sessionId;
-              }
-            } catch {
-              // Ignore parse errors for partial chunks
+        // Buffer chunks to handle partial JSON lines at chunk boundaries
+        // Chunks may split JSON lines arbitrarily, so we buffer incomplete lines
+        streamBufferRef.current += chunk;
+
+        // Process complete lines (those ending with newline)
+        const lines = streamBufferRef.current.split('\n');
+        // Keep the last part in buffer (may be incomplete if no trailing newline)
+        streamBufferRef.current = lines.pop() || '';
+
+        for (const line of lines) {
+          const trimmedLine = line.trim();
+          if (!trimmedLine) continue;
+
+          try {
+            const parsed = JSON.parse(trimmedLine);
+            if (parsed.text && parsed.text.length > 0) {
+              accumulatedContentRef.current += parsed.text;
+              setStreamingContent(accumulatedContentRef.current);
             }
-          });
+            // Capture chatId (sessionId) from the stream
+            if (parsed.sessionId && !streamChatIdRef.current) {
+              streamChatIdRef.current = parsed.sessionId;
+            }
+          } catch {
+            // Log parse errors for debugging - complete lines should always be valid JSON
+            console.warn('Failed to parse JSONL line:', trimmedLine);
+          }
+        }
+      }
+
+      // Process any remaining content in buffer after stream ends
+      const remainingLine = streamBufferRef.current.trim();
+      if (remainingLine) {
+        try {
+          const parsed = JSON.parse(remainingLine);
+          if (parsed.text && parsed.text.length > 0) {
+            accumulatedContentRef.current += parsed.text;
+            setStreamingContent(accumulatedContentRef.current);
+          }
+          if (parsed.sessionId && !streamChatIdRef.current) {
+            streamChatIdRef.current = parsed.sessionId;
+          }
+        } catch {
+          console.warn('Failed to parse final JSONL line:', remainingLine);
+        }
       }
 
       setWriting(false);

--- a/packages/web/src/vite-env.d.ts
+++ b/packages/web/src/vite-env.d.ts
@@ -7,6 +7,7 @@ interface ImportMetaEnv {
   readonly VITE_APP_USER_POOL_CLIENT_ID: string;
   readonly VITE_APP_IDENTITY_POOL_ID: string;
   readonly VITE_APP_PREDICT_STREAM_FUNCTION_ARN: string;
+  readonly VITE_APP_ASSISTANT_MESSAGE_STREAM_FUNCTION_ARN: string;
   readonly VITE_APP_RAG_ENABLED: string;
   readonly VITE_APP_RAG_KNOWLEDGE_BASE_ENABLED: string;
   readonly VITE_APP_AGENT_ENABLED: string;


### PR DESCRIPTION
## 📋 変更概要

アシスタントチャット機能にリアルタイムストリーミングレスポンスを実装。従来のリクエスト/レスポンス方式から、Lambda Response Streamingを活用したリアルタイム表示に変更し、ユーザー体験を大幅に向上。

## 🏗️ アーキテクチャ変更

```
変更前:
┌──────────┐     POST      ┌─────────────┐     同期呼出     ┌─────────┐
│ Frontend │ ───────────> │ API Gateway │ ─────────────> │ Lambda  │
└──────────┘               └─────────────┘                └────┬────┘
     │                                                          │
     │<──────────────── 完了まで待機 ──────────────────────────┘

変更後:
┌──────────┐   直接呼出    ┌────────────────────────────┐
│ Frontend │ ───────────> │ Lambda (Response Streaming) │
└──────────┘               └─────────────┬──────────────┘
     │                                    │
     │<────── リアルタイムチャンク ────────┘
     │<────── リアルタイムチャンク ────────┘
     │<────── リアルタイムチャンク ────────┘
```

**変更理由:** API Gatewayの29秒タイムアウト制限を回避し、LLMの生成中にリアルタイムでテキストを表示することでUXを改善。

## 📊 変更内容詳細

### 新規追加 ✨

- **packages/cdk/lambda/assistantMessageStreamHandler.ts** (+342行)
  - Lambda Response Streamingを使用したストリーミングハンドラー
  - `awslambda.streamifyResponse`でストリーミングレスポンスを実装
  - テナント認証コンテキストの構築（idTokenからAuthorization headerを設定）
  - RAGコンテキスト検索とBedrock/LiteLLMモデル呼び出しを統合
  - メッセージの永続化（ユーザー/アシスタント両方）

### 変更 🔄

- **packages/cdk/lib/construct/api/assistant.ts** (+70行)
  - `assistantMessageStreamFunction`の追加
  - 必要なIAMポリシー付与（DynamoDB, OpenSearch, Bedrock, Lambda invoke）
  - Identity Poolの認証ロールにLambda呼び出し権限を付与

- **packages/web/src/hooks/useAssistantApi.ts** (+79行)
  - `streamMessage`ジェネレーター関数を追加
  - `InvokeWithResponseStreamCommand`でLambda直接呼び出し
  - Cognito Identity Poolを使用した認証

- **packages/web/src/pages/AssistantChatPage.tsx** (+90/-24行)
  - `createMessage` → `streamMessage`に変更
  - `writing`/`streamingContent`ステートを追加
  - ストリーミング中のリアルタイムMarkdown表示
  - 一時的なユーザーメッセージの即座表示

- **packages/cdk/lib/construct/web.ts** (+3行)
  - `assistantMessageStreamFunctionArn`環境変数を追加

- **packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts** (+4/-1行)
  - AssistantApiStackからストリーミング関数ARNを取得・伝播

- **packages/cdk/lib/stacks/common/web-stack.ts** (+12/-2行)
  - ストリーミング関数ARNをWebPropsに追加・伝播

- **packages/web/src/vite-env.d.ts** (+1行)
  - `VITE_APP_ASSISTANT_MESSAGE_STREAM_FUNCTION_ARN`型定義を追加

## 🔀 データフロー変更

```
ストリーミングフロー:
[Browser] ──┬──> [Lambda Stream Handler]
            │           │
            │           ├──> [DynamoDB] ユーザーメッセージ保存
            │           │
            │           ├──> [OpenSearch] RAG検索 (オプション)
            │           │
            │           ├──> [Bedrock/LiteLLM] ストリーミング生成
            │           │         │
            │<──────────┼─────────┘ チャンクごとに送信
            │           │
            │           └──> [DynamoDB] アシスタントメッセージ保存
            │
            └──> [React State] リアルタイム表示更新
```

## 🔗 依存関係の変更

### フロントエンド追加依存
- `@aws-sdk/client-lambda`: Lambda直接呼び出し
- `@aws-sdk/credential-provider-cognito-identity`: 認証情報取得
- `@aws-sdk/client-cognito-identity`: Identity Pool連携

## 🧪 テスト

- [ ] 単体テスト: 未実装
- [ ] 統合テスト: 手動確認済み
- [ ] E2Eテスト: 未実装

## ⚠️ 破壊的変更

なし（既存のAPIエンドポイントは維持）

## 📝 注意事項

- Lambda Response Streamingはタイムアウトが最大15分まで延長可能
- フロントエンドからの直接Lambda呼び出しにはIdentity Pool認証が必要
- テナント分離のため、requestContextにAuthorizationヘッダーを設定する修正を含む

## Checklist（レビュワー用）

- [ ] `npm run lint`でエラーが出ない
- [ ] TypeScriptのビルドで型エラーが出ない
- [ ] 手元でフォーマットした際に差分が出ない