### PR TITLE
🐛 チャット画面での利用回数制限回数を正しく返すようにする

### DIFF
--- a/packages/cdk/lambda/predictStream.ts
+++ b/packages/cdk/lambda/predictStream.ts
@@ -5,6 +5,7 @@ import { defaultModel } from './utils/models';
 import {
   checkAccessWithQuota,
   incrementUsage,
+  getLatestUsage,
   AccessCheckResult,
 } from './utils/accessChecker';
 
@@ -90,16 +91,31 @@ export const handler = awslambda.streamifyResponse(
         responseStream.write(token);
       }
 
-      // Increment usage count after successful streaming (fire-and-forget)
+      // Increment usage count after successful streaming and return latest usage info
       if (accessCheckResult.limitType && accessCheckResult.limitType !== 'unlimited') {
-        incrementUsage(
-          event.idToken,
-          'llm',
-          model.modelId,
-          accessCheckResult.limitType
-        ).catch((error) => {
+        try {
+          await incrementUsage(
+            event.idToken,
+            'llm',
+            model.modelId,
+            accessCheckResult.limitType
+          );
+
+          // Get latest usage info after incrementing
+          const latestUsage = await getLatestUsage(event.idToken, 'llm', model.modelId);
+
+          // Send final chunk with updated usage info
+          if (latestUsage) {
+            responseStream.write(
+              JSON.stringify({
+                text: '',
+                usage: latestUsage,
+              })
+            );
+          }
+        } catch (error) {
           console.error('Failed to increment usage count:', error);
-        });
+        }
       }
 
       responseStream.end();


### PR DESCRIPTION
## 変更の概要

- チャット回答生成のストリーミング終了後に利用回数制限の回数を返す

<!-- どのような変更を行ったかを書く -->

## 申し送り事項

<!-- レビュワーに伝えておきたい事柄等を書く（Draftの理由など） -->

## Checklist（レビュワー用）

- [ ] `npm run lint`でエラーが出ない
- [ ] TypeScriptのビルドで型エラーが出ない
- [ ] 手元でフォーマットした際に差分が出ない
