### PR TITLE
✨ feat(assistant): メッセージ送信前にチャットを作成してURL遷移する

### DIFF
--- a/packages/cdk/lambda/assistantMessageHandler.ts
+++ b/packages/cdk/lambda/assistantMessageHandler.ts
@@ -186,7 +186,14 @@ async function handleCreateMessage(
 
   // Create chat history entry only for new conversations
   // This ensures the assistant conversation appears in the unified chat history
-  if (isNewConversation) {
+  // Check if chat exists when chatId is provided from frontend
+  let shouldCreateChat = isNewConversation;
+  if (!isNewConversation) {
+    const existingChat = await findChatById(userId, cleanChatId, event);
+    shouldCreateChat = !existingChat;
+  }
+
+  if (shouldCreateChat) {
     await createAssistantChat(
       userId,
       assistantId,

--- a/packages/cdk/lambda/assistantMessageHandler.ts
+++ b/packages/cdk/lambda/assistantMessageHandler.ts
@@ -73,7 +73,8 @@ export const handler = async (
     }
 
     // Determine if this is a chat or messages endpoint
-    const isChatEndpoint = event.resource?.endsWith('/chat') || event.path?.endsWith('/chat');
+    const isChatEndpoint =
+      event.resource?.endsWith('/chat') || event.path?.endsWith('/chat');
 
     // Route based on HTTP method and path
     switch (method) {

--- a/packages/cdk/lambda/assistantMessageHandler.ts
+++ b/packages/cdk/lambda/assistantMessageHandler.ts
@@ -24,6 +24,7 @@ import { canAccessAssistant } from './utils/assistantAccessControl';
 import {
   badRequest400Response,
   conflict409Response,
+  created201Response,
   forbidden403Response,
   internalServerError500Response,
   methodNotAllowed405Response,
@@ -52,8 +53,9 @@ function addAssistantIdToMessage(
 }
 
 /**
- * Consolidated handler for assistant message operations
- * Routes based on HTTP method:
+ * Consolidated handler for assistant message and chat operations
+ * Routes based on HTTP method and path:
+ * - POST /{assistantId}/chat → create chat (new)
  * - POST /{assistantId}/messages → create message (with RAG)
  * - GET /{assistantId}/messages → list messages
  */
@@ -70,9 +72,15 @@ export const handler = async (
       return badRequest400Response({ message: 'Missing assistantId' });
     }
 
-    // Route based on HTTP method
+    // Determine if this is a chat or messages endpoint
+    const isChatEndpoint = event.resource?.endsWith('/chat') || event.path?.endsWith('/chat');
+
+    // Route based on HTTP method and path
     switch (method) {
       case 'POST':
+        if (isChatEndpoint) {
+          return await handleCreateChat(userId, assistantId, event);
+        }
         return await handleCreateMessage(userId, assistantId, event);
 
       case 'GET':
@@ -86,6 +94,51 @@ export const handler = async (
     return internalServerError500Response({ message: 'Internal Server Error' });
   }
 };
+
+/**
+ * Handle POST /{assistantId}/chat - Create a new chat for the assistant
+ * This endpoint creates a chat entry in the database with a server-generated chatId
+ */
+async function handleCreateChat(
+  userId: string,
+  assistantId: string,
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> {
+  // Get assistant configuration
+  const assistant = await getAssistant(assistantId, event);
+
+  if (!assistant) {
+    return notFound404Response({ message: 'Assistant not found' });
+  }
+
+  // Check access: owner OR (public AND same tenant)
+  if (!canAccessAssistant(assistant, userId, event)) {
+    return forbidden403Response({
+      message: 'Access denied to this assistant',
+      code: 'ASSISTANT_ACCESS_DENIED',
+    });
+  }
+
+  // Generate a new chatId on the server side
+  const chatId = crypto.randomUUID();
+
+  // Create the chat entry in the database
+  const chat = await createAssistantChat(
+    userId,
+    assistantId,
+    chatId,
+    assistant.name,
+    event
+  );
+
+  // Return the created chat with cleaned chatId (without 'chat#' prefix)
+  return created201Response({
+    chat: {
+      ...chat,
+      chatId: chat.chatId.replace('chat#', ''),
+    },
+  });
+}
 
 /**
  * Handle POST /{assistantId}/messages - Create message with RAG

--- a/packages/cdk/lambda/assistantMessageStreamHandler.ts
+++ b/packages/cdk/lambda/assistantMessageStreamHandler.ts
@@ -206,7 +206,18 @@ export const handler = awslambda.streamifyResponse(
       );
 
       // Create chat history entry for new conversations
-      if (isNewConversation) {
+      // Check if chat exists when chatId is provided from frontend
+      let shouldCreateChat = isNewConversation;
+      if (!isNewConversation) {
+        const existingChat = await findChatById(
+          userId,
+          cleanChatId,
+          requestContext
+        );
+        shouldCreateChat = !existingChat;
+      }
+
+      if (shouldCreateChat) {
         await createAssistantChat(
           userId,
           assistantId,

--- a/packages/cdk/lib/construct/api/assistant.ts
+++ b/packages/cdk/lib/construct/api/assistant.ts
@@ -255,6 +255,14 @@ class AssistantApi extends Construct {
       commonAuthorizerProps
     );
 
+    // POST: /assistant/{assistantId}/chat → assistantMessageHandler (create chat)
+    const chatResource = assistantIdResource.addResource('chat');
+    chatResource.addMethod(
+      'POST',
+      new LambdaIntegration(assistantMessageHandler),
+      commonAuthorizerProps
+    );
+
     // File upload endpoint: POST /assistant/upload-url
     if (fileBucket) {
       const uploadHandler = new NodejsFunction(

--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -86,6 +86,7 @@ assistant:
     chunksEnabled: Chunks display enabled
     confirmClear: Are you sure you want to clear the conversation?
     copy: Copy
+    createChatError: Failed to create chat
     failedAlertTitle: Sync Failed
     inputPlaceholder: Type a message...
     instruction: Instruction

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -86,6 +86,7 @@ assistant:
     chunksEnabled: チャンク表示が有効
     confirmClear: 会話履歴をクリアしてもよろしいですか？
     copy: コピー
+    createChatError: チャットの作成に失敗しました
     failedAlertTitle: 同期失敗
     inputPlaceholder: メッセージを入力...
     instruction: 指示

--- a/packages/web/src/hooks/useAssistantApi.ts
+++ b/packages/web/src/hooks/useAssistantApi.ts
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import {
   Assistant,
   AssistantMessage,
+  Chat,
   CreateAssistantRequest,
   CreateAssistantMessageRequest,
   ListAssistantsQueryParams,
@@ -109,6 +110,20 @@ const useAssistantApi = () => {
 
         deleteAssistant: async (assistantId: string): Promise<void> => {
           await http.delete<void>(`assistant/${assistantId}`);
+        },
+
+        /**
+         * Create a new chat for the assistant
+         * This creates a chat entry with a server-generated chatId
+         */
+        createAssistantChat: async (
+          assistantId: string
+        ): Promise<{ chat: Chat }> => {
+          const res = await http.post<{ chat: Chat }, Record<string, never>>(
+            `assistant/${assistantId}/chat`,
+            {}
+          );
+          return res.data;
         },
 
         updateAssistantVisibility: async (

--- a/packages/web/src/pages/AssistantChatPage.tsx
+++ b/packages/web/src/pages/AssistantChatPage.tsx
@@ -83,7 +83,10 @@ const AssistantChatPage: React.FC = () => {
   useEffect(() => {
     if (assistantId) {
       fetchAssistant();
-      fetchMessages();
+      // 新規作成直後のチャットはfetchMessagesをスキップ（ローカルステートを保持）
+      if (justCreatedChatIdRef.current !== conversationId) {
+        fetchMessages();
+      }
       // Update currentChatId when conversationId changes
       setCurrentChatId(conversationId);
     }

--- a/packages/web/src/pages/AssistantChatPage.tsx
+++ b/packages/web/src/pages/AssistantChatPage.tsx
@@ -56,6 +56,7 @@ const AssistantChatPage: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [sending, setSending] = useState(false);
   const [writing, setWriting] = useState(false);
+  const [isCreatingChat, setIsCreatingChat] = useState(false);
   const [streamingContent, setStreamingContent] = useState('');
   const [showAssistantInfo, setShowAssistantInfo] = useState(false);
   const [isComposing, setIsComposing] = useState(false);
@@ -65,7 +66,6 @@ const AssistantChatPage: React.FC = () => {
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
-  const streamChatIdRef = useRef<string | undefined>(undefined);
   const accumulatedContentRef = useRef('');
   const streamBufferRef = useRef('');
 
@@ -257,6 +257,19 @@ const AssistantChatPage: React.FC = () => {
 
     const userMessageContent = inputMessage;
     const isFirstMessage = !currentChatId;
+
+    // 新規チャットの場合、先にchatIdを生成してURL遷移
+    let targetChatId = currentChatId;
+    if (!currentChatId) {
+      setIsCreatingChat(true);
+      targetChatId = crypto.randomUUID();
+      setCurrentChatId(targetChatId);
+      navigate(`/chat/assistants/chat/${assistantId}/${targetChatId}`, {
+        replace: true,
+      });
+      setIsCreatingChat(false);
+    }
+
     setInputMessage('');
     setSending(true);
     setWriting(true);
@@ -268,7 +281,7 @@ const AssistantChatPage: React.FC = () => {
       id: tempMessageId,
       messageId: tempMessageId,
       assistantId: assistantId,
-      chatId: currentChatId || 'temp-chat',
+      chatId: targetChatId || 'temp-chat',
       userId: 'temp-user',
       role: 'user',
       content: userMessageContent,
@@ -277,7 +290,6 @@ const AssistantChatPage: React.FC = () => {
     setMessages((prev) => [...prev, tempUserMessage]);
 
     // Reset refs for new stream
-    streamChatIdRef.current = undefined;
     accumulatedContentRef.current = '';
     streamBufferRef.current = '';
 
@@ -291,7 +303,7 @@ const AssistantChatPage: React.FC = () => {
       // Use streaming API
       const stream = streamMessage(assistantId, {
         content: userMessageContent,
-        chatId: currentChatId,
+        chatId: targetChatId,
         customInstructions,
       });
 
@@ -315,10 +327,6 @@ const AssistantChatPage: React.FC = () => {
               accumulatedContentRef.current += parsed.text;
               setStreamingContent(accumulatedContentRef.current);
             }
-            // Capture chatId (sessionId) from the stream
-            if (parsed.sessionId && !streamChatIdRef.current) {
-              streamChatIdRef.current = parsed.sessionId;
-            }
           } catch {
             // Log parse errors for debugging - complete lines should always be valid JSON
             console.warn('Failed to parse JSONL line:', trimmedLine);
@@ -335,9 +343,6 @@ const AssistantChatPage: React.FC = () => {
             accumulatedContentRef.current += parsed.text;
             setStreamingContent(accumulatedContentRef.current);
           }
-          if (parsed.sessionId && !streamChatIdRef.current) {
-            streamChatIdRef.current = parsed.sessionId;
-          }
         } catch {
           console.warn('Failed to parse final JSONL line:', remainingLine);
         }
@@ -346,30 +351,26 @@ const AssistantChatPage: React.FC = () => {
       setWriting(false);
       setSending(false);
 
-      // If this was a new conversation, update state and navigate
-      if (!currentChatId && streamChatIdRef.current) {
-        setCurrentChatId(streamChatIdRef.current);
-        navigate(
-          `/chat/assistants/chat/${assistantId}/${streamChatIdRef.current}`,
-          {
-            replace: true,
-          }
-        );
-      }
-
       // Refresh messages to get the persisted messages from server
-      // Use streamChatIdRef.current for new conversations since state update is async
-      await fetchMessages(streamChatIdRef.current ?? currentChatId);
+      await fetchMessages(targetChatId);
 
       // Generate title for the first message
-      if (isFirstMessage && streamChatIdRef.current) {
-        await generateChatTitle(streamChatIdRef.current);
+      if (isFirstMessage && targetChatId) {
+        await generateChatTitle(targetChatId);
       }
     } catch (error) {
       console.error('Failed to send message:', error);
       setWriting(false);
       setSending(false);
+      setIsCreatingChat(false);
       toast.error(t('assistant.chatPage.sendError'));
+
+      // 新規チャットでエラーの場合、元のURLに戻す
+      if (isFirstMessage) {
+        navigate(`/chat/assistants/chat/${assistantId}`, { replace: true });
+        setCurrentChatId(undefined);
+      }
+
       // Remove the temporary user message on error
       setMessages((prev) =>
         prev.filter((m) => m.messageId !== tempUserMessage.messageId)
@@ -696,7 +697,9 @@ const AssistantChatPage: React.FC = () => {
                 ? t('assistant.chatPage.syncingPlaceholder')
                 : t('assistant.chatPage.inputPlaceholder')
             }
-            disabled={sending || writing || !assistantId || isBlocked}
+            disabled={
+              sending || writing || !assistantId || isBlocked || isCreatingChat
+            }
             className="flex-1 rounded border border-black/30 p-1.5 outline-none disabled:bg-gray-100 disabled:text-gray-500"
           />
           <Button
@@ -706,7 +709,8 @@ const AssistantChatPage: React.FC = () => {
               sending ||
               writing ||
               !assistantId ||
-              isBlocked
+              isBlocked ||
+              isCreatingChat
             }
             className="flex items-center gap-1">
             <PiPaperPlaneTilt />

--- a/packages/web/src/pages/AssistantChatPage.tsx
+++ b/packages/web/src/pages/AssistantChatPage.tsx
@@ -46,7 +46,8 @@ const AssistantChatPage: React.FC = () => {
     conversationId?: string;
   }>();
 
-  const { getAssistant, listMessages, streamMessage } = useAssistantApi();
+  const { getAssistant, listMessages, streamMessage, createAssistantChat } =
+    useAssistantApi();
   const { predictTitle, updateTitle } = useChatApi();
   const { mutate: mutateChatList } = useChatList();
   const http = useHttp();
@@ -264,16 +265,25 @@ const AssistantChatPage: React.FC = () => {
     const userMessageContent = inputMessage;
     const isFirstMessage = !currentChatId;
 
-    // 新規チャットの場合、先にchatIdを生成してURL遷移
+    // 新規チャットの場合、サーバーからchatIdを取得してURL遷移
     let targetChatId = currentChatId;
     if (!currentChatId) {
       setIsCreatingChat(true);
-      targetChatId = crypto.randomUUID();
-      justCreatedChatIdRef.current = targetChatId;
-      setCurrentChatId(targetChatId);
-      navigate(`/chat/assistants/chat/${assistantId}/${targetChatId}`, {
-        replace: true,
-      });
+      try {
+        const response = await createAssistantChat(assistantId);
+        const newChatId = response.chat.chatId;
+        targetChatId = newChatId;
+        justCreatedChatIdRef.current = newChatId;
+        setCurrentChatId(newChatId);
+        navigate(`/chat/assistants/chat/${assistantId}/${newChatId}`, {
+          replace: true,
+        });
+      } catch (error) {
+        console.error('Failed to create chat:', error);
+        setIsCreatingChat(false);
+        toast.error(t('assistant.chatPage.createChatError'));
+        return;
+      }
       setIsCreatingChat(false);
     }
 

--- a/packages/web/src/pages/AssistantChatPage.tsx
+++ b/packages/web/src/pages/AssistantChatPage.tsx
@@ -353,8 +353,19 @@ const AssistantChatPage: React.FC = () => {
       setWriting(false);
       setSending(false);
 
-      // Refresh messages to get the persisted messages from server
-      await fetchMessages(targetChatId);
+      // Add assistant message to local state instead of fetching from server
+      // This prevents the "reload" effect after streaming completes
+      const assistantMessage: AssistantMessage = {
+        id: `assistant-${Date.now()}`,
+        messageId: `assistant-${Date.now()}`,
+        assistantId: assistantId,
+        chatId: targetChatId || '',
+        userId: 'assistant',
+        role: 'assistant',
+        content: accumulatedContentRef.current,
+        createdDate: Date.now().toString(),
+      };
+      setMessages((prev) => [...prev, assistantMessage]);
 
       // Generate title for the first message
       if (isFirstMessage && targetChatId) {

--- a/packages/web/src/pages/AssistantChatPage.tsx
+++ b/packages/web/src/pages/AssistantChatPage.tsx
@@ -66,6 +66,7 @@ const AssistantChatPage: React.FC = () => {
 
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
+  const justCreatedChatIdRef = useRef<string | undefined>(undefined);
   const accumulatedContentRef = useRef('');
   const streamBufferRef = useRef('');
 
@@ -263,6 +264,7 @@ const AssistantChatPage: React.FC = () => {
     if (!currentChatId) {
       setIsCreatingChat(true);
       targetChatId = crypto.randomUUID();
+      justCreatedChatIdRef.current = targetChatId;
       setCurrentChatId(targetChatId);
       navigate(`/chat/assistants/chat/${assistantId}/${targetChatId}`, {
         replace: true,
@@ -493,7 +495,9 @@ const AssistantChatPage: React.FC = () => {
     );
   };
 
-  if (loading) {
+  // 新規作成直後のチャットはローディング画面を表示しない
+  const isJustCreated = justCreatedChatIdRef.current === conversationId;
+  if (loading && !isJustCreated) {
     return (
       <div className="flex h-screen items-center justify-center">
         <LoadingWave />

--- a/packages/web/src/pages/AssistantChatPage.tsx
+++ b/packages/web/src/pages/AssistantChatPage.tsx
@@ -36,6 +36,7 @@ import {
 import { findModelByModelId } from '../hooks/useModel';
 import { getPrompter } from '../prompts';
 import { useSettings } from '../hooks/useSettings';
+import useChatList from '../hooks/useChatList';
 
 const AssistantChatPage: React.FC = () => {
   const { t } = useTranslation();
@@ -47,6 +48,7 @@ const AssistantChatPage: React.FC = () => {
 
   const { getAssistant, listMessages, streamMessage } = useAssistantApi();
   const { predictTitle, updateTitle } = useChatApi();
+  const { mutate: mutateChatList } = useChatList();
   const http = useHttp();
   const { settings } = useSettings();
 
@@ -369,6 +371,11 @@ const AssistantChatPage: React.FC = () => {
         createdDate: Date.now().toString(),
       };
       setMessages((prev) => [...prev, assistantMessage]);
+
+      // Update chat list in sidebar for new chats
+      if (isFirstMessage) {
+        mutateChatList();
+      }
 
       // Generate title for the first message
       if (isFirstMessage && targetChatId) {


### PR DESCRIPTION
## Summary

- 通常チャットページと同様に、アシスタントチャットページでもメッセージ送信前にchatIdを生成してURL遷移するよう改善
- 新規チャット時、`crypto.randomUUID()`でchatIdを生成し、即座にURL遷移
- エラー発生時は元のURLに戻す処理を追加
- 不要になった`streamChatIdRef`を削除してコードを簡略化

## Test plan

- [ ] 新規アシスタントチャットでメッセージ送信時、即座にURLが変わることを確認
- [ ] ストリーミング中のUI状態が正常であることを確認
- [ ] エラー発生時に元のURLに戻ることを確認
- [ ] 既存チャットへのメッセージ追加が正常に動作することを確認
- [ ] ブラウザバック時の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)