### PR TITLE
🐛 アシスタント利用回答生成の利用回数制限で数があわない不具合の修正

### DIFF
--- a/packages/cdk/lambda/assistantMessageStreamHandler.ts
+++ b/packages/cdk/lambda/assistantMessageStreamHandler.ts
@@ -481,6 +481,46 @@ ${assistant.instruction}
         );
       }
 
+      // Send usage information at the end of streaming
+      if (accessCheckResult?.usage) {
+        // Calculate updated usage (current + 1 for this request)
+        const updatedUsage: {
+          daily?: { current: number; limit: number; remaining: number };
+          monthly?: { current: number; limit: number; remaining: number };
+          total?: { current: number; limit: number; remaining: number };
+        } = {};
+        if (accessCheckResult.usage.daily) {
+          const newCurrent = accessCheckResult.usage.daily.current + 1;
+          updatedUsage.daily = {
+            current: newCurrent,
+            limit: accessCheckResult.usage.daily.limit,
+            remaining: Math.max(0, accessCheckResult.usage.daily.limit - newCurrent),
+          };
+        }
+        if (accessCheckResult.usage.monthly) {
+          const newCurrent = accessCheckResult.usage.monthly.current + 1;
+          updatedUsage.monthly = {
+            current: newCurrent,
+            limit: accessCheckResult.usage.monthly.limit,
+            remaining: Math.max(0, accessCheckResult.usage.monthly.limit - newCurrent),
+          };
+        }
+        if (accessCheckResult.usage.total) {
+          const newCurrent = accessCheckResult.usage.total.current + 1;
+          updatedUsage.total = {
+            current: newCurrent,
+            limit: accessCheckResult.usage.total.limit,
+            remaining: Math.max(0, accessCheckResult.usage.total.limit - newCurrent),
+          };
+        }
+        responseStream.write(
+          streamingChunk({
+            text: '',
+            usage: updatedUsage,
+          })
+        );
+      }
+
       responseStream.end();
     } catch {
       responseStream.write(

--- a/packages/cdk/lambda/authorization/repositories/types.ts
+++ b/packages/cdk/lambda/authorization/repositories/types.ts
@@ -23,7 +23,7 @@ export interface PermissionGrantItem {
   features: Array<{
     // 付与された機能のリスト
     featureId: string;
-    limitType: 'unlimited' | 'daily' | 'monthly';
+    limitType: 'unlimited' | 'daily' | 'monthly' | 'total';
     limitCount?: number;
   }>;
   status: 'active' | 'revoked'; // 状態
@@ -43,7 +43,7 @@ export interface GrantPermissionRequest {
   planId: string; // プランID（Entitlement IDの生成に使用）
   features: Array<{
     featureId: string; // 機能ID（例: "llm:gemini-2.5-flash"）
-    limitType: 'unlimited' | 'daily' | 'monthly';
+    limitType: 'unlimited' | 'daily' | 'monthly' | 'total';
     limitCount?: number; // limitTypeが'unlimited'以外の場合に必須
   }>; // DynamoDBへの回数制限カウンター作成に使用
   sourceType: string; // 付与元のタイプ（例: "subscription", "trial", "campaign", "manual"）

--- a/packages/cdk/lambda/authorization/repositories/types.ts
+++ b/packages/cdk/lambda/authorization/repositories/types.ts
@@ -11,7 +11,7 @@ export interface UsageEventItem {
   userId: string; // ユーザID（パーティションキー）
   timestamp: number; // イベント発生時刻（ソートキー、Unixタイムスタンプ、ミリ秒単位）
   featureId: string; // 使用した機能ID
-  ttl: number; // TTL属性（Unixタイムスタンプ、秒単位）記録から120日後に自動削除
+  ttl?: number; // TTL属性（Unixタイムスタンプ、秒単位）記録から120日後に自動削除。累計制限(total)の場合は設定しない
 }
 
 /**

--- a/packages/cdk/lambda/utils/accessChecker.ts
+++ b/packages/cdk/lambda/utils/accessChecker.ts
@@ -29,9 +29,15 @@ export interface AccessCheckResult {
       limit: number;
       remaining: number;
     };
+    /** 累計の利用回数制限（期間なし） */
+    total?: {
+      current: number;
+      limit: number;
+      remaining: number;
+    };
   };
   /** 回数制限のタイプ（incrementUsageで使用） */
-  limitType?: 'unlimited' | 'daily' | 'monthly';
+  limitType?: 'unlimited' | 'daily' | 'monthly' | 'total';
   /** 検証済みのユーザー情報（後続処理で使用） */
   userContext?: {
     tenantId: string;
@@ -45,6 +51,14 @@ export interface AccessCheckResult {
  * - assistant: アシスタント機能（例: chat）
  */
 export type ResourceType = 'llm' | 'assistant';
+
+/**
+ * デフォルトの利用回数制限設定
+ * PermissionGrantテーブルに設定がない場合に適用される
+ */
+const DEFAULT_LIMITS: Record<string, { limitType: 'daily' | 'monthly' | 'total'; limitCount: number }> = {
+  'assistant:chat': { limitType: 'total', limitCount: 30 },
+};
 
 /**
  * テーブル名を生成するヘルパー関数
@@ -211,25 +225,49 @@ export async function checkAccessWithQuota(
     // この機能に対する制限情報を探す
     let dailyLimit: number | null = null;
     let monthlyLimit: number | null = null;
+    let totalLimit: number | null = null;
     let limitType: AccessCheckResult['limitType'] = 'unlimited';
+    let foundInGrants = false;
 
     for (const grant of activeGrants) {
       const feature = grant.features.find((f) => f.featureId === featureId);
       if (feature) {
+        foundInGrants = true;
         if (feature.limitType === 'daily' && feature.limitCount) {
           dailyLimit = feature.limitCount;
           limitType = 'daily';
         } else if (feature.limitType === 'monthly' && feature.limitCount) {
           monthlyLimit = feature.limitCount;
           limitType = 'monthly';
+        } else if (feature.limitType === 'total' && feature.limitCount) {
+          totalLimit = feature.limitCount;
+          limitType = 'total';
         } else if (feature.limitType === 'unlimited') {
           limitType = 'unlimited';
         }
       }
     }
 
+    // PermissionGrantに設定がない場合、デフォルト制限を適用
+    if (!foundInGrants && DEFAULT_LIMITS[featureId]) {
+      const defaultLimit = DEFAULT_LIMITS[featureId];
+      if (defaultLimit.limitType === 'daily') {
+        dailyLimit = defaultLimit.limitCount;
+        limitType = 'daily';
+      } else if (defaultLimit.limitType === 'monthly') {
+        monthlyLimit = defaultLimit.limitCount;
+        limitType = 'monthly';
+      } else if (defaultLimit.limitType === 'total') {
+        totalLimit = defaultLimit.limitCount;
+        limitType = 'total';
+      }
+      console.log(
+        `[AccessCheck] Applying default limit for ${featureId} - type: ${defaultLimit.limitType}, count: ${defaultLimit.limitCount}`
+      );
+    }
+
     console.log(
-      `[AccessCheck] Limit configuration - dailyLimit: ${dailyLimit}, monthlyLimit: ${monthlyLimit}, limitType: ${limitType}`
+      `[AccessCheck] Limit configuration - dailyLimit: ${dailyLimit}, monthlyLimit: ${monthlyLimit}, totalLimit: ${totalLimit}, limitType: ${limitType}`
     );
 
     const usage: AccessCheckResult['usage'] = {};
@@ -315,6 +353,46 @@ export async function checkAccessWithQuota(
       console.log(`[AccessCheck] No monthly limit configured for ${featureId}`);
     }
 
+    // 累計制限のチェック（期間なし）
+    if (totalLimit !== null) {
+      // 全期間のイベント数をカウント（開始時刻を0にして全件取得）
+      const totalCount = await usageEventRepository.countUsageInPeriod(
+        userId,
+        featureId,
+        0,
+        now
+      );
+
+      console.log(
+        `[AccessCheck] Total limit found - currentCount: ${totalCount}, limitCount: ${totalLimit}`
+      );
+
+      const remaining = totalLimit - totalCount;
+      usage.total = {
+        current: totalCount,
+        limit: totalLimit,
+        remaining: Math.max(0, remaining),
+      };
+
+      if (totalCount >= totalLimit) {
+        console.log(
+          `[AccessCheck] Total quota exceeded - User ${userId}, featureId: ${featureId}, current: ${totalCount}, limit: ${totalLimit}`
+        );
+        return {
+          allowed: false,
+          reason: 'quota_exceeded',
+          usage,
+          limitType: 'total',
+          userContext: { tenantId, userId },
+        };
+      }
+      console.log(
+        `[AccessCheck] Total quota check passed - remaining: ${remaining}`
+      );
+    } else {
+      console.log(`[AccessCheck] No total limit configured for ${featureId}`);
+    }
+
     // 回数制限がない（unlimitedまたは制限なしプラン）
     console.log(
       `[AccessCheck] Access granted - User ${userId}, featureId: ${featureId}, limitType: ${limitType}`
@@ -351,7 +429,7 @@ export async function incrementUsage(
   idToken: string,
   resourceType: ResourceType,
   resourceId: string,
-  limitType: 'unlimited' | 'daily' | 'monthly'
+  limitType: 'unlimited' | 'daily' | 'monthly' | 'total'
 ): Promise<void> {
   const featureId = buildFeatureId(resourceType, resourceId);
 

--- a/packages/cdk/lambda/utils/accessChecker.ts
+++ b/packages/cdk/lambda/utils/accessChecker.ts
@@ -480,17 +480,21 @@ export async function incrementUsage(
     );
 
     const now = Date.now();
-    const ttl = Math.floor(now / 1000) + 120 * 24 * 60 * 60; // 120日後に自動削除
+    // 累計制限(total)の場合はTTLを設定しない（永続化）
+    // daily/monthlyの場合は120日後に自動削除
+    const ttl = limitType === 'total'
+      ? undefined
+      : Math.floor(now / 1000) + 120 * 24 * 60 * 60;
 
     console.log(
-      `[IncrementUsage] Recording usage event - tableName: ${usageEventTableName}, userId: ${userId}, featureId: ${featureId}, timestamp: ${now}`
+      `[IncrementUsage] Recording usage event - tableName: ${usageEventTableName}, userId: ${userId}, featureId: ${featureId}, timestamp: ${now}, ttl: ${ttl ?? 'none (permanent)'}`
     );
 
     await usageEventRepository.recordEvent({
       userId,
       timestamp: now,
       featureId,
-      ttl,
+      ...(ttl !== undefined && { ttl }),
     });
 
     console.log(

--- a/packages/types/src/protocol.d.ts
+++ b/packages/types/src/protocol.d.ts
@@ -25,6 +25,25 @@ export type StreamingChunk = {
   metadata?: Metadata;
   stopReason?: StopReason | 'error';
   sessionId?: string;
+  /** 利用回数情報（ストリーミング終了時に返却） */
+  usage?: {
+    daily?: {
+      current: number;
+      limit: number;
+      remaining: number;
+    };
+    monthly?: {
+      current: number;
+      limit: number;
+      remaining: number;
+    };
+    /** 累計の利用回数制限（期間なし） */
+    total?: {
+      current: number;
+      limit: number;
+      remaining: number;
+    };
+  };
 };
 
 export type Pagination<T> = {


### PR DESCRIPTION
## 変更の概要
回答生成のレスポンスに利用回数制限の回数を返すようにする
<!-- どのような変更を行ったかを書く -->

## 申し送り事項

<!-- レビュワーに伝えておきたい事柄等を書く（Draftの理由など） -->

## Checklist（レビュワー用）

- [ ] `npm run lint`でエラーが出ない
- [ ] TypeScriptのビルドで型エラーが出ない
- [ ] 手元でフォーマットした際に差分が出ない
