### PR TITLE
✨ feat(assistant): バックエンドでfirstQuestionsフィールドをサポート

### DIFF
--- a/packages/cdk/lambda/repository/assistant.ts
+++ b/packages/cdk/lambda/repository/assistant.ts
@@ -124,6 +124,7 @@ export const createAssistant = async (
     syncStatus: 'QUEUED',
     syncStatusReason: '',
     knowledgeSources: normalizeKnowledgeSources(data.knowledgeSources),
+    ...(data.firstQuestions && { firstQuestions: data.firstQuestions }),
     ...(data.s3Urls && { s3Urls: data.s3Urls }),
     updatedDate: now,
   };
@@ -451,6 +452,11 @@ export const updateAssistant = async (
     updateExpressions.push('#s3Urls = :s3Urls');
     expressionAttributeNames['#s3Urls'] = 's3Urls';
     expressionAttributeValues[':s3Urls'] = updates.s3Urls;
+  }
+  if (updates.firstQuestions !== undefined) {
+    updateExpressions.push('#firstQuestions = :firstQuestions');
+    expressionAttributeNames['#firstQuestions'] = 'firstQuestions';
+    expressionAttributeValues[':firstQuestions'] = updates.firstQuestions;
   }
 
   // Always update updatedDate

--- a/packages/cdk/lambda/repository/assistantCommon.ts
+++ b/packages/cdk/lambda/repository/assistantCommon.ts
@@ -20,6 +20,7 @@ export function formatAssistantFromDb(item: any): any {
     syncStatus: item.syncStatus,
     syncStatusReason: item.syncStatusReason,
     knowledgeSources: ensureKnowledgeSourceStatus(item.knowledgeSources),
+    firstQuestions: item.firstQuestions,
     s3Urls: item.s3Urls || [],
     createdDate: item.createdDate,
     updatedDate: item.updatedDate,

--- a/packages/types/src/assistant.d.ts
+++ b/packages/types/src/assistant.d.ts
@@ -26,6 +26,7 @@ export type Assistant = {
   syncStatus: 'QUEUED' | 'SYNCING' | 'SUCCEEDED' | 'FAILED' | 'PARTIAL';
   syncStatusReason: string;
   knowledgeSources: KnowledgeSource[];
+  firstQuestions?: string[]; // Quick starter questions for new chats
   s3Urls?: string[]; // Legacy field for backward compatibility
   updatedDate: string;
 };
@@ -83,6 +84,7 @@ export type CreateAssistantRequest = {
   ragEnabled: boolean;
   visibility?: 'private' | 'public'; // Optional, defaults to 'private'
   knowledgeSources?: KnowledgeSource[];
+  firstQuestions?: string[]; // Quick starter questions for new chats
   s3Urls?: string[]; // Legacy field for backward compatibility
 };
 
@@ -94,6 +96,7 @@ export type UpdateAssistantRequest = {
   ragEnabled?: boolean;
   visibility?: 'private' | 'public';
   knowledgeSources?: KnowledgeSource[];
+  firstQuestions?: string[]; // Quick starter questions for new chats
   s3Urls?: string[]; // Legacy field for backward compatibility
 };
 


### PR DESCRIPTION
## Summary
- アシスタントの「最初の質問」機能をバックエンドで対応
- Assistant型にfirstQuestionsフィールドを追加
- createAssistant()、updateAssistant()、formatAssistantFromDb()で処理

## Test plan
- [ ] アシスタント作成時にfirstQuestionsが保存されることを確認
- [ ] アシスタント更新時にfirstQuestionsが更新されることを確認
- [ ] アシスタント取得時にfirstQuestionsがレスポンスに含まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)