### PR TITLE
✨ feat(api): レート制限エラー時に適切なHTTPステータスコードを返却

### DIFF
--- a/packages/cdk/lambda/createChat.ts
+++ b/packages/cdk/lambda/createChat.ts
@@ -1,10 +1,8 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { createChat } from './repository';
 import { getUsername } from './utils/tenantUtils';
-import {
-  internalServerError500Response,
-  ok200Response,
-} from './utils/apiResponse';
+import { ok200Response } from './utils/apiResponse';
+import { handleLambdaError } from './utils/errorHandler';
 
 export const handler = async (
   event: APIGatewayProxyEvent
@@ -17,7 +15,6 @@ export const handler = async (
       chat,
     });
   } catch (error) {
-    console.log(error);
-    return internalServerError500Response({ message: 'Internal Server Error' });
+    return handleLambdaError(error);
   }
 };

--- a/packages/cdk/lambda/createMessages.ts
+++ b/packages/cdk/lambda/createMessages.ts
@@ -9,10 +9,10 @@ import {
 import { getTenant } from './tenantManager';
 import {
   badRequest400Response,
-  internalServerError500Response,
   notFound404Response,
   ok200Response,
 } from './utils/apiResponse';
+import { handleLambdaError } from './utils/errorHandler';
 
 const FILE_UPLOAD_BUCKET_NAME = process.env.BUCKET_NAME!;
 
@@ -86,7 +86,6 @@ export const handler = async (
       messages,
     });
   } catch (error) {
-    console.log(error);
-    return internalServerError500Response({ message: 'Internal Server Error' });
+    return handleLambdaError(error);
   }
 };

--- a/packages/cdk/lambda/deleteChat.ts
+++ b/packages/cdk/lambda/deleteChat.ts
@@ -1,10 +1,8 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { deleteChat, deleteShareId, findShareId } from './repository';
 import { getUsername } from './utils/tenantUtils';
-import {
-  internalServerError500Response,
-  noContent204Response,
-} from './utils/apiResponse';
+import { noContent204Response } from './utils/apiResponse';
+import { handleLambdaError } from './utils/errorHandler';
 
 export const handler = async (
   event: APIGatewayProxyEvent
@@ -22,7 +20,6 @@ export const handler = async (
 
     return noContent204Response();
   } catch (error) {
-    console.log(error);
-    return internalServerError500Response({ message: 'Internal Server Error' });
+    return handleLambdaError(error);
   }
 };

--- a/packages/cdk/lambda/findChatById.ts
+++ b/packages/cdk/lambda/findChatById.ts
@@ -1,10 +1,8 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { findChatById } from './repository';
 import { getUsername } from './utils/tenantUtils';
-import {
-  internalServerError500Response,
-  ok200Response,
-} from './utils/apiResponse';
+import { ok200Response } from './utils/apiResponse';
+import { handleLambdaError } from './utils/errorHandler';
 
 export const handler = async (
   event: APIGatewayProxyEvent
@@ -18,7 +16,6 @@ export const handler = async (
       chat,
     });
   } catch (error) {
-    console.log(error);
-    return internalServerError500Response({ message: 'Internal Server Error' });
+    return handleLambdaError(error);
   }
 };

--- a/packages/cdk/lambda/listChats.ts
+++ b/packages/cdk/lambda/listChats.ts
@@ -1,10 +1,8 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { listChats } from './repository';
 import { getUsername } from './utils/tenantUtils';
-import {
-  internalServerError500Response,
-  ok200Response,
-} from './utils/apiResponse';
+import { ok200Response } from './utils/apiResponse';
+import { handleLambdaError } from './utils/errorHandler';
 
 export const handler = async (
   event: APIGatewayProxyEvent
@@ -16,7 +14,6 @@ export const handler = async (
 
     return ok200Response(res);
   } catch (error) {
-    console.log(error);
-    return internalServerError500Response({ message: 'Internal Server Error' });
+    return handleLambdaError(error);
   }
 };

--- a/packages/cdk/lambda/listMessages.ts
+++ b/packages/cdk/lambda/listMessages.ts
@@ -1,11 +1,8 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { findChatById, listMessages } from './repository';
 import { getUsername } from './utils/tenantUtils';
-import {
-  internalServerError500Response,
-  notFound404Response,
-  ok200Response,
-} from './utils/apiResponse';
+import { notFound404Response, ok200Response } from './utils/apiResponse';
+import { handleLambdaError } from './utils/errorHandler';
 
 export const handler = async (
   event: APIGatewayProxyEvent
@@ -25,7 +22,6 @@ export const handler = async (
       messages,
     });
   } catch (error) {
-    console.log(error);
-    return internalServerError500Response({ message: 'Internal Server Error' });
+    return handleLambdaError(error);
   }
 };

--- a/packages/cdk/lambda/repository/common.ts
+++ b/packages/cdk/lambda/repository/common.ts
@@ -3,6 +3,11 @@ import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { APIGatewayProxyEvent } from 'aws-lambda';
 import { getTenantId } from '../utils/tenantUtils';
 import { createTenantDynamoDBClient } from '../utils/tenantDynamoDBClient';
