### PR TITLE
:bug: fix: AssumeRoleWithWebIdentityのリトライロジックを改善

### DIFF
--- a/packages/cdk/lambda/utils/assumeRoleWithWebIdentity.ts
+++ b/packages/cdk/lambda/utils/assumeRoleWithWebIdentity.ts
@@ -12,9 +12,41 @@ import {
 import { getTenantId, getUsername } from './tenantUtils';
 
 // Constants for AssumeRole operations
-const MAX_RETRIES = 3;
-const RETRY_DELAY_MS = 1000;
+const MAX_RETRIES = 5;
+const BASE_DELAY_MS = 500;
+const MAX_DELAY_MS = 10000;
 const SESSION_DURATION_SECONDS = 3600;
+
+/**
+ * ジッター付き指数バックオフでリトライ間隔を計算
+ * サンダリングハード問題を緩和するためランダム要素を追加
+ */
+function calculateRetryDelay(attempt: number): number {
+  // 指数バックオフ: 500ms, 1000ms, 2000ms, 4000ms, 8000ms (最大10000ms)
+  const exponentialDelay = Math.min(
+    BASE_DELAY_MS * Math.pow(2, attempt - 1),
+    MAX_DELAY_MS
+  );
+  // ジッター: 0〜50%のランダムな遅延を追加
+  const jitter = Math.random() * exponentialDelay * 0.5;
+  return Math.floor(exponentialDelay + jitter);
+}
+
+/**
+ * リトライ可能なエラーかどうかを判定
+ */
+function isRetryableError(error: Error): boolean {
+  const retryableErrors = [
+    'TooManyRequestsException',
+    'ThrottlingException',
+    'ServiceUnavailable',
+    'InternalServerError',
+    'ECONNRESET',
+    'ETIMEDOUT',
+  ];
+  const errorString = `${error.name} ${error.message}`;
+  return retryableErrors.some((e) => errorString.includes(e));
+}
 
 /**
  * Assume role using Identity Pool token exchange from Cognito User Pool JWT
@@ -135,12 +167,19 @@ export async function assumeRoleWithWebIdentity(
         }
       );
 
+      // リトライ不可能なエラーの場合は即座に失敗
+      if (!isRetryableError(lastError)) {
+        console.error(`Non-retryable error detected, failing immediately`);
+        break;
+      }
+
       if (attempt < MAX_RETRIES) {
-        // Exponential backoff
-        console.log(`Retrying in ${RETRY_DELAY_MS * attempt}ms...`);
-        await new Promise((resolve) =>
-          setTimeout(resolve, RETRY_DELAY_MS * attempt)
+        // ジッター付き指数バックオフ
+        const delay = calculateRetryDelay(attempt);
+        console.log(
+          `Retrying in ${delay}ms (attempt ${attempt}/${MAX_RETRIES})...`
         );
+        await new Promise((resolve) => setTimeout(resolve, delay));
       }
     }
   }

--- a/packages/cdk/lambda/utils/assumeRoleWithWebIdentity.ts
+++ b/packages/cdk/lambda/utils/assumeRoleWithWebIdentity.ts
@@ -3,11 +3,16 @@ import {
   STSClient,
   AssumeRoleWithWebIdentityCommand,
   Credentials,
+  IDPCommunicationErrorException,
 } from '@aws-sdk/client-sts';
 import {
   CognitoIdentityClient,
   GetIdCommand,
   GetOpenIdTokenCommand,
+  TooManyRequestsException,
+  LimitExceededException,
+  ExternalServiceException,
+  InternalErrorException,
 } from '@aws-sdk/client-cognito-identity';
 import { getTenantId, getUsername } from './tenantUtils';
 
@@ -27,25 +32,45 @@ function calculateRetryDelay(attempt: number): number {
     BASE_DELAY_MS * Math.pow(2, attempt - 1),
     MAX_DELAY_MS
   );
-  // ジッター: 0〜50%のランダムな遅延を追加
+  // ジッター: 基本遅延の100%〜150%の範囲でランダム化
   const jitter = Math.random() * exponentialDelay * 0.5;
   return Math.floor(exponentialDelay + jitter);
 }
 
+/** ネットワークエラーコード（Node.js SystemError） */
+const RETRYABLE_NETWORK_ERROR_CODES = [
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'ENOTFOUND',
+  'ECONNREFUSED',
+];
+
 /**
  * リトライ可能なエラーかどうかを判定
+ * AWS SDKの例外クラスを instanceof で型安全に検出
  */
-function isRetryableError(error: Error): boolean {
-  const retryableErrors = [
-    'TooManyRequestsException',
-    'ThrottlingException',
-    'ServiceUnavailable',
-    'InternalServerError',
-    'ECONNRESET',
-    'ETIMEDOUT',
-  ];
-  const errorString = `${error.name} ${error.message}`;
-  return retryableErrors.some((e) => errorString.includes(e));
+function isRetryableError(error: unknown): boolean {
+  // AWS SDK例外クラスによる判定
+  if (
+    error instanceof TooManyRequestsException ||
+    error instanceof LimitExceededException ||
+    error instanceof ExternalServiceException ||
+    error instanceof InternalErrorException ||
+    error instanceof IDPCommunicationErrorException
+  ) {
+    return true;
+  }
+
+  // Node.jsネットワークエラー（SystemError）の判定
+  if (
+    error instanceof Error &&
+    'code' in error &&
+    typeof error.code === 'string'
+  ) {
+    return RETRYABLE_NETWORK_ERROR_CODES.includes(error.code);
+  }
+
+  return false;
 }
 
 /**
@@ -80,8 +105,10 @@ export async function assumeRoleWithWebIdentity(
   );
 
   let lastError: Error | null = null;
+  let lastAttempt = 0;
 
   for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    lastAttempt = attempt;
     try {
       const cognitoIdentityClient = new CognitoIdentityClient({ region });
       const stsClient = new STSClient({ region });
@@ -103,7 +130,9 @@ export async function assumeRoleWithWebIdentity(
         throw new Error('Failed to get Identity ID from Identity Pool');
       }
 
-      console.log(`Got Identity ID: ${getIdResponse.IdentityId}`);
+      // Identity IDは機密情報のため、末尾8文字のみログ出力
+      const maskedIdentityId = `...${getIdResponse.IdentityId.slice(-8)}`;
+      console.log(`Got Identity ID: ${maskedIdentityId}`);
 
       // Step 2: Get OpenID token from Identity Pool
       console.log(`Getting OpenID token from Identity Pool`);
@@ -157,23 +186,28 @@ export async function assumeRoleWithWebIdentity(
       return assumeRoleResponse.Credentials;
     } catch (error) {
       lastError = error as Error;
+      const retryable = isRetryableError(error);
+      const willRetry = retryable && attempt < MAX_RETRIES;
+
       console.error(
         `AssumeRoleWithWebIdentity attempt ${attempt} failed for tenant: ${tenantId}, user: ${userId}:`,
         {
           error: error,
-          errorMessage: (error as Error).message,
+          errorName: lastError.name ?? 'Unknown',
+          errorMessage: lastError.message,
           roleArn: roleArn,
           region: process.env.AWS_REGION!,
+          isRetryable: retryable,
+          willRetry: willRetry,
         }
       );
 
       // リトライ不可能なエラーの場合は即座に失敗
-      if (!isRetryableError(lastError)) {
-        console.error(`Non-retryable error detected, failing immediately`);
+      if (!retryable) {
         break;
       }
 
-      if (attempt < MAX_RETRIES) {
+      if (willRetry) {
         // ジッター付き指数バックオフ
         const delay = calculateRetryDelay(attempt);
         console.log(
@@ -184,10 +218,14 @@ export async function assumeRoleWithWebIdentity(
     }
   }
 
-  // All retries failed
-  throw new Error(
-    `Failed to assume role after ${MAX_RETRIES} attempts: ${lastError?.message}`
-  );
+  // All retries failed or non-retryable error
+  const finalMessage = isRetryableError(lastError)
+    ? `Failed to assume role after ${MAX_RETRIES} attempts: ${lastError?.message}`
+    : `Failed to assume role (non-retryable error after ${lastAttempt} attempt(s)): ${lastError?.message}`;
+
+  const finalError = new Error(finalMessage);
+  (finalError as Error & { cause?: unknown }).cause = lastError;
+  throw finalError;
 }
 
 /**


### PR DESCRIPTION
## Background / 背景

2025年12月2日 17:30〜17:50 の負荷テスト中、`/chat`エンドポイントが500エラーを返す問題が発生しました。

### 根本原因

1. **Cognito Identityのレート制限超過** (`TooManyRequestsException`)
   - `AssumeRoleWithWebIdentity`が`Rate exceeded`で失敗
2. **フォールバック時のアクセス拒否** (`AccessDeniedException`)
   - デフォルトLambdaロールにテナント専用テーブルへの権限がない

### 影響を受けたLambda関数

- `GenerativeAiUseCasesStack-APIChatsAPICreateMessage-*`
- `GenerativeAiUseCasesStack-APIChatsAPICreateChat58B-*`

### 全体の対策プラン

| 優先度 | 対策 | 効果 | ステータス |
|--------|------|------|------------|
| 1 | 認証情報キャッシュ | 高 | 別PR予定 |
| 2 | エラーハンドリング改善 | 中 | 別PR予定 |
| **3** | **指数バックオフ改善** | **中** | **このPR** |
| 4 | クォータ引き上げ | 低 | 運用対応 |

---

## Summary / 変更内容

### リトライ設定の改善

| 項目 | 変更前 | 変更後 |
|------|--------|--------|
| MAX_RETRIES | 3 | 5 |
| 遅延設定 | `RETRY_DELAY_MS = 1000` | `BASE_DELAY_MS = 500`, `MAX_DELAY_MS = 10000` |
| リトライ間隔 | 1秒, 2秒, 3秒（線形） | 500ms〜10秒（指数 + ジッター） |

### 新規追加した機能

1. **`calculateRetryDelay(attempt)`** - ジッター付き指数バックオフ計算
   - 基本遅延: 500ms × 2^(attempt-1)、最大10秒
   - ジッター: 基本遅延の100%〜150%の範囲でランダム化
   - サンダリングハード問題（同時リトライの衝突）を緩和

2. **`isRetryableError(error)`** - リトライ可能エラー判定（型安全）
   - AWS SDK例外: `TooManyRequestsException`, `LimitExceededException`, `ExternalServiceException`, `InternalErrorException`, `IDPCommunicationErrorException`
   - ネットワークエラー: `ECONNRESET`, `ETIMEDOUT`, `ENOTFOUND`, `ECONNREFUSED`

3. **ログの改善**
   - `isRetryable`, `willRetry`フラグをエラーログに追加
   - Identity IDをマスキング（末尾8文字のみ）してセキュリティ向上

4. **エラー情報の保持**
   - 最終エラーに`cause`プロパティで元エラーを保持
   - 非リトライ可能エラーで即座に失敗した場合のメッセージを分離

---

## Expected Effect / 期待効果

- サンダリングハード問題（同時リトライの衝突）の緩和
- リトライ成功率の向上（5回まで試行、最大約30秒待機）
- 非リトライ可能エラーでの不要な待機を排除
- デバッグ容易性の向上（ログ改善）

---

## Test plan / テスト計画

- [ ] 単体テスト: `calculateRetryDelay`が増加する遅延を返すことを確認
- [ ] 単体テスト: `isRetryableError`がTooManyRequestsExceptionでtrueを返すことを確認
- [ ] 単体テスト: `isRetryableError`がAccessDeniedExceptionでfalseを返すことを確認
- [ ] 統合テスト: Cognito IdentityのTooManyRequestsExceptionで5回リトライされることを確認
- [ ] 統合テスト: 非リトライ可能エラーで即座に失敗することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)