### PR TITLE
:bug: fix(assistant): Markdownファイルのアップロード時のMIMEタイプ検出を修正

### DIFF
--- a/packages/web/src/hooks/useAssistantForm.ts
+++ b/packages/web/src/hooks/useAssistantForm.ts
@@ -46,6 +46,25 @@ const getInitialFormData = (
   knowledgeSources: initialData?.knowledgeSources || [],
 });
 
+/**
+ * Get the correct MIME type for a file based on extension.
+ * Browsers don't always correctly detect MIME types for text files like .md
+ */
+const getContentType = (file: File): string => {
+  if (file.type) return file.type;
+
+  const extension = file.name.split('.').pop()?.toLowerCase();
+  const mimeTypes: Record<string, string> = {
+    md: 'text/markdown',
+    txt: 'text/plain',
+    pdf: 'application/pdf',
+    doc: 'application/msword',
+    docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  };
+
+  return mimeTypes[extension || ''] || 'application/octet-stream';
+};
+
 const useAssistantForm = (
   options: UseAssistantFormOptions = {}
 ): UseAssistantFormReturn => {
@@ -85,11 +104,13 @@ const useAssistantForm = (
         for (let i = 0; i < files.length; i++) {
           const file = files[i];
           try {
+            const contentType = getContentType(file);
+
             // Request upload URL
             const { uploadUrl, fileKey } = await requestUploadUrl({
               fileName: file.name,
               fileSize: file.size,
-              contentType: file.type,
+              contentType,
             });
 
             // Upload file to S3
@@ -97,7 +118,7 @@ const useAssistantForm = (
               method: 'PUT',
               body: file,
               headers: {
-                'Content-Type': file.type,
+                'Content-Type': contentType,
               },
             });
 


### PR DESCRIPTION
## 📋 変更概要

アシスタント機能でMarkdown（.md）ファイルをアップロードする際、ブラウザがMIMEタイプを正しく検出できない問題を修正しました。

## 📊 変更内容詳細

### 変更 🔄
- **`packages/web/src/hooks/useAssistantForm.ts`** (+23/-2行)
  - `getContentType()`ヘルパー関数を追加
  - ブラウザが`file.type`を空で返す場合、拡張子からMIMEタイプを判定
  - 対応拡張子: `.md`, `.txt`, `.pdf`, `.doc`, `.docx`

## 🧪 テスト手順

1. アシスタント作成画面でナレッジソースとして`.md`ファイルをアップロード
2. アップロードが成功することを確認

## ⚠️ 破壊的変更

なし