### PR TITLE
:bug: fix(litellm): マルチモーダルコンテンツがVertex AI Geminiに送信されない問題を修正

### DIFF
--- a/packages/cdk/lambda/utils/langchainApi.ts
+++ b/packages/cdk/lambda/utils/langchainApi.ts
@@ -15,7 +15,6 @@ import {
   SystemMessage,
   HumanMessage,
   AIMessage,
-  DataContentBlock,
 } from '@langchain/core/messages';
 import { streamingChunk } from './streamingChunk';
 import { StopReason } from '@aws-sdk/client-bedrock-runtime';
@@ -71,14 +70,40 @@ const getTextDataFromExtraData = async (
 };
 
 /**
- * ExtraDataをLangChain用のDataContentBlockに変換する
+ * OpenAI互換のimage_url形式のコンテンツブロック
+ * LiteLLMが全プロバイダー(OpenAI, Anthropic, Bedrock, Vertex AI等)に正しく変換する
+ */
+interface ImageUrlContentBlock {
+  type: 'image_url';
+  image_url: {
+    url: string;
+  };
+}
+
+/**
+ * テキスト形式のコンテンツブロック
+ */
+interface TextContentBlock {
+  type: 'text';
+  text: string;
+}
+
+/**
+ * サポートするコンテンツブロックの型
+ */
+type SupportedContentBlock = ImageUrlContentBlock | TextContentBlock;
+
+/**
+ * ExtraDataをLangChain用のコンテンツブロックに変換する
+ * OpenAI互換のimage_url形式を使用することで、LiteLLMが全プロバイダー
+ * (OpenAI, Anthropic, Bedrock, Vertex AI等)に正しく変換できる
  * @param extraData 対象のデータ
- * @returns LangChain用のDataContentBlock
+ * @returns LangChain用のコンテンツブロック
  */
 const convertExtraData = async (
   extraData: ExtraData
-): Promise<DataContentBlock> => {
-  const { type: dataType, name, source } = extraData;
+): Promise<SupportedContentBlock> => {
+  const { type: dataType, source } = extraData;
   const { type: sourceType, mediaType } = source;
 
   const data = await getTextDataFromExtraData(extraData);
@@ -86,35 +111,30 @@ const convertExtraData = async (
   if (sourceType === 'json') {
     return {
       type: 'text',
-      source_type: 'text',
-      mime_type: mediaType,
       text: data,
     };
   }
 
   switch (dataType) {
     case 'image':
+      // OpenAI互換のimage_url形式を使用（LiteLLMが全プロバイダーに変換）
       return {
-        type: 'image',
-        source_type: 'base64',
-        mime_type: mediaType,
-        data: data,
+        type: 'image_url',
+        image_url: {
+          url: `data:${mediaType};base64,${data}`,
+        },
       };
     case 'file':
+      // ファイルもimage_url形式で送信（PDFなどのドキュメントも対応）
       return {
-        type: 'file',
-        source_type: 'base64',
-        mime_type: mediaType,
-        data: data,
-        metadata: {
-          filename: name,
+        type: 'image_url',
+        image_url: {
+          url: `data:${mediaType};base64,${data}`,
         },
       };
     case 'json':
       return {
         type: 'text',
-        source_type: 'text',
-        mime_type: mediaType,
         text: data,
       };
     case 'video':

--- a/packages/cdk/lambda/utils/liteLlmApi.ts
+++ b/packages/cdk/lambda/utils/liteLlmApi.ts
@@ -1,5 +1,6 @@
 import {
   ApiInterface,
+  ExtraData,
   GenerateImageParams,
   GenerateVideoParams,
   Model,
@@ -11,14 +12,149 @@ import { SignatureV4 } from '@smithy/signature-v4';
 import { HttpRequest } from '@smithy/protocol-http';
 import { Sha256 } from '@aws-crypto/sha256-js';
 import { defaultProvider } from '@aws-sdk/credential-provider-node';
+import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
+import { sdkStreamMixin } from '@smithy/util-stream-node';
 
-const createOpenAIChatCompletionMessages = (messages: UnrecordedMessage[]) => {
-  return messages.map((message) => {
-    return {
-      role: message.role,
-      content: message.content,
-    };
+/**
+ * OpenAI互換のimage_url形式のコンテンツブロック
+ */
+interface ImageUrlContentBlock {
+  type: 'image_url';
+  image_url: {
+    url: string;
+  };
+}
+
+/**
+ * テキスト形式のコンテンツブロック
+ */
+interface TextContentBlock {
+  type: 'text';
+  text: string;
+}
+
+/**
+ * OpenAI互換のメッセージコンテンツ型
+ */
+type OpenAIMessageContent =
+  | string
+  | Array<TextContentBlock | ImageUrlContentBlock>;
+
+/**
+ * OpenAI互換のメッセージ型
+ */
+interface OpenAIMessage {
+  role: string;
+  content: OpenAIMessageContent;
+}
+
+/**
+ * S3からファイルを取得してBase64形式で返す
+ */
+const getS3FileAsBase64 = async (extraData: ExtraData): Promise<string> => {
+  const s3Client = new S3Client();
+  const command = new GetObjectCommand({
+    Bucket: process.env.BUCKET_NAME,
+    Key: extraData.source.data,
   });
+
+  const response = await s3Client.send(command);
+  if (!response.Body) {
+    throw new Error('No body in response');
+  }
+
+  const sdkStream = sdkStreamMixin(response.Body);
+  const data = await sdkStream.transformToByteArray();
+  return Buffer.from(data).toString('base64');
+};
+
+/**
+ * ExtraDataからデータを取得
+ */
+const getDataFromExtraData = async (extraData: ExtraData): Promise<string> => {
+  if (extraData.source.type === 's3') {
+    return await getS3FileAsBase64(extraData);
+  }
+  return extraData.source.data;
+};
+
+/**
+ * ExtraDataをOpenAI互換のimage_url形式に変換
+ * LiteLLMが全プロバイダー(OpenAI, Anthropic, Bedrock, Vertex AI等)に正しく変換する
+ */
+const convertExtraDataToContentBlock = async (
+  extraData: ExtraData
+): Promise<ImageUrlContentBlock | TextContentBlock> => {
+  const { type: dataType, source } = extraData;
+  const { type: sourceType, mediaType } = source;
+
+  const data = await getDataFromExtraData(extraData);
+
+  // JSONデータはテキストとして扱う
+  if (sourceType === 'json' || dataType === 'json') {
+    return {
+      type: 'text',
+      text: data,
+    };
+  }
+
+  // 画像、ファイル（PDF等）はimage_url形式で送信
+  // LiteLLMがプロバイダーごとに適切な形式に変換する
+  switch (dataType) {
+    case 'image':
+    case 'file':
+      return {
+        type: 'image_url',
+        image_url: {
+          url: `data:${mediaType};base64,${data}`,
+        },
+      };
+    case 'video':
+      throw new Error('Video input is not supported currently.');
+    default:
+      return {
+        type: 'text',
+        text: data,
+      };
+  }
+};
+
+/**
+ * UnrecordedMessageをOpenAI互換形式に変換
+ * extraDataがある場合はマルチモーダルコンテンツとして構築
+ */
+const createOpenAIChatCompletionMessages = async (
+  messages: UnrecordedMessage[]
+): Promise<OpenAIMessage[]> => {
+  return Promise.all(
+    messages.map(async (message) => {
+      // extraDataがない場合は単純なテキストメッセージ
+      if (!message.extraData || message.extraData.length === 0) {
+        return {
+          role: message.role,
+          content: message.content,
+        };
+      }
+
+      // extraDataがある場合はマルチモーダルコンテンツを構築
+      const contentBlocks: Array<TextContentBlock | ImageUrlContentBlock> = [
+        {
+          type: 'text',
+          text: message.content,
+        },
+      ];
+
+      for (const extra of message.extraData) {
+        const block = await convertExtraDataToContentBlock(extra);
+        contentBlocks.push(block);
+      }
+
+      return {
+        role: message.role,
+        content: contentBlocks,
+      };
+    })
+  );
 };
 
 const convertFinishReason = (
@@ -41,7 +177,7 @@ const convertFinishReason = (
 
 interface ChatCompletionRequest {
   model: string;
-  messages: Array<{ role: string; content: string }>;
+  messages: OpenAIMessage[];
   stream: boolean;
 }
 
@@ -91,7 +227,7 @@ const liteLlmApi: ApiInterface = {
       throw new Error('LITELLM_ENDPOINT environment variable is not set');
     }
 
-    const openAIMessages = createOpenAIChatCompletionMessages(messages);
+    const openAIMessages = await createOpenAIChatCompletionMessages(messages);
     const requestBody = {
       model: model.modelId,
       messages: openAIMessages,
@@ -137,7 +273,7 @@ const liteLlmApi: ApiInterface = {
       throw new Error('LITELLM_ENDPOINT environment variable is not set');
     }
 
-    const openAIMessages = createOpenAIChatCompletionMessages(messages);
+    const openAIMessages = await createOpenAIChatCompletionMessages(messages);
     const requestBody = {
       model: model.modelId,
       messages: openAIMessages,


### PR DESCRIPTION
## 📋 変更概要

LiteLLM経由でVertex AI Geminiにファイル（画像・PDF等）を送信しても認識されない問題を修正。`extraData`が無視されていた根本原因を解消し、OpenAI互換形式で正しくマルチモーダルコンテンツを送信するよう修正。

## 🔍 問題の原因

`liteLlmApi.ts`の`createOpenAIChatCompletionMessages`関数が`message.content`（テキスト）のみを抽出し、`message.extraData`（画像・ファイル）を完全に無視していた。

## 📊 変更内容

### `liteLlmApi.ts` (+144/-8 行) - **根本原因の修正**
- `extraData`をOpenAI互換の`image_url`形式に変換する処理を追加
- S3に保存されたファイルの取得・Base64変換処理を追加
- マルチモーダルコンテンツ配列の構築ロジックを実装

### `langchainApi.ts` (+39/-19 行)
- LangChainの`DataContentBlock`形式からOpenAI互換`image_url`形式に変更
- 不要なプロパティ（`source_type`, `mime_type`）を削除

## ✅ 互換性

OpenAI互換の`image_url`形式はLiteLLMが全プロバイダーに自動変換するため、既存のOpenAI/Anthropic/Bedrock連携に影響なし。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)