+import {
+  TooManyRequestsError,
+  ServiceUnavailableError,
+  isRateLimitError,
+} from '../utils/errors';
 
 const TABLE_PREFIX: string = process.env.TABLE_NAME!;
 const ENVIRONMENT: string = process.env.ENVIRONMENT!;
@@ -35,12 +40,20 @@ export async function getTenantDynamoDBDocument(
     const dynamoDb = await createTenantDynamoDBClient(event);
     return DynamoDBDocumentClient.from(dynamoDb);
   } catch (error) {
-    console.error(
-      'Failed to assume role for tenant access, falling back to default:',
-      error
+    console.error('Failed to create tenant DynamoDB client:', error);
+
+    // レート制限エラーの場合は 429 を返す
+    if (isRateLimitError(error)) {
+      throw new TooManyRequestsError(
+        'サービスが一時的に混雑しています。しばらく待ってから再試行してください。',
+        30 // 30秒後にリトライ推奨
+      );
+    }
+
+    // その他のエラーは 503 を返す
+    throw new ServiceUnavailableError(
+      'テナント認証に失敗しました。しばらく待ってから再試行してください。'
     );
-    // Fall back to standard DynamoDB client
-    return DynamoDBDocumentClient.from(new DynamoDBClient({}));
   }
 }
 

--- a/packages/cdk/lambda/repository/common.ts
+++ b/packages/cdk/lambda/repository/common.ts
@@ -21,7 +21,8 @@ const DEFAULT_ASSISTANT_TABLE_NAME: string =
 
 /**
  * Get or create a tenant-specific DynamoDB document client
- * Falls back to default client if tenant-specific access fails
+ * Throws TooManyRequestsError (429) for rate limit errors
+ * Throws ServiceUnavailableError (503) for other tenant authentication failures
  */
 export async function getTenantDynamoDBDocument(
   event: APIGatewayProxyEvent

--- a/packages/cdk/lambda/updateFeedback.ts
+++ b/packages/cdk/lambda/updateFeedback.ts
@@ -2,11 +2,8 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { UpdateFeedbackRequest } from 'generative-ai-use-cases';
 import { listMessages, updateFeedback } from './repository';
 import { getUsername } from './utils/tenantUtils';
-import {
-  forbidden403Response,
-  internalServerError500Response,
-  ok200Response,
-} from './utils/apiResponse';
+import { forbidden403Response, ok200Response } from './utils/apiResponse';
+import { handleLambdaError } from './utils/errorHandler';
 
 export const handler = async (
   event: APIGatewayProxyEvent
@@ -39,7 +36,6 @@ export const handler = async (
 
     return ok200Response({ message });
   } catch (error) {
-    console.log(error);
-    return internalServerError500Response({ message: 'Internal Server Error' });
+    return handleLambdaError(error);
   }
 };

--- a/packages/cdk/lambda/updateTitle.ts
+++ b/packages/cdk/lambda/updateTitle.ts
@@ -2,11 +2,8 @@ import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
 import { UpdateTitleRequest } from 'generative-ai-use-cases';
 import { findChatById, setChatTitle } from './repository';
 import { getUsername } from './utils/tenantUtils';
-import {
-  internalServerError500Response,
-  notFound404Response,
-  ok200Response,
-} from './utils/apiResponse';
+import { notFound404Response, ok200Response } from './utils/apiResponse';
+import { handleLambdaError } from './utils/errorHandler';
 
 export const handler = async (
   event: APIGatewayProxyEvent
@@ -31,7 +28,6 @@ export const handler = async (
 
     return ok200Response({ chat: updatedChat });
   } catch (error) {
-    console.log(error);
-    return internalServerError500Response({ message: 'Internal Server Error' });
+    return handleLambdaError(error);
   }
 };

--- a/packages/cdk/lambda/utils/errorHandler.ts
+++ b/packages/cdk/lambda/utils/errorHandler.ts
@@ -1,0 +1,46 @@
+import { APIGatewayProxyResult } from 'aws-lambda';
+import { CORS_HEADERS_JSON } from '@generative-ai-use-cases/common';
+import { TooManyRequestsError, ServiceUnavailableError } from './errors';
+
+/**
+ * Lambdaハンドラー用の共通エラーハンドラー
+ * カスタム例外を適切なHTTPレスポンスに変換
+ */
+export function handleLambdaError(error: unknown): APIGatewayProxyResult {
+  console.error('Lambda error:', error);
+
+  // TooManyRequestsError (429)
+  if (error instanceof TooManyRequestsError) {
+    return {
+      statusCode: 429,
+      headers: {
+        ...CORS_HEADERS_JSON,
+        'Retry-After': String(error.retryAfter),
+      },
+      body: JSON.stringify({
+        message: error.message,
+        retryAfter: error.retryAfter,
+      }),
+    };
+  }
+
+  // ServiceUnavailableError (503)
+  if (error instanceof ServiceUnavailableError) {
+    return {
+      statusCode: 503,
+      headers: CORS_HEADERS_JSON,
+      body: JSON.stringify({
+        message: error.message,
+      }),
+    };
+  }
+
+  // その他のエラー (500)
+  return {
+    statusCode: 500,
+    headers: CORS_HEADERS_JSON,
+    body: JSON.stringify({
+      message: 'Internal Server Error',
+    }),
+  };
+}

--- a/packages/cdk/lambda/utils/errors.ts
+++ b/packages/cdk/lambda/utils/errors.ts
@@ -1,0 +1,60 @@
+/**
+ * HTTPエラーレスポンスに対応するカスタム例外クラス
+ */
+
+/**
+ * 429 Too Many Requests エラー
+ * レート制限に達した場合にスロー
+ */
+export class TooManyRequestsError extends Error {
+  public readonly statusCode = 429;
+  public readonly retryAfter: number;
+
+  constructor(message: string, retryAfter: number = 60) {
+    super(message);
+    this.name = 'TooManyRequestsError';
+    this.retryAfter = retryAfter;
+  }
+}
+
+/**
+ * 503 Service Unavailable エラー
+ * サービスが一時的に利用不可の場合にスロー
+ */
+export class ServiceUnavailableError extends Error {
+  public readonly statusCode = 503;
+
+  constructor(message: string) {
+    super(message);
+    this.name = 'ServiceUnavailableError';
+  }
+}
+
+/**
+ * エラーがレート制限関連かどうかを判定
+ */
+export function isRateLimitError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+
+  const rateLimitPatterns = [
+    'TooManyRequestsException',
+    'ThrottlingException',
+    'Rate exceeded',
+    'Throttling',
+  ];
+
+  const errorString = `${error.name} ${error.message}`;
+  return rateLimitPatterns.some((pattern) => errorString.includes(pattern));
+}
+
+/**
+ * HTTPエラーかどうかを判定するための型ガード
+ */
+export function isHttpError(
+  error: unknown
+): error is TooManyRequestsError | ServiceUnavailableError {
+  return (
+    error instanceof TooManyRequestsError ||
+    error instanceof ServiceUnavailableError
+  );
+}

