### PR TITLE
✨  feat(cdk): OpenFGA ECSサービスにAuto Scaling機能を追加

### DIFF
--- a/packages/cdk/cdk.tenant.example.json
+++ b/packages/cdk/cdk.tenant.example.json
@@ -55,7 +55,13 @@
       "ecs": {
         "cpu": 256,
         "memoryLimitMiB": 512,
-        "desiredCount": 1,
+        "minCapacity": 1,
+        "maxCapacity": 10,
+        "cpuTargetUtilizationPercent": 70,
+        "memoryTargetUtilizationPercent": null,
+        "scaleOutCooldownSeconds": null,
+        "scaleInCooldownSeconds": null,
+        "scheduledScaling": [],
         "imageVersion": "v1.8.0"
       },
       "logging": {

--- a/packages/cdk/lib/create-tenant-stacks.ts
+++ b/packages/cdk/lib/create-tenant-stacks.ts
@@ -48,7 +48,28 @@ export interface OpenFgaConfig {
   ecs: {
     cpu: number;
     memoryLimitMiB: number;
-    desiredCount: number;
+    minCapacity: number;
+    maxCapacity: number;
+    cpuTargetUtilizationPercent?: number;
+    memoryTargetUtilizationPercent?: number;
+    scaleOutCooldownSeconds?: number;
+    scaleInCooldownSeconds?: number;
+    /**
+     * Schedule-based scaling configurations.
+     * @example
+     * scheduledScaling: [
+     *   { scheduleName: "ScaleUpMorning", schedule: "cron(0 9 * * ? *)", minCapacity: 2 },
+     *   { scheduleName: "ScaleDownNight", schedule: "cron(0 21 * * ? *)", maxCapacity: 1 }
+     * ]
+     */
+    scheduledScaling?: Array<{
+      /** Unique identifier for this schedule. Must be alphanumeric (used as CloudFormation logical ID). */
+      scheduleName: string;
+      /** Cron or rate expression. e.g., "cron(0 9 * * ? *)" or "rate(1 hour)" */
+      schedule: string;
+      minCapacity?: number;
+      maxCapacity?: number;
+    }>;
     imageVersion: string;
   };
   logging: {

--- a/packages/cdk/lib/stacks/tenant/tenant-openfga-stack.ts
+++ b/packages/cdk/lib/stacks/tenant/tenant-openfga-stack.ts
@@ -10,6 +10,7 @@ import * as iam from 'aws-cdk-lib/aws-iam';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as cr from 'aws-cdk-lib/custom-resources';
 import * as ssm from 'aws-cdk-lib/aws-ssm';
+import * as appscaling from 'aws-cdk-lib/aws-applicationautoscaling';
 import * as crypto from 'crypto';
 import { Construct } from 'constructs';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
@@ -420,10 +421,11 @@ export class TenantOpenFgaStack extends cdk.Stack {
     });
 
     // Create Fargate service
+    const ecsConfig = props.openFgaConfig.ecs;
     const service = new ecs.FargateService(this, 'OpenFgaService', {
       cluster,
       taskDefinition,
-      desiredCount: props.openFgaConfig.ecs.desiredCount,
+      desiredCount: ecsConfig.minCapacity,
       assignPublicIp: false,
       vpcSubnets: {
         subnets: props.subnets,
@@ -436,6 +438,67 @@ export class TenantOpenFgaStack extends cdk.Stack {
         rollback: true,
       },
     });
+
+    // ====================================================
+    // Auto Scaling Configuration
+    // ====================================================
+    // Auto scaling is enabled when maxCapacity > minCapacity
+    if (ecsConfig.maxCapacity > ecsConfig.minCapacity) {
+      const hasCpuScaling = !!ecsConfig.cpuTargetUtilizationPercent;
+      const hasMemoryScaling = !!ecsConfig.memoryTargetUtilizationPercent;
+      const hasScheduledScaling =
+        ecsConfig.scheduledScaling && ecsConfig.scheduledScaling.length > 0;
+
+      if (!hasCpuScaling && !hasMemoryScaling && !hasScheduledScaling) {
+        console.warn(
+          `[${props.tenantId}] Auto Scaling is enabled (maxCapacity: ${ecsConfig.maxCapacity} > minCapacity: ${ecsConfig.minCapacity}) ` +
+            'but no scaling policy is configured. Consider setting cpuTargetUtilizationPercent, ' +
+            'memoryTargetUtilizationPercent, or scheduledScaling.'
+        );
+      }
+
+      const scalableTarget = service.autoScaleTaskCount({
+        minCapacity: ecsConfig.minCapacity,
+        maxCapacity: ecsConfig.maxCapacity,
+      });
+
+      // Shared cooldown configuration for scaling policies
+      const cooldownConfig = {
+        scaleOutCooldown: ecsConfig.scaleOutCooldownSeconds
+          ? cdk.Duration.seconds(ecsConfig.scaleOutCooldownSeconds)
+          : undefined,
+        scaleInCooldown: ecsConfig.scaleInCooldownSeconds
+          ? cdk.Duration.seconds(ecsConfig.scaleInCooldownSeconds)
+          : undefined,
+      };
+
+      // CPU utilization based scaling (enabled when cpuTargetUtilizationPercent is specified)
+      if (ecsConfig.cpuTargetUtilizationPercent) {
+        scalableTarget.scaleOnCpuUtilization('CpuScaling', {
+          targetUtilizationPercent: ecsConfig.cpuTargetUtilizationPercent,
+          ...cooldownConfig,
+        });
+      }
+
+      // Memory utilization based scaling (enabled when memoryTargetUtilizationPercent is specified)
+      if (ecsConfig.memoryTargetUtilizationPercent) {
+        scalableTarget.scaleOnMemoryUtilization('MemoryScaling', {
+          targetUtilizationPercent: ecsConfig.memoryTargetUtilizationPercent,
+          ...cooldownConfig,
+        });
+      }
+
+      // Schedule based scaling
+      if (ecsConfig.scheduledScaling && ecsConfig.scheduledScaling.length > 0) {
+        for (const scheduleConfig of ecsConfig.scheduledScaling) {
+          scalableTarget.scaleOnSchedule(scheduleConfig.scheduleName, {
+            schedule: appscaling.Schedule.expression(scheduleConfig.schedule),
+            minCapacity: scheduleConfig.minCapacity,
+            maxCapacity: scheduleConfig.maxCapacity,
+          });
+        }
+      }
+    }
 
     // Attach the service to the target group
     service.attachToNetworkTargetGroup(targetGroup);


### PR DESCRIPTION
## Summary
- OpenFGA ECSサービスにApplication Auto Scaling機能を追加
- CPU/メモリ使用率ベースのターゲット追跡スケーリングポリシーをサポート
- スケジュールベースのスケーリング（時間帯に応じたキャパシティ調整）をサポート

## Changes
- `desiredCount` を `minCapacity` / `maxCapacity` に変更し、動的なタスク数調整を可能に
- `cpuTargetUtilizationPercent`: CPU使用率に基づくスケーリング閾値
- `memoryTargetUtilizationPercent`: メモリ使用率に基づくスケーリング閾値
- `scaleOutCooldown` / `scaleInCooldown`: スケーリングのクールダウン期間設定
- `scheduledScaling`: cron式によるスケジュールベースのスケーリング設定

## Test plan
- [ ] CDK synthが正常に完了すること
- [ ] Auto Scaling設定なし（maxCapacity = minCapacity）で従来通り動作すること
- [ ] CPU/メモリスケーリングポリシーが正しく作成されること
- [ ] スケジュールベーススケーリングが正しく作成されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)