### PR TITLE
:bug: `ASSISTANT_MESSAGE_STREAM_FUNCTION_ARN`を`setup-env.sh`で設定

### DIFF
--- a/setup-env.sh
+++ b/setup-env.sh
@@ -53,3 +53,4 @@ export VITE_APP_SPEECH_TO_SPEECH_EVENT_API_ENDPOINT=$(extract_value "$stack_outp
 export VITE_APP_SPEECH_TO_SPEECH_MODEL_IDS=$(extract_value "$stack_output" SpeechToSpeechModelIds)
 export VITE_APP_MCP_ENABLED=$(extract_value "$stack_output" McpEnabled)
 export VITE_APP_MCP_ENDPOINT=$(extract_value "$stack_output" McpEndpoint)
+export VITE_APP_ASSISTANT_MESSAGE_STREAM_FUNCTION_ARN=$(extract_value "$stack_output" AssistantMessageStreamFunctionArn)


### PR DESCRIPTION
## Summary
- Add `VITE_APP_ASSISTANT_MESSAGE_STREAM_FUNCTION_ARN` environment variable extraction from CDK stack output
- This enables the frontend to access the Assistant Message Stream Lambda function ARN for streaming support

## Test plan
- [ ] Verify `setup-env.sh` correctly extracts `AssistantMessageStreamFunctionArn` from CDK output
- [ ] Confirm the environment variable is properly set after running the script

🤖 Generated with [Claude Code](https://claude.com/claude-code)