### PR TITLE
✨ feat(waf): CloudFront Layer 7 DDoS保護機能をAWS WAF Anti-DDoSマネージドルールで追加

### DIFF
--- a/packages/cdk/cdk.example.json
+++ b/packages/cdk/cdk.example.json
@@ -73,6 +73,7 @@
     "allowedIpV4AddressRanges": null,
     "allowedIpV6AddressRanges": null,
     "allowedCountryCodes": null,
+    "antiDDoSProtection": false,
     "hostName": null,
     "domainName": null,
     "hostedZoneId": null,

--- a/packages/cdk/lib/construct/common-web-acl.ts
+++ b/packages/cdk/lib/construct/common-web-acl.ts
@@ -7,6 +7,7 @@ export interface CommonWebAclProps {
   readonly allowedIpV4AddressRanges?: string[] | null;
   readonly allowedIpV6AddressRanges?: string[] | null;
   readonly allowedCountryCodes?: string[] | null;
+  readonly antiDDoSProtection?: boolean;
 }
 
 export class CommonWebAcl extends Construct {
@@ -78,6 +79,50 @@ export class CommonWebAcl extends Construct {
       props.allowedIpV6AddressRanges.length > 0;
     const hasAllowedCountryCodes =
       props.allowedCountryCodes && props.allowedCountryCodes.length > 0;
+    const hasIpOrGeoRestriction =
+      hasAllowedIpV4 || hasAllowedIpV6 || hasAllowedCountryCodes;
+
+    // Priority offset: if Anti-DDoS is enabled, existing rules start from priority 1
+    const priorityOffset = props.antiDDoSProtection ? 1 : 0;
+
+    // Add Anti-DDoS managed rule group if enabled
+    if (props.antiDDoSProtection) {
+      rules.push({
+        name: 'AWS-AWSManagedRulesAntiDDoSRuleSet',
+        priority: 0,
+        overrideAction: { none: {} },
+        statement: {
+          managedRuleGroupStatement: {
+            vendorName: 'AWS',
+            name: 'AWSManagedRulesAntiDDoSRuleSet',
+            managedRuleGroupConfigs: [
+              {
+                awsManagedRulesAntiDDoSRuleSet: {
+                  clientSideActionConfig: {
+                    challenge: {
+                      usageOfAction: 'ENABLED',
+                      sensitivity: 'HIGH',
+                      exemptUriRegularExpressions: [
+                        {
+                          regexString:
+                            '\\/api\\/|\\.(acc|avi|css|gif|jpe?g|js|mp[34]|ogg|otf|pdf|png|tiff?|ttf|webm|webp|woff2?)$',
+                        },
+                      ],
+                    },
+                  },
+                  sensitivityToBlock: 'LOW',
+                },
+              },
+            ],
+          },
+        },
+        visibilityConfig: {
+          sampledRequestsEnabled: true,
+          cloudWatchMetricsEnabled: true,
+          metricName: 'AWSManagedRulesAntiDDoSRuleSet',
+        },
+      });
+    }
 
     // Define rules for IP v4 and v6 respectively
     if (hasAllowedIpV4) {
@@ -90,7 +135,7 @@ export class CommonWebAcl extends Construct {
         // If you want to perform Geo restriction, specify AND condition with IP restriction
         rules.push(
           generateIpSetAndGeoMatchRule(
-            1,
+            1 + priorityOffset,
             `IpV4SetAndGeoMatchRule${id}`,
             wafIPv4Set.attrArn,
             props.allowedCountryCodes ?? []
@@ -98,7 +143,11 @@ export class CommonWebAcl extends Construct {
         );
       } else {
         rules.push(
-          generateIpSetRule(1, `IpV4SetRule${id}`, wafIPv4Set.attrArn)
+          generateIpSetRule(
+            1 + priorityOffset,
+            `IpV4SetRule${id}`,
+            wafIPv4Set.attrArn
+          )
         );
       }
     }
@@ -113,7 +162,7 @@ export class CommonWebAcl extends Construct {
         // If you want to perform Geo restriction, specify AND condition with IP restriction
         rules.push(
           generateIpSetAndGeoMatchRule(
-            2,
+            2 + priorityOffset,
             `IpV6SetAndGeoMatchRule${id}`,
             wafIPv6Set.attrArn,
             props.allowedCountryCodes ?? []
@@ -121,7 +170,11 @@ export class CommonWebAcl extends Construct {
         );
       } else {
         rules.push(
-          generateIpSetRule(2, `IpV6SetRule${id}`, wafIPv6Set.attrArn)
+          generateIpSetRule(
+            2 + priorityOffset,
+            `IpV6SetRule${id}`,
+            wafIPv6Set.attrArn
+          )
         );
       }
     }
@@ -130,7 +183,7 @@ export class CommonWebAcl extends Construct {
     if (!hasAllowedIpV4 && !hasAllowedIpV6 && hasAllowedCountryCodes) {
       const name = `GeoMatchRule${id}`;
       rules.push({
-        priority: 3,
+        priority: 3 + priorityOffset,
         ...commonRulePropreties(name),
         statement: {
           geoMatchStatement: {
@@ -140,8 +193,13 @@ export class CommonWebAcl extends Construct {
       });
     }
 
+    // Default action: block if IP/Geo restriction is enabled, allow if only Anti-DDoS is enabled
+    const defaultAction = hasIpOrGeoRestriction
+      ? { block: {} }
+      : { allow: {} };
+
     const webAcl = new CfnWebACL(this, `WebAcl${id}`, {
-      defaultAction: { block: {} },
+      defaultAction,
       name: `WebAcl-${suffix}`,
       scope: props.scope,
       visibilityConfig: {

--- a/packages/cdk/lib/create-stacks.ts
+++ b/packages/cdk/lib/create-stacks.ts
@@ -22,14 +22,15 @@ class DeletionPolicySetter implements cdk.IAspect {
 
 export const createStacks = (app: cdk.App, params: ProcessedStackInput) => {
   // CloudFront WAF
-  // Only deploy CloudFrontWafStack if useWebUi is true and IP address range (v4 or v6) or geographic restriction or custom domain is defined
+  // Only deploy CloudFrontWafStack if useWebUi is true and IP address range (v4 or v6) or geographic restriction or custom domain or Anti-DDoS protection is defined
   // WAF v2 is only deployable in us-east-1, so the Stack is separated
   const cloudFrontWafStack =
     params.useWebUi &&
     (params.allowedIpV4AddressRanges ||
       params.allowedIpV6AddressRanges ||
       params.allowedCountryCodes ||
-      params.hostName)
+      params.hostName ||
+      params.antiDDoSProtection)
       ? new CloudFrontWafStack(app, `CloudFrontWafStack${params.env}`, {
           env: {
             account: params.account,

--- a/packages/cdk/lib/stack-input.ts
+++ b/packages/cdk/lib/stack-input.ts
@@ -170,6 +170,7 @@ const baseStackInputSchema = z.object({
   allowedIpV4AddressRanges: z.array(z.string()).nullish(),
   allowedIpV6AddressRanges: z.array(z.string()).nullish(),
   allowedCountryCodes: z.array(z.string()).nullish(),
+  antiDDoSProtection: z.boolean().default(false),
   // Custom Domain
   hostName: z.string().nullish(),
   domainName: z.string().nullish(),

--- a/packages/cdk/lib/stacks/common/cloud-front-waf-stack.ts
+++ b/packages/cdk/lib/stacks/common/cloud-front-waf-stack.ts
@@ -26,13 +26,15 @@ export class CloudFrontWafStack extends Stack {
     if (
       params.allowedIpV4AddressRanges ||
       params.allowedIpV6AddressRanges ||
-      params.allowedCountryCodes
+      params.allowedCountryCodes ||
+      params.antiDDoSProtection
     ) {
       const webAcl = new CommonWebAcl(this, `WebAcl${id}`, {
         scope: 'CLOUDFRONT',
         allowedIpV4AddressRanges: params.allowedIpV4AddressRanges,
         allowedIpV6AddressRanges: params.allowedIpV6AddressRanges,
         allowedCountryCodes: params.allowedCountryCodes,
+        antiDDoSProtection: params.antiDDoSProtection,
       });
 
       new CfnOutput(this, 'WebAclId', {


### PR DESCRIPTION
## Summary
- CloudFront の Layer 7 DDoS 保護機能（AWSManagedRulesAntiDDoSRuleSet）を CDK で実装
- `antiDDoSProtection: true` を cdk.json で設定することで有効化可能
- Challenge sensitivity: HIGH（全ての疑わしいリクエストにチャレンジ）
- Block sensitivity: LOW（高確信度の攻撃のみブロック）

## Changes
- `stack-input.ts`: `antiDDoSProtection` 設定スキーマを追加
- `common-web-acl.ts`: Anti-DDoS マネージドルールグループを追加、priority 調整
- `create-stacks.ts`: WAF スタック作成条件に Anti-DDoS を追加
- `cloud-front-waf-stack.ts`: props 受け渡しを追加

## Test plan
- [ ] `antiDDoSProtection: true` を設定して `cdk synth` が成功することを確認
- [ ] CloudFormation テンプレートに AWSManagedRulesAntiDDoSRuleSet が含まれることを確認
- [ ] デプロイ後、AWS コンソールで WAF ルールが正しく設定されていることを確認

## Notes
- `AWSManagedRulesAntiDDoSRuleSet` は有料のマネージドルール（AWS WAF Pricing 参照）
- WCU 消費: 50 WCU

🤖 Generated with [Claude Code](https://claude.com/claude-code)