### PR TITLE
✨ feat(lambda): テナント認証情報のキャッシュ機能を追加

### DIFF
--- a/packages/cdk/lambda/utils/tenantCredentials.ts
+++ b/packages/cdk/lambda/utils/tenantCredentials.ts
@@ -7,17 +7,41 @@ import {
 import { getTenant, Tenant } from '../tenantManager';
 import { getUsername } from './tenantUtils';
 
-// === キャッシュ関連の定義 ===
+/**
+ * === テナント認証情報キャッシュ ===
+ *
+ * Lambdaのウォームスタート時にメモリ上に保持される認証情報キャッシュ。
+ * Cold Start時はキャッシュは空で、認証情報取得後に保存される。
+ *
+ * キャッシュは以下のAPI呼び出しを削減する:
+ * - Cognito Identity Pool (GetId, GetOpenIdToken)
+ * - STS (AssumeRoleWithWebIdentity)
+ * - DynamoDB (テナント情報取得)
+ *
+ * セキュリティ:
+ * - テナントID+ユーザーID単位でキャッシュを分離
+ * - ユーザーIDが不明な場合はキャッシュをバイパス
+ * - LRU方式でキャッシュサイズを制限
+ */
 
 interface CachedCredentials {
-  credentials: Credentials;
-  tenant: Tenant;
-  expiresAt: number; // Unix timestamp (ms)
+  readonly credentials: Credentials;
+  readonly tenant: Tenant;
+  readonly expiresAt: number; // Unix timestamp (ms)
 }
 
 const credentialsCache = new Map<string, CachedCredentials>();
 const CACHE_BUFFER_MS = 5 * 60 * 1000; // 5分のバッファ
+const DEFAULT_CACHE_TTL_MS = 55 * 60 * 1000; // デフォルトTTL: 55分（STSデフォルト1時間 - 5分バッファ）
+const MAX_CACHE_SIZE = 100; // LRU方式で制限
 
+/**
+ * テナントIDとユーザーIDからキャッシュキーを生成
+ *
+ * ユーザーID単位でキャッシュを分離することで、
+ * 同一テナント内でも異なるユーザーの認証情報が混在しないようにする。
+ * これにより、ユーザー固有のIAMロール権限が正しく適用される。
+ */
 function getCacheKey(tenantId: string, userId: string): string {
   return `${tenantId}:${userId}`;
 }
@@ -29,10 +53,24 @@ function getFromCache(cacheKey: string): CachedCredentials | null {
   }
   if (Date.now() >= cached.expiresAt) {
     credentialsCache.delete(cacheKey);
-    console.log(`Cache expired for key: ${cacheKey}`);
+    console.log(`Cache expired for tenant`);
     return null;
   }
-  return cached;
+  return { ...cached };
+}
+
+/**
+ * LRU方式でキャッシュサイズを制限
+ * Map.keys()は挿入順でイテレートするため、最も古いエントリを削除
+ */
+function evictOldestIfNeeded(): void {
+  if (credentialsCache.size >= MAX_CACHE_SIZE) {
+    const oldestKey = credentialsCache.keys().next().value;
+    if (oldestKey) {
+      credentialsCache.delete(oldestKey);
+      console.log(`Evicted oldest cache entry due to size limit`);
+    }
+  }
 }
 
 function saveToCache(
@@ -40,9 +78,11 @@ function saveToCache(
   credentials: Credentials,
   tenant: Tenant
 ): void {
+  evictOldestIfNeeded();
+
   const expiresAt = credentials.Expiration
     ? new Date(credentials.Expiration).getTime() - CACHE_BUFFER_MS
-    : Date.now() + 55 * 60 * 1000;
+    : Date.now() + DEFAULT_CACHE_TTL_MS;
 
   credentialsCache.set(cacheKey, {
     credentials,
@@ -51,7 +91,7 @@ function saveToCache(
   });
 
   console.log(
-    `Cached credentials for key: ${cacheKey}, expires at: ${new Date(expiresAt).toISOString()}`
+    `Cached credentials for tenant, expires at: ${new Date(expiresAt).toISOString()}`
   );
 }
 
@@ -78,7 +118,8 @@ const validateEnvironment = () => {
 /**
  * Get tenant credentials using AssumeRoleWithWebIdentity
  * Supports both cross-account and same-account roles with automatic fallback
- * Credentials are cached per tenant+user to reduce Cognito API calls
+ * Credentials are cached per tenant+user to reduce API calls
+ * (Cognito Identity Pool, STS, DynamoDB)
  */
 export async function getTenantCredentials(
   event: APIGatewayProxyEvent
@@ -89,24 +130,33 @@ export async function getTenantCredentials(
   // Extract tenant ID from JWT claims
   const tenantId = extractTenantId(event);
 
-  // Extract user ID for logging
+  // Extract user ID for cache isolation
   const userId = getUsername(event);
 
-  // === キャッシュチェック ===
-  const cacheKey = getCacheKey(tenantId, userId);
-  const cached = getFromCache(cacheKey);
-  if (cached) {
-    console.log(
-      `Using cached credentials for tenant: ${tenantId}, user: ${userId}`
+  // === セキュリティチェック: ユーザーIDが不明な場合はキャッシュをバイパス ===
+  const shouldUseCache = userId !== 'unknown';
+
+  if (!shouldUseCache) {
+    console.warn(
+      `[SECURITY] No user ID found for tenant: ${tenantId}. Skipping cache.`
     );
-    return {
-      credentials: cached.credentials,
-      tenant: cached.tenant,
-    };
+  }
+
+  // === キャッシュチェック ===
+  if (shouldUseCache) {
+    const cacheKey = getCacheKey(tenantId, userId);
+    const cached = getFromCache(cacheKey);
+    if (cached) {
+      console.log(`Using cached credentials for tenant: ${tenantId}`);
+      return {
+        credentials: cached.credentials,
+        tenant: cached.tenant,
+      };
+    }
   }
 
   console.log(
-    `Getting tenant credentials for tenant: ${tenantId}, user: ${userId} using AssumeRoleWithWebIdentity`
+    `Getting tenant credentials for tenant: ${tenantId} using AssumeRoleWithWebIdentity`
   );
 
   try {
@@ -126,27 +176,25 @@ export async function getTenantCredentials(
     // Use AssumeRoleWithWebIdentity to get tenant credentials
     const credentials = await assumeRoleWithWebIdentity(event, tenant.roleArn);
 
-    // === キャッシュに保存 ===
-    saveToCache(cacheKey, credentials, tenant);
+    // === キャッシュに保存（ユーザーIDが有効な場合のみ）===
+    if (shouldUseCache) {
+      const cacheKey = getCacheKey(tenantId, userId);
+      saveToCache(cacheKey, credentials, tenant);
+    }
 
-    console.log(
-      `Successfully obtained tenant credentials for tenant: ${tenantId}, user: ${userId}`
-    );
+    console.log(`Successfully obtained tenant credentials for tenant: ${tenantId}`);
 
     return {
       credentials,
       tenant,
     };
   } catch (error) {
-    console.error(
-      `Failed to get tenant credentials for tenant: ${tenantId}, user: ${userId}:`,
-      {
-        error: error,
-        errorMessage: (error as Error).message,
-        accountId,
-        region,
-      }
-    );
+    console.error(`Failed to get tenant credentials for tenant: ${tenantId}:`, {
+      error: error,
+      errorMessage: (error as Error).message,
+      accountId,
+      region,
+    });
 
     throw new Error(
       `Failed to get tenant credentials: ${(error as Error).message}`

--- a/packages/cdk/lambda/utils/tenantCredentials.ts
+++ b/packages/cdk/lambda/utils/tenantCredentials.ts
@@ -7,6 +7,54 @@ import {
 import { getTenant, Tenant } from '../tenantManager';
 import { getUsername } from './tenantUtils';
 
+// === キャッシュ関連の定義 ===
+
+interface CachedCredentials {
+  credentials: Credentials;
+  tenant: Tenant;
+  expiresAt: number; // Unix timestamp (ms)
+}
+
+const credentialsCache = new Map<string, CachedCredentials>();
+const CACHE_BUFFER_MS = 5 * 60 * 1000; // 5分のバッファ
+
+function getCacheKey(tenantId: string, userId: string): string {
+  return `${tenantId}:${userId}`;
+}
+
+function getFromCache(cacheKey: string): CachedCredentials | null {
+  const cached = credentialsCache.get(cacheKey);
+  if (!cached) {
+    return null;
+  }
+  if (Date.now() >= cached.expiresAt) {
+    credentialsCache.delete(cacheKey);
+    console.log(`Cache expired for key: ${cacheKey}`);
+    return null;
+  }
+  return cached;
+}
+
+function saveToCache(
+  cacheKey: string,
+  credentials: Credentials,
+  tenant: Tenant
+): void {
+  const expiresAt = credentials.Expiration
+    ? new Date(credentials.Expiration).getTime() - CACHE_BUFFER_MS
+    : Date.now() + 55 * 60 * 1000;
+
+  credentialsCache.set(cacheKey, {
+    credentials,
+    tenant,
+    expiresAt,
+  });
+
+  console.log(
+    `Cached credentials for key: ${cacheKey}, expires at: ${new Date(expiresAt).toISOString()}`
+  );
+}
+
 // Interface for returning both credentials and tenant info
 export interface TenantCredentialsWithInfo {
   credentials: Credentials;
@@ -30,7 +78,7 @@ const validateEnvironment = () => {
 /**
  * Get tenant credentials using AssumeRoleWithWebIdentity
  * Supports both cross-account and same-account roles with automatic fallback
- * NOTE: No caching to ensure proper user isolation within tenants
+ * Credentials are cached per tenant+user to reduce Cognito API calls
  */
 export async function getTenantCredentials(
   event: APIGatewayProxyEvent
@@ -43,6 +91,19 @@ export async function getTenantCredentials(
 
   // Extract user ID for logging
   const userId = getUsername(event);
+
+  // === キャッシュチェック ===
+  const cacheKey = getCacheKey(tenantId, userId);
+  const cached = getFromCache(cacheKey);
+  if (cached) {
+    console.log(
+      `Using cached credentials for tenant: ${tenantId}, user: ${userId}`
+    );
+    return {
+      credentials: cached.credentials,
+      tenant: cached.tenant,
+    };
+  }
 
   console.log(
     `Getting tenant credentials for tenant: ${tenantId}, user: ${userId} using AssumeRoleWithWebIdentity`
@@ -64,6 +125,9 @@ export async function getTenantCredentials(
 
     // Use AssumeRoleWithWebIdentity to get tenant credentials
     const credentials = await assumeRoleWithWebIdentity(event, tenant.roleArn);
+
+    // === キャッシュに保存 ===
+    saveToCache(cacheKey, credentials, tenant);
 
     console.log(
       `Successfully obtained tenant credentials for tenant: ${tenantId}, user: ${userId}`


### PR DESCRIPTION
## Background

マルチテナント環境において、各APIリクエストでテナント固有のAWS認証情報を取得する際、以下のAPI呼び出しが発生します：

1. **Cognito Identity Pool** - `GetId`, `GetOpenIdToken`
2. **STS** - `AssumeRoleWithWebIdentity`
3. **DynamoDB** - テナント情報取得

これらのAPI呼び出しは、特にCognito Identity Poolにおいて**レート制限（TooManyRequestsException）**が発生しやすく、高負荷時にサービス全体の可用性に影響を与える可能性があります。

本PRでは、Lambdaのウォームスタート時にメモリ上で認証情報をキャッシュすることで、これらのAPI呼び出しを大幅に削減し、レート制限のリスクを軽減します。

## Summary

- Cognito Identity APIのレート制限（TooManyRequestsException）対策として、STS認証情報をLambdaメモリ上にキャッシュする機能を実装
- テナントID+ユーザーID単位でキャッシュを分離し、クロステナントアクセスを防止
- 有効期限は認証情報のExpiration - 5分バッファで設定

### セキュリティ対策

| 対策 | 説明 |
|------|------|
| ユーザー分離 | テナントID+ユーザーID単位でキャッシュを分離 |
| unknown対策 | ユーザーIDが取得できない場合はキャッシュをバイパス |
| LRUサイズ制限 | 最大100エントリでメモリリークを防止 |
| 不変性担保 | `readonly`によりキャッシュエントリの改変を防止 |
| PII保護 | ログからユーザーIDを削除 |

## Test plan

- [ ] キャッシュヒット時にログ `Using cached credentials for tenant:` が表示されることを確認
- [ ] キャッシュミス時にログ `Getting tenant credentials for tenant:` が表示されることを確認
- [ ] 有効期限切れ後は再取得されることを確認
- [ ] 異なるユーザーは異なるキャッシュエントリを使用することを確認
- [ ] 異なるテナントは異なるキャッシュエントリを使用することを確認
- [ ] ユーザーID不明時に `[SECURITY] No user ID found` 警告が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)