### PR TITLE
:sparkles: feat(chat): メッセージ送信前にチャットを作成してURL遷移する

### DIFF
--- a/packages/web/src/components/InputChatContent.tsx
+++ b/packages/web/src/components/InputChatContent.tsx
@@ -35,6 +35,7 @@ type Props = {
   accept?: string[];
   canStop?: boolean;
   className?: string;
+  isCreatingChat?: boolean;
 } & (
   | {
       hideReset?: false;
@@ -236,8 +237,8 @@ const InputChatContent: React.FC<Props> = (props) => {
           {/* 右側の送信ボタン */}
           <ButtonSend
             className=""
-            disabled={disabledSend}
-            loading={loading || uploading}
+            disabled={disabledSend || props.isCreatingChat}
+            loading={loading || uploading || props.isCreatingChat}
             onClick={props.onSend}
             icon={props.sendIcon}
             canStop={props.canStop}

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -134,6 +134,7 @@ const useChatState = create<{
   addMessageIdsToUnrecordedMessages: (id: string) => ToBeRecordedMessage[];
   replaceMessages: (id: string, messages: RecordedMessage[]) => void;
   setPredictedTitle: (id: string) => Promise<void>;
+  migrateState: (fromId: string, toId: string) => void;
 }>((set, get) => {
   const {
     createChat,
@@ -705,6 +706,40 @@ const useChatState = create<{
     replaceMessages(id, messages);
   };
 
+  const migrateState = (fromId: string, toId: string) => {
+    set((state) => {
+      const currentChat = state.chats[fromId];
+      if (!currentChat) return state;
+
+      return {
+        chats: produce(state.chats, (draft) => {
+          // Copy state to the new key
+          draft[toId] = { ...currentChat };
+          // Delete the old key
+          delete draft[fromId];
+        }),
+        modelIds: produce(state.modelIds, (draft) => {
+          if (state.modelIds[fromId]) {
+            draft[toId] = state.modelIds[fromId];
+            delete draft[fromId];
+          }
+        }),
+        loading: produce(state.loading, (draft) => {
+          if (state.loading[fromId] !== undefined) {
+            draft[toId] = state.loading[fromId];
+            delete draft[fromId];
+          }
+        }),
+        writing: produce(state.writing, (draft) => {
+          if (state.writing[fromId] !== undefined) {
+            draft[toId] = state.writing[fromId];
+            delete draft[fromId];
+          }
+        }),
+      };
+    });
+  };
+
   return {
     chats: {},
     modelIds: {},
@@ -950,6 +985,7 @@ const useChatState = create<{
     addMessageIdsToUnrecordedMessages,
     replaceMessages,
     setPredictedTitle,
+    migrateState,
   };
 });
 
@@ -988,6 +1024,7 @@ const useChat = (id: string, chatId?: string) => {
     addMessageIdsToUnrecordedMessages,
     replaceMessages,
     setPredictedTitle,
+    migrateState,
   } = useChatState();
   const { data: messagesData, isLoading: isLoadingMessage } =
     useChatApi().listMessages(chatId);
@@ -1044,11 +1081,21 @@ ${baseSystemContext}
 
   useEffect(() => {
     // In the case of a registered chat
-    if (!isLoadingMessage && messagesData && !isLoadingChat && chatData) {
+    // Skip restore if the chat was just created (state already migrated)
+    const existingChat = chats[id]?.chat;
+    const isJustCreated = existingChat?.chatId === chatId;
+
+    if (
+      !isLoadingMessage &&
+      messagesData &&
+      !isLoadingChat &&
+      chatData &&
+      !isJustCreated
+    ) {
       restore(id, messagesData.messages, chatData.chat);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoadingMessage, isLoadingChat]);
+  }, [isLoadingMessage, isLoadingChat, chatId]);
 
   const filteredMessages = useMemo(() => {
     return chats[id]?.messages.filter((chat) => chat.role !== 'system') ?? [];
@@ -1267,6 +1314,9 @@ ${baseSystemContext}
     },
     setPredictedTitle: async () => {
       await setPredictedTitle(id);
+    },
+    migrateState: (newId: string) => {
+      migrateState(id, newId);
     },
   };
 };

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -1082,8 +1082,9 @@ ${baseSystemContext}
   useEffect(() => {
     // In the case of a registered chat
     // Skip restore if the chat was just created (state already migrated)
+    // Note: chatId from URL doesn't have 'chat#' prefix, but existingChat.chatId does
     const existingChat = chats[id]?.chat;
-    const isJustCreated = existingChat?.chatId === chatId;
+    const isJustCreated = existingChat?.chatId === `chat#${chatId}`;
 
     if (
       !isLoadingMessage &&
@@ -1176,6 +1177,40 @@ ${baseSystemContext}
     ) => {
       post(
         id,
+        content,
+        mutateChatList,
+        ignoreHistory,
+        preProcessInput,
+        postProcessOutput,
+        sessionId,
+        uploadedFiles,
+        extraData,
+        overrideModelType,
+        setSessionId,
+        base64Cache,
+        overrideModelParameters
+      );
+    },
+    postChatWithId: (
+      targetId: string,
+      content: string,
+      ignoreHistory: boolean = false,
+      preProcessInput:
+        | ((message: ShownMessage[]) => ShownMessage[])
+        | undefined = undefined,
+      postProcessOutput: ((message: string) => string) | undefined = undefined,
+      sessionId: string | undefined = undefined,
+      uploadedFiles: UploadedFileType[] | undefined = undefined,
+      extraData: ExtraData[] | undefined = undefined,
+      overrideModelType: Model['type'] | undefined = undefined,
+      setSessionId: (sessionId: string) => void = () => {},
+      base64Cache: Record<string, string> | undefined = undefined,
+      overrideModelParameters:
+        | AdditionalModelRequestFields
+        | undefined = undefined
+    ) => {
+      post(
+        targetId,
         content,
         mutateChatList,
         ignoreHistory,

--- a/packages/web/src/pages/ChatPage.tsx
+++ b/packages/web/src/pages/ChatPage.tsx
@@ -395,7 +395,8 @@ ${baseContext}
         </h1>
 
         {/* Wrapper for messages and input to enable vertical centering when empty */}
-        {loadingMessages && chatId ? (
+        {/* Show loading only when fetching existing chat messages (not for just-created chats) */}
+        {loadingMessages && chatId && isEmpty ? (
           <div className="flex flex-1 flex-col items-center justify-center">
             <LoadingWave />
           </div>

--- a/packages/web/src/pages/ChatPage.tsx
+++ b/packages/web/src/pages/ChatPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useParams, useNavigate } from 'react-router-dom';
 import InputChatContent from '../components/InputChatContent';
 import useChat from '../hooks/useChat';
 import useChatApi from '../hooks/useChatApi';
@@ -66,6 +66,10 @@ const ChatPage: React.FC = () => {
     base64Cache,
   } = useFiles(pathname);
   const { chatId } = useParams();
+  const navigate = useNavigate();
+
+  const [isCreatingChat, setIsCreatingChat] = useState(false);
+  const [createChatError, setCreateChatError] = useState<string | null>(null);
 
   const {
     getModelId,
@@ -81,6 +85,8 @@ const ChatPage: React.FC = () => {
     retryGeneration,
     forceToStop,
     loadingMessages,
+    createChatIfNotExist,
+    migrateState,
   } = useChat(pathname, chatId);
   const { createShareId, findShareId, deleteShareId } = useChatApi();
   const { scrollableContainer, setFollowing } = useFollow();
@@ -178,8 +184,31 @@ ${baseContext}
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [search, setContent, availableModels, pathname, chatId]);
 
-  const onSend = useCallback(() => {
+  const onSend = useCallback(async () => {
     setFollowing(true);
+    setCreateChatError(null);
+
+    // For new chats, create the chat first and navigate to its URL
+    if (!chatId) {
+      setIsCreatingChat(true);
+      try {
+        const newChatId = await createChatIfNotExist();
+        const newPathname = `/chat/${newChatId}`;
+
+        // Migrate the state to the new path
+        migrateState(newPathname);
+
+        // Navigate to the new chat URL
+        navigate(newPathname, { replace: true });
+      } catch (error) {
+        setIsCreatingChat(false);
+        setCreateChatError('チャットの作成に失敗しました。もう一度お試しください。');
+        return; // Keep the input content and return
+      }
+      setIsCreatingChat(false);
+    }
+
+    // Start LLM inference
     postChat(
       prompter.chatPrompt({ content }),
       false,
@@ -196,7 +225,20 @@ ${baseContext}
     setContent('');
     clearFiles();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [content, base64Cache, fileUpload, setFollowing, overrideModelParameters]);
+  }, [
+    content,
+    base64Cache,
+    fileUpload,
+    setFollowing,
+    overrideModelParameters,
+    chatId,
+    createChatIfNotExist,
+    migrateState,
+    navigate,
+    prompter,
+    postChat,
+    uploadedFiles,
+  ]);
 
   const onRetry = useCallback(() => {
     retryGeneration(
@@ -342,22 +384,27 @@ ${baseContext}
         </h1>
 
         {/* Wrapper for messages and input to enable vertical centering when empty */}
-        {loadingMessages ? (
+        {loadingMessages && chatId ? (
           <div className="flex flex-1 flex-col items-center justify-center">
             <LoadingWave />
           </div>
         ) : isEmpty ? (
           <div className="flex flex-1 flex-col justify-center">
+            {createChatError && (
+              <div className="mx-auto mb-4 rounded-md bg-red-50 p-3 text-sm text-red-600">
+                {createChatError}
+              </div>
+            )}
             <InputChatContent
               className="mx-auto print:hidden"
               content={content}
-              disabled={loading && !writing}
+              disabled={(loading && !writing) || isCreatingChat}
               onChangeContent={setContent}
               hideReset={true}
               onSend={() => {
-                if (!loading) {
+                if (!loading && !isCreatingChat) {
                   onSend();
-                } else {
+                } else if (writing) {
                   onStop();
                 }
               }}
@@ -369,6 +416,7 @@ ${baseContext}
                 setShowSetting(true);
               }}
               canStop={writing}
+              isCreatingChat={isCreatingChat}
             />
           </div>
         ) : (
@@ -392,16 +440,21 @@ ${baseContext}
             </div>
 
             <div className="sticky bottom-0 print:hidden">
+              {createChatError && (
+                <div className="mx-auto mb-2 max-w-3xl rounded-md bg-red-50 p-3 text-sm text-red-600">
+                  {createChatError}
+                </div>
+              )}
               <InputChatContent
                 className="mx-auto my-4"
                 content={content}
-                disabled={loading && !writing}
+                disabled={(loading && !writing) || isCreatingChat}
                 onChangeContent={setContent}
                 hideReset={true}
                 onSend={() => {
-                  if (!loading) {
+                  if (!loading && !isCreatingChat) {
                     onSend();
-                  } else {
+                  } else if (writing) {
                     onStop();
                   }
                 }}
@@ -413,6 +466,7 @@ ${baseContext}
                   setShowSetting(true);
                 }}
                 canStop={writing}
+                isCreatingChat={isCreatingChat}
               />
             </div>
           </>

--- a/packages/web/src/pages/ChatPage.tsx
+++ b/packages/web/src/pages/ChatPage.tsx
@@ -79,7 +79,6 @@ const ChatPage: React.FC = () => {
     isEmpty,
     messages,
     clear,
-    postChat,
     editChat,
     updateSystemContext,
     retryGeneration,
@@ -87,6 +86,7 @@ const ChatPage: React.FC = () => {
     loadingMessages,
     createChatIfNotExist,
     migrateState,
+    postChatWithId,
   } = useChat(pathname, chatId);
   const { createShareId, findShareId, deleteShareId } = useChatApi();
   const { scrollableContainer, setFollowing } = useFollow();
@@ -188,6 +188,8 @@ ${baseContext}
     setFollowing(true);
     setCreateChatError(null);
 
+    let targetPathname = pathname;
+
     // For new chats, create the chat first and navigate to its URL
     if (!chatId) {
       setIsCreatingChat(true);
@@ -202,6 +204,9 @@ ${baseContext}
 
         // Navigate to the new chat URL
         navigate(newPathname, { replace: true });
+
+        // Use the new pathname for postChat
+        targetPathname = newPathname;
       } catch (error) {
         setIsCreatingChat(false);
         setCreateChatError('チャットの作成に失敗しました。もう一度お試しください。');
@@ -210,8 +215,9 @@ ${baseContext}
       setIsCreatingChat(false);
     }
 
-    // Start LLM inference
-    postChat(
+    // Start LLM inference with the correct pathname
+    postChatWithId(
+      targetPathname,
       prompter.chatPrompt({ content }),
       false,
       undefined,
@@ -238,8 +244,9 @@ ${baseContext}
     migrateState,
     navigate,
     prompter,
-    postChat,
+    postChatWithId,
     uploadedFiles,
+    pathname,
   ]);
 
   const onRetry = useCallback(() => {

--- a/packages/web/src/pages/ChatPage.tsx
+++ b/packages/web/src/pages/ChatPage.tsx
@@ -209,7 +209,9 @@ ${baseContext}
         targetPathname = newPathname;
       } catch (error) {
         setIsCreatingChat(false);
-        setCreateChatError('チャットの作成に失敗しました。もう一度お試しください。');
+        setCreateChatError(
+          'チャットの作成に失敗しました。もう一度お試しください。'
+        );
         return; // Keep the input content and return
       }
       setIsCreatingChat(false);

--- a/packages/web/src/pages/ChatPage.tsx
+++ b/packages/web/src/pages/ChatPage.tsx
@@ -193,7 +193,9 @@ ${baseContext}
       setIsCreatingChat(true);
       try {
         const newChatId = await createChatIfNotExist();
-        const newPathname = `/chat/${newChatId}`;
+        // Remove 'chat#' prefix from chatId for URL
+        const chatIdForUrl = newChatId.replace(/^chat#/, '');
+        const newPathname = `/chat/${chatIdForUrl}`;
 
         // Migrate the state to the new path
         migrateState(newPathname);


### PR DESCRIPTION
## Summary

- 新規チャットのフローを変更: メッセージ送信前にチャットを作成してURL遷移する
- チャット作成中は送信ボタンを無効化してスピナーを表示
- チャット作成失敗時のエラーハンドリングを追加
- URL遷移後の状態管理を修正（`migrateState`関数を追加）
- `isJustCreated`チェックで`chat#`プレフィックスを考慮するように修正

### 変更後のフロー
```
メッセージ送信 → チャット作成 → URL遷移 → LLM推論 → メッセージ永続化
```

## Test plan

- [ ] 新規チャットでメッセージを送信し、URLが即座に変更されることを確認
- [ ] チャット作成中に送信ボタンが無効化されスピナーが表示されることを確認
- [ ] LLM推論が正常に開始され、メッセージが表示されることを確認
- [ ] 既存のチャットに遷移した際、メッセージが正常に復元されることを確認
- [ ] ブラウザの戻るボタンで`/chat`に戻った場合、新規チャットとして動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)