### PR TITLE
:sparkles: feat(cdk): アシスタントストリーミング関数のARNをCfnOutputに追加

### DIFF
--- a/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
@@ -331,6 +331,12 @@ export class GenerativeAiUseCasesStack extends Stack {
       value: api.invokeFlowFunction.functionArn,
     });
 
+    new CfnOutput(this, 'AssistantMessageStreamFunctionArn', {
+      value:
+        assistantApiStack.assistantApi.assistantMessageStreamFunction
+          .functionArn,
+    });
+
     new CfnOutput(this, 'Flows', {
       value: Buffer.from(JSON.stringify(params.flows)).toString('base64'),
     });


### PR DESCRIPTION
## 📋 変更概要

CloudFormationスタックの出力に `AssistantMessageStreamFunctionArn` を追加し、アシスタントのストリーミングレスポンス用Lambda関数のARNを外部から参照可能にする。

## 📊 変更内容詳細

### 変更 🔄
- **packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts** (+6行)
  - `AssistantMessageStreamFunctionArn` という新しい `CfnOutput` を追加
  - `assistantApiStack.assistantApi.assistantMessageStreamFunction.functionArn` を出力
  - 他システムやCI/CDパイプラインからLambda ARNを参照するために必要

## ⚠️ 破壊的変更

なし

## 🧪 テスト

- [ ] `npm run lint` でエラーが出ない
- [ ] TypeScriptのビルドで型エラーが出ない
- [ ] 手元でフォーマットした際に差分が出ない

## 📝 注意事項

PR #158 で追加されたアシスタントストリーミング機能に関連する変更です。