### PR TITLE
✨ feat(api): API GatewayにTLS 1.2セキュリティポリシーを設定

### DIFF
--- a/packages/cdk/lib/construct/api/index.ts
+++ b/packages/cdk/lib/construct/api/index.ts
@@ -175,6 +175,7 @@ export class Api extends Construct {
     // Set TLS 1.2 security policy
     const cfnApi = api.node.defaultChild as CfnRestApi;
     cfnApi.securityPolicy = 'SecurityPolicy_TLS12_2018_EDGE';
+    // TODO: Replace with cfnApi.endpointAccessMode = 'BASIC' after upgrading aws-cdk-lib
     cfnApi.addPropertyOverride('EndpointAccessMode', 'BASIC');
 
     api.addGatewayResponse('Api4XX', {

--- a/packages/cdk/lib/construct/api/index.ts
+++ b/packages/cdk/lib/construct/api/index.ts
@@ -175,6 +175,7 @@ export class Api extends Construct {
     // Set TLS 1.2 security policy
     const cfnApi = api.node.defaultChild as CfnRestApi;
     cfnApi.securityPolicy = 'SecurityPolicy_TLS12_2018_EDGE';
+    cfnApi.addPropertyOverride('EndpointAccessMode', 'BASIC');
 
     api.addGatewayResponse('Api4XX', {
       type: ResponseType.DEFAULT_4XX,

--- a/packages/cdk/lib/construct/api/index.ts
+++ b/packages/cdk/lib/construct/api/index.ts
@@ -1,6 +1,7 @@
 import { Stack, CfnOutput, Duration } from 'aws-cdk-lib';
 import {
   AuthorizationType,
+  CfnRestApi,
   CognitoUserPoolsAuthorizer,
   Cors,
   LambdaIntegration,
@@ -170,6 +171,10 @@ export class Api extends Construct {
       cloudWatchRole: true,
       defaultMethodOptions: commonAuthorizerProps,
     });
+
+    // Set TLS 1.2 security policy
+    const cfnApi = api.node.defaultChild as CfnRestApi;
+    cfnApi.securityPolicy = 'SecurityPolicy_TLS12_2018_EDGE';
 
     api.addGatewayResponse('Api4XX', {
       type: ResponseType.DEFAULT_4XX,


### PR DESCRIPTION
## Summary
- API GatewayのセキュリティポリシーをTLS 1.2 (`SecurityPolicy_TLS12_2018_EDGE`) に設定
- CDK L2コンストラクト（RestApi）からL1プロパティにアクセスしてセキュリティポリシーを設定

## Test plan
- [ ] `npm run cdk:deploy` でデプロイ
- [ ] AWSコンソールでAPI Gateway > APIの設定からセキュリティポリシーが `SecurityPolicy_TLS12_2018_EDGE` になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)