### PR TITLE
:wrench: chore(assistant): アシスタントファイルサイズ上限を設定可能に

### DIFF
--- a/packages/cdk/cdk.example.json
+++ b/packages/cdk/cdk.example.json
@@ -69,6 +69,7 @@
     "inlineAgents": false,
     "mcpEnabled": false,
     "pptxEnabled": false,
+    "assistantFileMaxSizeMB": 10,
     "flows": [],
     "allowedIpV4AddressRanges": null,
     "allowedIpV6AddressRanges": null,

--- a/packages/cdk/lambda/assistantFileUpload.ts
+++ b/packages/cdk/lambda/assistantFileUpload.ts
@@ -19,6 +19,10 @@ import {
 
 const MANAGED_BUCKET_NAME = process.env.ASSISTANT_FILES_BUCKET_NAME;
 const UPLOAD_EXPIRATION_SECONDS = 300; // 5 minutes
+const MAX_FILE_SIZE_MB = parseInt(
+  process.env.ASSISTANT_FILE_MAX_SIZE_MB || '10',
+  10
+);
 
 interface RequestPresignedUrlRequest {
   fileName: string;
@@ -59,11 +63,11 @@ export const handler = async (
       });
     }
 
-    // Validate file size (10 MB limit)
-    const MAX_FILE_SIZE = 10 * 1024 * 1024;
-    if (body.fileSize > MAX_FILE_SIZE) {
+    // Validate file size (configurable, default 10 MB)
+    const maxFileSizeBytes = MAX_FILE_SIZE_MB * 1024 * 1024;
+    if (body.fileSize > maxFileSizeBytes) {
       return badRequest400Response({
-        message: `File size exceeds limit of ${MAX_FILE_SIZE} bytes`,
+        message: `File size exceeds limit of ${MAX_FILE_SIZE_MB} MB`,
       });
     }
 

--- a/packages/cdk/lib/construct/api/assistant.ts
+++ b/packages/cdk/lib/construct/api/assistant.ts
@@ -265,6 +265,9 @@ class AssistantApi extends Construct {
             ASSISTANT_FILES_BUCKET_NAME: fileBucket.bucketName,
             OPENSEARCH_INDEX: 'assistant-docs',
             TENANTS_TABLE_NAME: tenantManager?.tenantsTable.tableName || '',
+            ASSISTANT_FILE_MAX_SIZE_MB: String(
+              props.assistantFileMaxSizeMB ?? 10
+            ),
           }),
         }
       );

--- a/packages/cdk/lib/construct/api/props.ts
+++ b/packages/cdk/lib/construct/api/props.ts
@@ -57,6 +57,9 @@ export type GenericApiProps = {
     readonly apiKey: string; // OPENAI_API_KEY
   };
 
+  // Assistant configuration
+  readonly assistantFileMaxSizeMB?: number;
+
   api: RestApi;
   fileBucket: Bucket;
 

--- a/packages/cdk/lib/stack-input.ts
+++ b/packages/cdk/lib/stack-input.ts
@@ -145,6 +145,8 @@ const baseStackInputSchema = z.object({
   mcpEnabled: z.boolean().default(false),
   // PPTX
   pptxEnabled: z.boolean().default(false),
+  // Assistant
+  assistantFileMaxSizeMB: z.number().min(1).max(100).default(10),
   // LiteLLM Proxy Server
   litellmProxyEnabled: z.boolean().default(false),
   // Guardrail

--- a/packages/cdk/lib/stacks/common/assistant-api-stack.ts
+++ b/packages/cdk/lib/stacks/common/assistant-api-stack.ts
@@ -112,6 +112,9 @@ class AssistantApiStack extends NestedStack {
 
       // OpenAI
       openai: params.openai,
+
+      // Assistant configuration
+      assistantFileMaxSizeMB: params.assistantFileMaxSizeMB,
     });
 
     this.assistantApi = assistantApi;


### PR DESCRIPTION
## 変更概要

アシスタント機能のファイルアップロードサイズ上限をハードコードの10MBから、CDK設定で1〜100MBの範囲で変更可能にしました。

## 変更内容詳細

### 設定追加
- **cdk.example.json**: `assistantFileMaxSizeMB` 設定項目を追加（デフォルト: 10）
- **stack-input.ts**: zodスキーマにバリデーション付きで定義（1〜100MB、デフォルト10）

### Lambda環境変数
- **assistant.ts**: `ASSISTANT_FILE_MAX_SIZE_MB` 環境変数をLambdaに渡すよう追加
- **assistantFileUpload.ts**: ハードコードの10MB制限を環境変数から取得するよう変更

### 型定義
- **props.ts**: `GenericApiProps` に `assistantFileMaxSizeMB` プロパティを追加
- **assistant-api-stack.ts**: 設定値をAPIコンストラクトに伝播

## 設定方法

`cdk.json` に以下を追加:
```json
{
  "assistantFileMaxSizeMB": 50
}
```

## 破壊的変更

なし（デフォルト値10MBで既存動作を維持）

## テスト

- [ ] 設定値を変更してデプロイ
- [ ] 上限以下のファイルがアップロード可能
- [ ] 上限超過時に適切なエラーメッセージが表示される