### PR TITLE
:sparkles: .envrcでESLintカスタムプラグインを自動ビルドするように追加

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -8,5 +8,6 @@
 eval "$(devbox generate direnv --print-envrc)"
 
 if [ -f package-lock.json ] && [ ! -d node_modules ]; then
-  npm ci
+  npm ci                                              # パッケージをインストール
+  npm -w packages/eslint-plugin-i18nhelper run build  # ESLintのプラグインをビルドする
 fi

--- a/devbox.json
+++ b/devbox.json
@@ -19,9 +19,10 @@
       "if [ ! -d 'node_modules' ]; then",
       "  echo '📦 Installing npm dependencies...'",
       "  npm ci",
+      "  echo '🏗 Building custom ESLint plugin...'",
+      "  npm -w packages/eslint-plugin-i18nhelper run build",
       "fi",
     ],
-    "scripts": {
-    }
+    "scripts": {}
   }
 }


### PR DESCRIPTION
## Summary

- devbox環境セットアップ時にESLintカスタムプラグイン（packages/eslint-plugin-i18nhelper）を自動ビルドするコマンドを追加
- `npm ci`実行後に`npm -w packages/eslint-plugin-i18nhelper run build`を実行するように変更