--- a/packages/cdk/lambda/utils/errors.ts
+++ b/packages/cdk/lambda/utils/errors.ts
@@ -13,7 +13,8 @@ export class TooManyRequestsError extends Error {
   constructor(message: string, retryAfter: number = 60) {
     super(message);
     this.name = 'TooManyRequestsError';
-    this.retryAfter = retryAfter;
+    // retryAfterは正の数であることを保証
+    this.retryAfter = Math.max(1, Math.floor(retryAfter));
   }
 }
 
@@ -45,16 +46,4 @@ export function isRateLimitError(error: unknown): boolean {
 
   const errorString = `${error.name} ${error.message}`;
   return rateLimitPatterns.some((pattern) => errorString.includes(pattern));
-}
-
-/**
- * HTTPエラーかどうかを判定するための型ガード
- */
-export function isHttpError(
-  error: unknown
-): error is TooManyRequestsError | ServiceUnavailableError {
-  return (
-    error instanceof TooManyRequestsError ||
-    error instanceof ServiceUnavailableError
-  );
 }

--- a/packages/cdk/lambda/utils/tenantDynamoDBClient.ts
+++ b/packages/cdk/lambda/utils/tenantDynamoDBClient.ts
@@ -46,9 +46,7 @@ export async function createTenantDynamoDBClient(
     });
   } catch (error) {
     console.error('Failed to create tenant DynamoDB client:', error);
-    throw new Error(
-      `Failed to create tenant-isolated DynamoDB client: ${error}`
-    );
+    throw error; // 元のエラーをそのまま再スローし、エラータイプ情報を保持
   }
 }
 


### PR DESCRIPTION
## Summary

- TooManyRequestsError (429) と ServiceUnavailableError (503) のカスタム例外クラスを追加
- 共通エラーハンドラー (`handleLambdaError`) を実装し、429には `Retry-After` ヘッダーを含める
- `common.ts` のフォールバック処理を削除し、テナント認証失敗時に適切な例外をスロー
- 8つのLambdaハンドラーに新しいエラーハンドリングを適用

## 背景

負荷テスト中に `/chat` エンドポイントが 500 エラーを返す問題への対策として、レート制限エラー（Cognito Identity の `TooManyRequestsException`）を適切に処理し、クライアントがリトライ可能な 429 ステータスコードを返すように改善。

## 変更内容

### 新規ファイル
- `packages/cdk/lambda/utils/errors.ts` - カスタム例外クラス
- `packages/cdk/lambda/utils/errorHandler.ts` - 共通エラーハンドラー

### 修正ファイル
- `packages/cdk/lambda/repository/common.ts` - フォールバック削除、例外スロー
- 8つのLambdaハンドラー - `handleLambdaError` 適用

## Test plan

- [ ] TypeScriptビルドが成功すること
- [ ] レート制限エラー時に 429 + Retry-After ヘッダーが返却されること
- [ ] その他の認証エラー時に 503 が返却されること
- [ ] 正常系のAPIリクエストが引き続き動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)