### PR TITLE
✨ feat: ユーザー削除機能を実装

### DIFF
--- a/packages/cdk/lambda/deleteOwnAccount.ts
+++ b/packages/cdk/lambda/deleteOwnAccount.ts
@@ -1,0 +1,76 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import {
+  CognitoIdentityProviderClient,
+  AdminDeleteUserCommand,
+} from '@aws-sdk/client-cognito-identity-provider';
+import { verifyToken } from './utils/auth';
+import {
+  internalServerError500Response,
+  notFound404Response,
+  ok200Response,
+  unauthorized401Response,
+} from './utils/apiResponse';
+
+const cognitoClient = new CognitoIdentityProviderClient({
+  region: process.env.AWS_REGION!,
+});
+const USER_POOL_ID = process.env.USER_POOL_ID!;
+
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  console.log('Event:', JSON.stringify(event, null, 2));
+
+  try {
+    // Get token from Authorization header
+    const authHeader = event.headers.Authorization || event.headers.authorization;
+    if (!authHeader) {
+      return unauthorized401Response({ message: 'Authorization header is required' });
+    }
+
+    // Remove 'Bearer ' prefix if present
+    const token = authHeader.startsWith('Bearer ')
+      ? authHeader.slice(7)
+      : authHeader;
+
+    // Verify token and get user info
+    const claims = await verifyToken(token);
+    if (!claims) {
+      return unauthorized401Response({ message: 'Invalid or expired token' });
+    }
+
+    const username = claims['cognito:username'] || claims.username;
+    if (!username) {
+      return unauthorized401Response({ message: 'Username not found in token' });
+    }
+
+    // Delete the user from Cognito
+    try {
+      const deleteCommand = new AdminDeleteUserCommand({
+        UserPoolId: USER_POOL_ID,
+        Username: username,
+      });
+
+      await cognitoClient.send(deleteCommand);
+      console.log(`Successfully deleted user: ${username}`);
+
+      return ok200Response({
+        message: 'Account deleted successfully',
+      });
+    } catch (error: unknown) {
+      console.error(`Failed to delete user ${username}:`, error);
+
+      if (error instanceof Error && error.name === 'UserNotFoundException') {
+        return notFound404Response({ message: 'User not found' });
+      }
+
+      throw error;
+    }
+  } catch (error) {
+    console.error('Error deleting account:', error);
+    return internalServerError500Response({
+      message: 'Failed to delete account',
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+};

--- a/packages/cdk/lib/construct/api/index.ts
+++ b/packages/cdk/lib/construct/api/index.ts
@@ -49,6 +49,7 @@ import FileApi from './file';
 import FileBucket from '../file-bucket';
 import ShareApi from './share';
 import AdminApi from './admin';
+import UserApi from './user';
 import { CentralPptxApi } from './central-pptx';
 
 export interface BackendApiProps {
@@ -395,6 +396,7 @@ export class Api extends Construct {
     new VideoApi(this, 'VideoAPI', apiProps);
     new WebTextApi(this, 'WebTextAPI', apiProps);
     new AdminApi(this, 'AdminAPI', apiProps);
+    new UserApi(this, 'UserAPI', apiProps);
 
     // Central PPTX API for multi-tenant architecture
     // Lambda functions dynamically access tenant-specific resources based on Cognito claims

--- a/packages/cdk/lib/construct/api/user.ts
+++ b/packages/cdk/lib/construct/api/user.ts
@@ -1,0 +1,57 @@
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { Construct } from 'constructs';
+import { LAMBDA_RUNTIME_NODEJS } from '../../../consts';
+import { Duration } from 'aws-cdk-lib';
+import { getBaseEnvironment } from './util';
+import { GenericApiProps } from './props';
+import { LambdaIntegration } from 'aws-cdk-lib/aws-apigateway';
+import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
+
+export type UserApiProps = GenericApiProps;
+
+class UserApi extends Construct {
+  constructor(scope: Construct, id: string, props: UserApiProps) {
+    super(scope, id);
+
+    const { api, userPool, commonAuthorizerProps, userPoolClient } = props;
+
+    // Lambda function for deleting own account
+    const deleteOwnAccountFunction = new NodejsFunction(
+      this,
+      'DeleteOwnAccount',
+      {
+        runtime: LAMBDA_RUNTIME_NODEJS,
+        entry: './lambda/deleteOwnAccount.ts',
+        timeout: Duration.minutes(2),
+        bundling: {
+          nodeModules: ['aws-jwt-verify'],
+        },
+        environment: getBaseEnvironment(this, props, {
+          USER_POOL_CLIENT_ID: userPoolClient.userPoolClientId,
+        }),
+      }
+    );
+
+    // Grant Cognito delete permission
+    deleteOwnAccountFunction.addToRolePolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: ['cognito-idp:AdminDeleteUser'],
+        resources: [userPool.userPoolArn],
+      })
+    );
+
+    // API routes
+    const userResource = api.root.addResource('user');
+    const accountResource = userResource.addResource('account');
+
+    // DELETE /user/account - Delete own account
+    accountResource.addMethod(
+      'DELETE',
+      new LambdaIntegration(deleteOwnAccountFunction),
+      commonAuthorizerProps
+    );
+  }
+}
+
+export default UserApi;

--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -1036,6 +1036,16 @@ rag:
   please_refer: .
   retrieving: Retrieving reference documents from Kendra...
   title: RAG Chat
+settings:
+  deleteAccount: Delete Account
+  deleteAccountButton: Delete Account
+  deleteAccountCancel: Cancel
+  deleteAccountConfirm: Delete
+  deleteAccountConfirmDescription: This action cannot be undone. Please enter the following to confirm.
+  deleteAccountConfirmTitle: Confirm Account Deletion
+  deleteAccountDeleteLabel: Type "DELETE" to confirm
+  deleteAccountDescription: Deleting your account will permanently remove all your data. This action cannot be undone.
+  deleteAccountEmailLabel: Enter your email address
 shared:
   contact_admin: Please contact the administrator.
   error: Error

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -878,6 +878,16 @@ rag:
   please_refer: をご参照ください。
   retrieving: Kendra から参考ドキュメントを取得しています...
   title: RAG チャット
+settings:
+  deleteAccount: アカウント削除
+  deleteAccountButton: アカウントを削除
+  deleteAccountCancel: キャンセル
+  deleteAccountConfirm: 削除する
+  deleteAccountConfirmDescription: この操作は取り消せません。確認のため、以下の情報を入力してください。
+  deleteAccountConfirmTitle: アカウント削除の確認
+  deleteAccountDeleteLabel: 「DELETE」と入力
+  deleteAccountDescription: アカウントを削除すると、すべてのデータが失われます。この操作は取り消せません。
+  deleteAccountEmailLabel: メールアドレスを入力
 shared:
   contact_admin: 管理者に問い合わせてください。
   error: エラー

--- a/packages/web/src/components/DialogConfirmDeleteAccount.tsx
+++ b/packages/web/src/components/DialogConfirmDeleteAccount.tsx
@@ -38,7 +38,7 @@ const DialogConfirmDeleteAccount: React.FC<Props> = (props) => {
             <Dialog.Close asChild>
               <button
                 className="rounded-sm opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 disabled:pointer-events-none"
-                aria-label="Close">
+                aria-label={t('common.close')}>
                 <PiX className="h-4 w-4" />
               </button>
             </Dialog.Close>

--- a/packages/web/src/components/DialogConfirmDeleteAccount.tsx
+++ b/packages/web/src/components/DialogConfirmDeleteAccount.tsx
@@ -1,0 +1,92 @@
+import React, { useState, useEffect } from 'react';
+import { BaseProps } from '../@types/common';
+import Button from './Button';
+import ModalDialog from './ModalDialog';
+import { useTranslation } from 'react-i18next';
+
+type Props = BaseProps & {
+  isOpen: boolean;
+  userEmail: string;
+  onDelete: () => void;
+  onClose: () => void;
+  isDeleting?: boolean;
+};
+
+const DialogConfirmDeleteAccount: React.FC<Props> = (props) => {
+  const { t } = useTranslation();
+  const [emailInput, setEmailInput] = useState('');
+  const [deleteInput, setDeleteInput] = useState('');
+
+  // Reset inputs when dialog opens/closes
+  useEffect(() => {
+    if (!props.isOpen) {
+      setEmailInput('');
+      setDeleteInput('');
+    }
+  }, [props.isOpen]);
+
+  const isValid = emailInput === props.userEmail && deleteInput === 'DELETE';
+
+  return (
+    <ModalDialog
+      {...props}
+      title={t('settings.deleteAccountConfirmTitle')}
+      onClose={props.onClose}>
+      <div className="space-y-4">
+        <p className="text-gray-600">
+          {t('settings.deleteAccountConfirmDescription')}
+        </p>
+
+        <div className="space-y-3">
+          <div>
+            <label className="mb-1 block text-sm font-medium text-gray-700">
+              {t('settings.deleteAccountEmailLabel')}
+            </label>
+            <input
+              type="email"
+              value={emailInput}
+              onChange={(e) => setEmailInput(e.target.value)}
+              placeholder={props.userEmail}
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+              disabled={props.isDeleting}
+            />
+          </div>
+
+          <div>
+            <label className="mb-1 block text-sm font-medium text-gray-700">
+              {t('settings.deleteAccountDeleteLabel')}
+            </label>
+            <input
+              type="text"
+              value={deleteInput}
+              onChange={(e) => setDeleteInput(e.target.value)}
+              placeholder="DELETE"
+              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+              disabled={props.isDeleting}
+            />
+          </div>
+        </div>
+
+        <div className="mt-6 flex justify-end gap-2">
+          <Button
+            outlined
+            onClick={props.onClose}
+            className="p-2"
+            disabled={props.isDeleting}>
+            {t('settings.deleteAccountCancel')}
+          </Button>
+          <Button
+            onClick={props.onDelete}
+            className="bg-red-600 p-2 text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:bg-red-300"
+            disabled={!isValid || props.isDeleting}>
+            {props.isDeleting
+              ? t('common.loading')
+              : t('settings.deleteAccountConfirm')}
+          </Button>
+        </div>
+      </div>
+    </ModalDialog>
+  );
+};
+
+export default DialogConfirmDeleteAccount;

--- a/packages/web/src/components/DialogConfirmDeleteAccount.tsx
+++ b/packages/web/src/components/DialogConfirmDeleteAccount.tsx
@@ -1,10 +1,9 @@
 import React, { useState, useEffect } from 'react';
-import { BaseProps } from '../@types/common';
-import Button from './Button';
-import ModalDialog from './ModalDialog';
+import * as Dialog from '@radix-ui/react-dialog';
 import { useTranslation } from 'react-i18next';
+import { PiX } from 'react-icons/pi';
 
-type Props = BaseProps & {
+type Props = {
   isOpen: boolean;
   userEmail: string;
   onDelete: () => void;
@@ -28,64 +27,75 @@ const DialogConfirmDeleteAccount: React.FC<Props> = (props) => {
   const isValid = emailInput === props.userEmail && deleteInput === 'DELETE';
 
   return (
-    <ModalDialog
-      {...props}
-      title={t('settings.deleteAccountConfirmTitle')}
-      onClose={props.onClose}>
-      <div className="space-y-4">
-        <p className="text-gray-600">
-          {t('settings.deleteAccountConfirmDescription')}
-        </p>
+    <Dialog.Root open={props.isOpen} onOpenChange={(open: boolean) => !open && props.onClose()}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-[60] bg-black/30 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
+        <Dialog.Content className="fixed left-[50%] top-[50%] z-[60] w-full max-w-md translate-x-[-50%] translate-y-[-50%] rounded-lg bg-white p-6 shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95">
+          <div className="flex items-center justify-between">
+            <Dialog.Title className="text-lg font-semibold text-gray-900">
+              {t('settings.deleteAccountConfirmTitle')}
+            </Dialog.Title>
+            <Dialog.Close asChild>
+              <button
+                className="rounded-sm opacity-70 ring-offset-white transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-gray-400 focus:ring-offset-2 disabled:pointer-events-none"
+                aria-label="Close">
+                <PiX className="h-4 w-4" />
+              </button>
+            </Dialog.Close>
+          </div>
+          <Dialog.Description className="mt-2 text-sm text-gray-600">
+            {t('settings.deleteAccountConfirmDescription')}
+          </Dialog.Description>
 
-        <div className="space-y-3">
-          <div>
-            <label className="mb-1 block text-sm font-medium text-gray-700">
-              {t('settings.deleteAccountEmailLabel')}
-            </label>
-            <input
-              type="email"
-              value={emailInput}
-              onChange={(e) => setEmailInput(e.target.value)}
-              placeholder={props.userEmail}
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
-              disabled={props.isDeleting}
-            />
+          <div className="mt-4 space-y-3">
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                {t('settings.deleteAccountEmailLabel')}
+              </label>
+              <input
+                type="email"
+                value={emailInput}
+                onChange={(e) => setEmailInput(e.target.value)}
+                placeholder={props.userEmail}
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+                disabled={props.isDeleting}
+              />
+            </div>
+
+            <div>
+              <label className="mb-1 block text-sm font-medium text-gray-700">
+                {t('settings.deleteAccountDeleteLabel')}
+              </label>
+              <input
+                type="text"
+                value={deleteInput}
+                onChange={(e) => setDeleteInput(e.target.value)}
+                placeholder="DELETE"
+                className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
+                disabled={props.isDeleting}
+              />
+            </div>
           </div>
 
-          <div>
-            <label className="mb-1 block text-sm font-medium text-gray-700">
-              {t('settings.deleteAccountDeleteLabel')}
-            </label>
-            <input
-              type="text"
-              value={deleteInput}
-              onChange={(e) => setDeleteInput(e.target.value)}
-              placeholder="DELETE"
-              className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
-              disabled={props.isDeleting}
-            />
+          <div className="mt-6 flex justify-end gap-2">
+            <button
+              onClick={props.onClose}
+              className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+              disabled={props.isDeleting}>
+              {t('settings.deleteAccountCancel')}
+            </button>
+            <button
+              onClick={props.onDelete}
+              className="rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 disabled:cursor-not-allowed disabled:bg-red-300"
+              disabled={!isValid || props.isDeleting}>
+              {props.isDeleting
+                ? t('common.loading')
+                : t('settings.deleteAccountConfirm')}
+            </button>
           </div>
-        </div>
-
-        <div className="mt-6 flex justify-end gap-2">
-          <Button
-            outlined
-            onClick={props.onClose}
-            className="p-2"
-            disabled={props.isDeleting}>
-            {t('settings.deleteAccountCancel')}
-          </Button>
-          <Button
-            onClick={props.onDelete}
-            className="bg-red-600 p-2 text-white hover:bg-red-700 disabled:cursor-not-allowed disabled:bg-red-300"
-            disabled={!isValid || props.isDeleting}>
-            {props.isDeleting
-              ? t('common.loading')
-              : t('settings.deleteAccountConfirm')}
-          </Button>
-        </div>
-      </div>
-    </ModalDialog>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 };
 

--- a/packages/web/src/components/SettingsModal.tsx
+++ b/packages/web/src/components/SettingsModal.tsx
@@ -7,6 +7,7 @@ import {
   PiX,
   PiCaretDown,
   PiCheck,
+  PiTrash,
 } from 'react-icons/pi';
 import {
   useSettings,
@@ -14,6 +15,11 @@ import {
   Language,
   SendMessageMethod,
 } from '../hooks/useSettings';
+import { useTranslation } from 'react-i18next';
+import useHttp from '../hooks/useHttp';
+import useUserInfo from '../hooks/useUserInfo';
+import { performLogoutAndReload } from '../utils/auth';
+import DialogConfirmDeleteAccount from './DialogConfirmDeleteAccount';
 
 interface SettingsModalProps {
   open: boolean;
@@ -82,10 +88,27 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
   open,
   onOpenChange,
 }) => {
+  const { t } = useTranslation();
   const { settings, updateSettings } = useSettings();
+  const { api } = useHttp();
+  const { userInfo } = useUserInfo();
   const [activeTab, setActiveTab] = useState<'general' | 'ai-customize'>(
     'general'
   );
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
+
+  const handleDeleteAccount = async () => {
+    setIsDeleting(true);
+    try {
+      await api.delete('/user/account');
+      // After successful deletion, logout and reload
+      await performLogoutAndReload('Account deleted');
+    } catch (error) {
+      console.error('Failed to delete account:', error);
+      setIsDeleting(false);
+    }
+  };
 
   const themeOptions: { value: Theme; label: string }[] = [
     { value: 'light', label: 'ライト' },
@@ -204,6 +227,24 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
                       options={sendMessageOptions}
                     />
                   </div>
+
+                  {/* Delete Account Section */}
+                  <div className="border-t border-gray-200 pt-6">
+                    <div className="space-y-2">
+                      <label className="text-sm font-medium text-red-600">
+                        {t('settings.deleteAccount')}
+                      </label>
+                      <p className="text-sm text-gray-500">
+                        {t('settings.deleteAccountDescription')}
+                      </p>
+                      <button
+                        onClick={() => setIsDeleteDialogOpen(true)}
+                        className="mt-2 flex items-center gap-2 rounded-md bg-red-600 px-4 py-2 text-sm font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2">
+                        <PiTrash className="h-4 w-4" />
+                        {t('settings.deleteAccountButton')}
+                      </button>
+                    </div>
+                  </div>
                 </div>
               )}
 
@@ -261,6 +302,15 @@ const SettingsModal: React.FC<SettingsModalProps> = ({
           </div>
         </Dialog.Content>
       </Dialog.Portal>
+
+      {/* Delete Account Confirmation Dialog */}
+      <DialogConfirmDeleteAccount
+        isOpen={isDeleteDialogOpen}
+        userEmail={userInfo?.email || ''}
+        onDelete={handleDeleteAccount}
+        onClose={() => setIsDeleteDialogOpen(false)}
+        isDeleting={isDeleting}
+      />
     </Dialog.Root>
   );
 };


### PR DESCRIPTION
## Summary
- ユーザーが自分のアカウントを削除できる機能を追加
- Cognito UserPoolからユーザーを削除する実装（データ削除は今後対応）
- 設定モーダルの「一般」タブに退会ボタンを配置
- メールアドレスと「DELETE」の入力による二重確認を実装

## Test plan
- [ ] 設定モーダルを開き、「一般」タブに退会ボタンが表示されることを確認
- [ ] 退会ボタンをクリックし、確認ダイアログが表示されることを確認
- [ ] 誤ったメールアドレスまたは「DELETE」以外の入力では削除ボタンが無効のままであることを確認
- [ ] 正しいメールアドレスと「DELETE」を入力すると削除ボタンが有効になることを確認
- [ ] 削除実行後、ログアウトされることを確認
- [ ] CDKデプロイ後、APIが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)