### PR TITLE
✨  feat(opensearch): サーバレスOpenSearchからマネージドOpenSearchドメインへの移行

### DIFF
--- a/packages/cdk/bin/generative-ai-use-cases-tenant.ts
+++ b/packages/cdk/bin/generative-ai-use-cases-tenant.ts
@@ -4,28 +4,17 @@ import * as cdk from 'aws-cdk-lib';
 import * as fs from 'fs';
 import * as path from 'path';
 import { createTenantStacks } from '../lib/create-tenant-stacks';
-import * as ec2 from 'aws-cdk-lib/aws-ec2';
 
 const app = new cdk.App();
 
-// EBS Volume Type mapping
-const ebsVolumeTypeMap: { [key: string]: ec2.EbsDeviceVolumeType } = {
-  GP3: ec2.EbsDeviceVolumeType.GP3,
-  GP2: ec2.EbsDeviceVolumeType.GP2,
-  IO1: ec2.EbsDeviceVolumeType.IO1,
-  IO2: ec2.EbsDeviceVolumeType.IO2,
-  STANDARD: ec2.EbsDeviceVolumeType.STANDARD,
-  SC1: ec2.EbsDeviceVolumeType.SC1,
-  ST1: ec2.EbsDeviceVolumeType.ST1,
-};
-
 // Read tenant configuration from cdk.tenant.json
+// Note: OpenSearch configuration has been removed - OpenSearch is now unified
+// across all tenants via UnifiedOpenSearchStack
 interface TenantConfig {
   tenantId?: string;
   environment?: string;
   tenantRegion?: string;
   enableAutoDelete?: boolean;
-  openSearchCapacity?: any; // Will be parsed as JSON string or object
   networkConfig?: {
     vpcCidr?: string;
     maxAzs?: number;
@@ -42,7 +31,6 @@ interface TenantConfig {
     identityPoolId: string;
     userPoolClientId: string;
     controlPlaneLambdaRoleArn?: string;
-    openSearchIndexName?: string;
   };
   ipAccessControl?: {
     enabled: boolean;
@@ -172,16 +160,8 @@ const params = {
     context.tenantRegion ||
     process.env.CDK_DEFAULT_REGION ||
     'us-east-1',
-  openSearchConfig: {
-    capacity: context.openSearchConfig.capacity,
-    ebsVolumeSize: context.openSearchConfig.ebsVolumeSize,
-    ebsVolumeType:
-      ebsVolumeTypeMap[context.openSearchConfig.ebsVolumeType] ||
-      ec2.EbsDeviceVolumeType.GP3,
-    availabilityZoneCount: context.openSearchConfig.availabilityZoneCount,
-    automatedSnapshotStartHour:
-      context.openSearchConfig.automatedSnapshotStartHour,
-  },
+  // Note: OpenSearch is now unified - no per-tenant OpenSearch configuration needed
+  // The unified OpenSearch endpoint is provided via environment variables
   networkConfig: context.networkConfig,
   ipAccessControl: context.ipAccessControl,
   controlPlaneRegion: context.controlPlane?.region,
@@ -190,7 +170,6 @@ const params = {
   tenantsTableName:
     context.controlPlane?.tenantsTableName ||
     `Tenants-${context.environment || 'dev'}`,
-  openSearchIndexName: context.openSearchIndexName || 'assistant-docs',
 };
 
 createTenantStacks(app, params);

--- a/packages/cdk/custom-resources/opensearch-tenant-updater.js
+++ b/packages/cdk/custom-resources/opensearch-tenant-updater.js
@@ -1,3 +1,12 @@
+/**
+ * @deprecated This custom resource is deprecated and no longer used.
+ *
+ * OpenSearch is now unified in UnifiedOpenSearchStack.
+ * Per-tenant OpenSearch configuration is no longer needed.
+ *
+ * This file is kept for backward compatibility during migration.
+ * It can be safely removed after all existing deployments have been migrated.
+ */
 const {
   DynamoDBClient,
   UpdateItemCommand,

--- a/packages/cdk/custom-resources/unified-opensearch-index.js
+++ b/packages/cdk/custom-resources/unified-opensearch-index.js
@@ -1,0 +1,273 @@
+const { defaultProvider } = require('@aws-sdk/credential-provider-node');
+const { Client } = require('@opensearch-project/opensearch');
+const { AwsSigv4Signer } = require('@opensearch-project/opensearch/aws');
+
+const sleep = (msec) => new Promise((resolve) => setTimeout(resolve, msec));
+
+const updateStatus = async (event, status, reason, physicalResourceId) => {
+  const body = JSON.stringify({
+    Status: status,
+    Reason: reason,
+    PhysicalResourceId: physicalResourceId,
+    StackId: event.StackId,
+    RequestId: event.RequestId,
+    LogicalResourceId: event.LogicalResourceId,
+    NoEcho: false,
+    Data: {},
+  });
+
+  const res = await fetch(event.ResponseURL, {
+    method: 'PUT',
+    body,
+    headers: {
+      'Content-Type': '',
+      'Content-Length': body.length.toString(),
+    },
+  });
+
+  // For recording failures
+  console.log(res);
+  console.log(await res.text());
+};
+
+/**
+ * Custom resource handler for creating OpenSearch indexes in managed OpenSearch domains.
+ * This is used for the unified OpenSearch domain that supports both:
+ * - Bedrock Knowledge Base (vector search)
+ * - Assistant RAG documents (vector search)
+ */
+exports.handler = async (event, context) => {
+  // For debugging
+  console.log(
+    'UnifiedOpenSearchIndex - Event:',
+    JSON.stringify(event, null, 2)
+  );
+
+  const props = event.ResourceProperties;
+  const domainEndpoint = props.domainEndpoint;
+  const vectorIndexName = props.vectorIndexName;
+  const region = process.env.AWS_DEFAULT_REGION;
+
+  // Create OpenSearch client with SigV4 authentication
+  // Use 'es' service for managed OpenSearch (not 'aoss' which is for Serverless)
+  const client = new Client({
+    ...AwsSigv4Signer({
+      region,
+      service: 'es', // Managed OpenSearch uses 'es' service
+      getCredentials: () => {
+        const credentialsProvider = defaultProvider();
+        return credentialsProvider();
+      },
+    }),
+    node: domainEndpoint,
+  });
+
+  const physicalResourceId = `unified-os-index-${vectorIndexName}`;
+
+  try {
+    switch (event.RequestType) {
+      case 'Create':
+        // Parse number/boolean props
+        const vectorDimension = Number(props.vectorDimension);
+        const ragKnowledgeBaseBinaryVector =
+          String(props.ragKnowledgeBaseBinaryVector).toLowerCase() === 'true';
+
+        console.log(
+          `Creating index ${vectorIndexName} with dimension ${vectorDimension}, binary: ${ragKnowledgeBaseBinaryVector}`
+        );
+
+        // Check if index already exists
+        const indexExists = await client.indices.exists({
+          index: vectorIndexName,
+        });
+
+        if (indexExists.body) {
+          console.log(
+            `Index ${vectorIndexName} already exists, skipping creation`
+          );
+          await updateStatus(
+            event,
+            'SUCCESS',
+            'Index already exists',
+            physicalResourceId
+          );
+          return;
+        }
+
+        // Determine metadata field mapping based on index type
+        // For assistant-docs (metadataField = 'metadata'), use object type with nested fields
+        // For Bedrock KB (metadataField = 'AMAZON_BEDROCK_METADATA'), use text type
+        const isAssistantDocsIndex = props.metadataField === 'metadata';
+
+        const metadataMapping = isAssistantDocsIndex
+          ? {
+              type: 'object',
+              properties: {
+                assistantId: { type: 'keyword' },
+                tenantId: { type: 'keyword' },
+              },
+              dynamic: true, // Allow additional metadata fields
+            }
+          : {
+              type: 'text',
+              index: false,
+            };
+
+        // Create the index with knn enabled and Japanese analyzer
+        await client.indices.create({
+          index: vectorIndexName,
+          body: {
+            mappings: {
+              properties: {
+                [props.metadataField]: metadataMapping,
+                [props.textField]: {
+                  type: 'text',
+                  analyzer: 'custom_kuromoji_analyzer',
+                },
+                [props.vectorField]: {
+                  type: 'knn_vector',
+                  dimension: vectorDimension,
+                  ...(ragKnowledgeBaseBinaryVector
+                    ? { data_type: 'binary' }
+                    : {}),
+                  method: {
+                    engine: 'faiss',
+                    space_type: ragKnowledgeBaseBinaryVector ? 'hamming' : 'l2',
+                    name: 'hnsw',
+                    parameters: {},
+                  },
+                },
+              },
+            },
+            settings: {
+              index: {
+                knn: true,
+                'knn.algo_param.ef_search': 100,
+                analysis: {
+                  analyzer: {
+                    custom_kuromoji_analyzer: {
+                      type: 'custom',
+                      tokenizer: 'kuromoji_tokenizer',
+                      filter: [
+                        'kuromoji_baseform',
+                        'kuromoji_part_of_speech',
+                        'kuromoji_stemmer',
+                        'lowercase',
+                        'ja_stop',
+                      ],
+                      char_filter: [
+                        'kuromoji_iteration_mark',
+                        'icu_normalizer',
+                        'html_strip',
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          },
+        });
+
+        console.log(`Index ${vectorIndexName} created successfully`);
+
+        // Wait for index to be ready with polling instead of fixed sleep
+        const maxRetries = 10;
+        const pollIntervalMs = 3000;
+        for (let i = 0; i < maxRetries; i++) {
+          try {
+            const health = await client.cluster.health({
+              index: vectorIndexName,
+              wait_for_status: 'yellow',
+              timeout: '5s',
+            });
+            if (
+              health.body.status === 'green' ||
+              health.body.status === 'yellow'
+            ) {
+              console.log(
+                `Index ${vectorIndexName} is ready (status: ${health.body.status})`
+              );
+              break;
+            }
+          } catch (healthError) {
+            console.log(
+              `Waiting for index ${vectorIndexName} to be ready... (attempt ${i + 1}/${maxRetries})`
+            );
+          }
+          if (i < maxRetries - 1) {
+            await sleep(pollIntervalMs);
+          }
+        }
+
+        await updateStatus(
+          event,
+          'SUCCESS',
+          'Successfully created index',
+          physicalResourceId
+        );
+        break;
+
+      case 'Update':
+        console.log(
+          `Update requested for index ${vectorIndexName} - no action taken`
+        );
+        await updateStatus(
+          event,
+          'SUCCESS',
+          'Update operation is not supported for indexes',
+          physicalResourceId
+        );
+        break;
+
+      case 'Delete':
+        const indexName =
+          vectorIndexName ||
+          event.PhysicalResourceId.replace('unified-os-index-', '');
+        console.log(`Deleting index ${indexName}`);
+
+        try {
+          // Check if index exists before deleting
+          const exists = await client.indices.exists({
+            index: indexName,
+          });
+
+          if (exists.body) {
+            await client.indices.delete({
+              index: indexName,
+            });
+            console.log(`Index ${indexName} deleted successfully`);
+          } else {
+            console.log(`Index ${indexName} does not exist, skipping deletion`);
+          }
+        } catch (deleteError) {
+          // If the index doesn't exist, that's fine
+          if (deleteError.meta?.statusCode === 404) {
+            console.log(`Index ${indexName} not found, skipping deletion`);
+          } else {
+            throw deleteError;
+          }
+        }
+
+        await updateStatus(
+          event,
+          'SUCCESS',
+          'Successfully deleted',
+          physicalResourceId
+        );
+        break;
+
+      default:
+        throw new Error(`Unsupported request type: ${event.RequestType}`);
+    }
+  } catch (e) {
+    console.error('---- Error');
+    console.error(e);
+
+    await updateStatus(
+      event,
+      'FAILED',
+      e.message || 'Unknown error',
+      physicalResourceId
+    );
+  }
+};

--- a/packages/cdk/lambda/repository/assistantSearch.ts
+++ b/packages/cdk/lambda/repository/assistantSearch.ts
@@ -3,17 +3,47 @@ import { BedrockEmbeddings } from '@langchain/community/embeddings/bedrock';
 import { Document } from '@langchain/core/documents';
 import { Client } from '@opensearch-project/opensearch';
 import { AwsSigv4Signer } from '@opensearch-project/opensearch/aws';
-import { DynamoDBClient, GetItemCommand } from '@aws-sdk/client-dynamodb';
-import { unmarshall } from '@aws-sdk/util-dynamodb';
 import { APIGatewayProxyEvent } from 'aws-lambda';
 import { getTenantCredentials } from '../utils/tenantCredentials';
 
-// Tenant-aware cache: store vector store per tenant to prevent cross-tenant data leakage
-const vectorStoreCache = new Map<string, OpenSearchVectorStore>();
-let cachedEndpoint: string | null = null;
-let cachedTenantId: string | null = null;
+// Cache for vector store per tenant to avoid credential leakage between tenants
+// Key format: `${tenantId}:${endpoint}:${region}`
+const vectorStoreCache = new Map<
+  string,
+  { store: OpenSearchVectorStore; createdAt: number }
+>();
 
-const dynamoClient = new DynamoDBClient({ region: process.env.AWS_REGION! });
+// Cache TTL in milliseconds (5 minutes - shorter than typical credential expiry)
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+/**
+ * Get the unified OpenSearch endpoint from environment variable.
+ * All tenants share the same unified OpenSearch domain.
+ */
+function getUnifiedOpenSearchEndpoint(): string {
+  const endpoint = process.env.UNIFIED_OPENSEARCH_ENDPOINT;
+
+  if (!endpoint || endpoint.trim() === '') {
+    throw new Error(
+      'UNIFIED_OPENSEARCH_ENDPOINT environment variable is required and must not be empty. ' +
+        'This should be set to the endpoint of the unified OpenSearch domain.'
+    );
+  }
+
+  return endpoint.trim();
+}
+
+/**
+ * Get the OpenSearch region from environment variable.
+ * Defaults to AWS_REGION if UNIFIED_OPENSEARCH_REGION is not set.
+ */
+function getOpenSearchRegion(): string {
+  return (
+    process.env.UNIFIED_OPENSEARCH_REGION ||
+    process.env.AWS_REGION ||
+    'us-east-1'
+  );
+}
 
 /**
  * Extract tenant ID from API Gateway event
@@ -33,91 +63,45 @@ function getTenantIdFromEvent(event: APIGatewayProxyEvent): string {
 }
 
 /**
- * Query tenants table for OpenSearch endpoint
- */
-async function getOpenSearchEndpoint(tenantId: string): Promise<string> {
-  // Return cached endpoint if tenant hasn't changed
-  if (cachedEndpoint && cachedTenantId === tenantId) {
-    console.log(`Using cached OpenSearch endpoint for tenant ${tenantId}`);
-    return cachedEndpoint;
-  }
-
-  const tenantsTableName = process.env.TENANTS_TABLE_NAME;
-
-  if (!tenantsTableName) {
-    throw new Error(
-      'TENANTS_TABLE_NAME environment variable is required for multi-tenant OpenSearch access'
-    );
-  }
-
-  try {
-    console.log(
-      `Retrieving OpenSearch endpoint for tenant ${tenantId} from table ${tenantsTableName}`
-    );
-
-    const response = await dynamoClient.send(
-      new GetItemCommand({
-        TableName: tenantsTableName,
-        Key: {
-          tenantId: { S: tenantId },
-        },
-      })
-    );
-
-    if (!response.Item) {
-      throw new Error(
-        `Tenant ${tenantId} not found in tenants table. Ensure tenant is registered with OpenSearch configuration.`
-      );
-    }
-
-    const tenant = unmarshall(response.Item);
-    const endpoint = tenant.openSearchEndpoint;
-
-    if (!endpoint) {
-      throw new Error(
-        `OpenSearch endpoint not configured for tenant ${tenantId}. Please run tenant OpenSearch setup.`
-      );
-    }
-
-    // Cache for subsequent calls
-    cachedEndpoint = endpoint;
-    cachedTenantId = tenantId;
-
-    console.log(
-      `Successfully retrieved OpenSearch endpoint for tenant ${tenantId}: ${endpoint}`
-    );
-    return endpoint;
-  } catch (error) {
-    console.error(
-      `Failed to retrieve OpenSearch endpoint for tenant ${tenantId}:`,
-      error
-    );
-    throw error;
-  }
-}
-
-/**
- * Initialize the OpenSearch vector store with AWS credentials
+ * Initialize the OpenSearch vector store with AWS credentials.
+ * Uses the unified OpenSearch endpoint for all tenants.
+ * Cache is tenant-aware to prevent credential leakage between tenants.
+ *
  * @param event API Gateway event to extract tenant context
  */
 async function initVectorStore(
   event: APIGatewayProxyEvent
 ): Promise<OpenSearchVectorStore> {
-  const tenantId = getTenantIdFromEvent(event);
   const indexName = process.env.OPENSEARCH_INDEX || 'assistant-docs';
-  const region = process.env.AWS_REGION || 'us-east-1';
+  const region = getOpenSearchRegion();
+  const tenantId = getTenantIdFromEvent(event);
 
-  // Get OpenSearch endpoint from tenants table
-  const endpoint = await getOpenSearchEndpoint(tenantId);
+  // Get unified OpenSearch endpoint from environment
+  const endpoint = getUnifiedOpenSearchEndpoint();
 
-  // Check if we have a cached vector store for this tenant
-  const cachedStore = vectorStoreCache.get(tenantId);
-  if (cachedStore) {
-    console.log(`Using cached vector store for tenant ${tenantId}`);
-    return cachedStore;
+  // Create cache key based on tenant, endpoint, and region
+  const cacheKey = `${tenantId}:${endpoint}:${region}`;
+
+  // Check if we have a valid cached vector store for this tenant
+  const cached = vectorStoreCache.get(cacheKey);
+  if (cached && Date.now() - cached.createdAt < CACHE_TTL_MS) {
+    console.log(
+      `Using cached vector store for tenant ${tenantId} (unified OpenSearch)`
+    );
+    return cached.store;
   }
 
-  console.log(`Creating new vector store for tenant ${tenantId}`);
+  // Remove expired cache entry if exists
+  if (cached) {
+    vectorStoreCache.delete(cacheKey);
+    console.log(
+      `Cache expired for tenant ${tenantId}, recreating vector store`
+    );
+  }
+
+  console.log(
+    `Creating new vector store for tenant ${tenantId} (unified OpenSearch: ${endpoint})`
+  );
 
   // Ensure endpoint has https:// protocol
   const nodeUrl = endpoint.startsWith('http')
@@ -125,17 +109,18 @@ async function initVectorStore(
     : `https://${endpoint}`;
 
   // Get tenant credentials for OpenSearch access
-  const { credentials, tenant } = await getTenantCredentials(event);
+  const { credentials } = await getTenantCredentials(event);
 
   if (!credentials.AccessKeyId || !credentials.SecretAccessKey) {
     throw new Error('Invalid tenant credentials for OpenSearch access');
   }
 
   // Create OpenSearch client with AWS Sigv4 authentication using tenant credentials
+  // Note: Use 'es' service for managed OpenSearch (not 'aoss' for Serverless)
   const client = new Client({
     ...AwsSigv4Signer({
       region,
-      service: 'es', // Use 'es' for managed OpenSearch, 'aoss' for OpenSearch Serverless
+      service: 'es', // Managed OpenSearch uses 'es' service
       getCredentials: () =>
         Promise.resolve({
           accessKeyId: credentials.AccessKeyId!,
@@ -163,14 +148,20 @@ async function initVectorStore(
     indexName,
   });
 
-  // Cache the vector store for this tenant
-  vectorStoreCache.set(tenantId, newVectorStore);
+  // Cache the vector store with timestamp for TTL management
+  vectorStoreCache.set(cacheKey, {
+    store: newVectorStore,
+    createdAt: Date.now(),
+  });
 
   return newVectorStore;
 }
 
 /**
- * Index documents for an assistant
+ * Index documents for an assistant.
+ * Documents are stored in the unified OpenSearch domain with assistantId metadata
+ * for tenant/assistant-level data isolation.
+ *
  * @param assistantId The assistant ID
  * @param documents The documents to index
  * @param event API Gateway event for tenant context
@@ -182,21 +173,23 @@ export async function indexDocuments(
 ): Promise<void> {
   try {
     const store = await initVectorStore(event);
+    const tenantId = getTenantIdFromEvent(event);
 
-    // Add assistantId to all document metadata
-    const docsWithAssistantId = documents.map((doc) => ({
+    // Add assistantId and tenantId to all document metadata for data isolation
+    const docsWithMetadata = documents.map((doc) => ({
       ...doc,
       metadata: {
         ...doc.metadata,
         assistantId,
+        tenantId, // Add tenantId for additional isolation if needed
       },
     }));
 
     // Add documents to vector store
-    await store.addDocuments(docsWithAssistantId);
+    await store.addDocuments(docsWithMetadata);
 
     console.log(
-      `Successfully indexed ${documents.length} documents for assistant ${assistantId}`
+      `Successfully indexed ${documents.length} documents for assistant ${assistantId} (tenant: ${tenantId})`
     );
   } catch (error) {
     console.error('Error indexing documents:', error);
@@ -205,7 +198,9 @@ export async function indexDocuments(
 }
 
 /**
- * Perform similarity search for relevant documents
+ * Perform similarity search for relevant documents.
+ * Filters by both assistantId and tenantId to ensure proper data isolation.
+ *
  * @param assistantId The assistant ID to filter by
  * @param query The search query
  * @param event API Gateway event for tenant context
@@ -220,14 +215,17 @@ export async function similaritySearch(
 ): Promise<Document[]> {
   try {
     const store = await initVectorStore(event);
+    const tenantId = getTenantIdFromEvent(event);
 
     // Perform similarity search with metadata filter
+    // Filter by both assistantId and tenantId for proper multi-tenant data isolation
     const results = await store.similaritySearch(query, k, {
       assistantId,
+      tenantId, // Critical: Filter by tenantId to prevent cross-tenant data leakage
     });
 
     console.log(
-      `Found ${results.length} relevant documents for query: ${query.substring(0, 50)}...`
+      `Found ${results.length} relevant documents for assistant ${assistantId} (tenant: ${tenantId})`
     );
 
     return results;
@@ -238,7 +236,9 @@ export async function similaritySearch(
 }
 
 /**
- * Delete all documents for an assistant
+ * Delete all documents for an assistant.
+ * Filters by both assistantId and tenantId to ensure proper data isolation.
+ *
  * @param assistantId The assistant ID
  * @param event API Gateway event for tenant context
  */
@@ -249,23 +249,30 @@ export async function deleteAssistantDocuments(
   try {
     const store = await initVectorStore(event);
     const indexName = process.env.OPENSEARCH_INDEX || 'assistant-docs';
+    const tenantId = getTenantIdFromEvent(event);
 
     // Get the OpenSearch client
     const client = (store as any).client as Client;
 
-    // Delete by query - remove all documents with matching assistantId
+    // Delete by query - remove all documents with matching assistantId AND tenantId
+    // Critical: Filter by both to prevent cross-tenant data deletion
     await client.deleteByQuery({
       index: indexName,
       body: {
         query: {
-          term: {
-            'metadata.assistantId': assistantId,
+          bool: {
+            must: [
+              { term: { 'metadata.assistantId': assistantId } },
+              { term: { 'metadata.tenantId': tenantId } },
+            ],
           },
         },
       },
     });
 
-    console.log(`Deleted all documents for assistant ${assistantId}`);
+    console.log(
+      `Deleted all documents for assistant ${assistantId} (tenant: ${tenantId})`
+    );
   } catch (error) {
     console.error('Error deleting assistant documents:', error);
     throw error;

--- a/packages/cdk/lambda/tenantRegistrationHandler.ts
+++ b/packages/cdk/lambda/tenantRegistrationHandler.ts
@@ -20,6 +20,8 @@ const TENANTS_TABLE_NAME = process.env.TENANTS_TABLE_NAME!;
 const dynamoClient = new DynamoDBClient({ region: process.env.AWS_REGION! });
 
 // Request interface
+// Note: OpenSearch fields are optional and deprecated - OpenSearch is now unified
+// via UnifiedOpenSearchStack. Legacy tenants may still provide these fields.
 interface TenantRegistrationRequest {
   tenantId: string;
   accountId: string;
@@ -27,6 +29,7 @@ interface TenantRegistrationRequest {
   environment: string;
   roleArn?: string;
   controlPlaneLambdaRoleArn?: string;
+  // Deprecated: OpenSearch is now unified. These fields are kept for backwards compatibility.
   openSearchDomainArn?: string;
   openSearchEndpoint?: string;
   openSearchIndexName?: string;
@@ -83,7 +86,9 @@ export const handler = async (
       });
     }
 
-    // Validate OpenSearch configuration - all three fields must be provided together
+    // Validate OpenSearch configuration if provided (deprecated - for backwards compatibility)
+    // Note: OpenSearch is now unified via UnifiedOpenSearchStack.
+    // Legacy tenants may still provide these fields, so we validate them if present.
     const hasOpenSearchConfig = !!(
       openSearchDomainArn?.trim() ||
       openSearchEndpoint?.trim() ||
@@ -91,7 +96,11 @@ export const handler = async (
     );
 
     if (hasOpenSearchConfig) {
-      // All three must be provided and non-empty
+      console.log(
+        '[WARN] OpenSearch configuration provided but deprecated. OpenSearch is now unified.'
+      );
+
+      // If any OpenSearch field is provided, all must be provided (backwards compatibility)
       if (
         !openSearchDomainArn?.trim() ||
         !openSearchEndpoint?.trim() ||
@@ -99,7 +108,7 @@ export const handler = async (
       ) {
         return badRequest400Response({
           message:
-            'All OpenSearch fields (domainArn, endpoint, indexName) must be provided together',
+            'If providing OpenSearch configuration (deprecated), all fields (domainArn, endpoint, indexName) must be provided together',
         });
       }
 
@@ -150,7 +159,8 @@ export const handler = async (
       },
     };
 
-    // Add OpenSearch configuration if provided
+    // Add OpenSearch configuration if provided (deprecated - for backwards compatibility)
+    // Note: New tenants should NOT provide OpenSearch configuration as it's now unified
     if (hasOpenSearchConfig) {
       tenant.openSearchDomainArn = openSearchDomainArn;
       tenant.openSearchEndpoint = openSearchEndpoint;

--- a/packages/cdk/lib/construct/api/assistant.ts
+++ b/packages/cdk/lib/construct/api/assistant.ts
@@ -48,6 +48,8 @@ class AssistantApi extends Construct {
         OPENSEARCH_INDEX: 'assistant-docs',
         ASSISTANT_FILES_BUCKET_NAME: fileBucket?.bucketName || '',
         TENANTS_TABLE_NAME: tenantManager?.tenantsTable.tableName || '',
+        UNIFIED_OPENSEARCH_ENDPOINT: props.unifiedOpenSearchEndpoint || '',
+        UNIFIED_OPENSEARCH_REGION: props.unifiedOpenSearchRegion || '',
         ASSISTANT_CREATION_REQUIRES_ADMIN: (
           props.assistantCreationRequiresAdmin ?? true
         ).toString(),
@@ -105,6 +107,8 @@ class AssistantApi extends Construct {
           ),
           OPENSEARCH_INDEX: 'assistant-docs',
           TENANTS_TABLE_NAME: tenantManager?.tenantsTable.tableName || '',
+          UNIFIED_OPENSEARCH_ENDPOINT: props.unifiedOpenSearchEndpoint || '',
+          UNIFIED_OPENSEARCH_REGION: props.unifiedOpenSearchRegion || '',
           LITELLM_ENDPOINT: props.litellmEndpoint ?? '',
           ...(props.openai?.apiKey
             ? { OPENAI_API_KEY: props.openai.apiKey }
@@ -155,6 +159,8 @@ class AssistantApi extends Construct {
           USER_POOL_ID: userPool.userPoolId,
           USER_POOL_CLIENT_ID: userPoolClient.userPoolClientId,
           TENANTS_TABLE_NAME: tenantManager?.tenantsTable.tableName || '',
+          UNIFIED_OPENSEARCH_ENDPOINT: props.unifiedOpenSearchEndpoint || '',
+          UNIFIED_OPENSEARCH_REGION: props.unifiedOpenSearchRegion || '',
           LITELLM_ENDPOINT: props.litellmEndpoint ?? '',
         }),
       }
@@ -276,6 +282,8 @@ class AssistantApi extends Construct {
             ASSISTANT_FILES_BUCKET_NAME: fileBucket.bucketName,
             OPENSEARCH_INDEX: 'assistant-docs',
             TENANTS_TABLE_NAME: tenantManager?.tenantsTable.tableName || '',
+            UNIFIED_OPENSEARCH_ENDPOINT: props.unifiedOpenSearchEndpoint || '',
+            UNIFIED_OPENSEARCH_REGION: props.unifiedOpenSearchRegion || '',
           }),
         }
       );

--- a/packages/cdk/lib/construct/api/props.ts
+++ b/packages/cdk/lib/construct/api/props.ts
@@ -53,6 +53,10 @@ export type GenericApiProps = {
   readonly tenantManager?: TenantManager;
   readonly tenantsTable?: Table;
 
+  // Unified OpenSearch (for assistant RAG)
+  readonly unifiedOpenSearchEndpoint?: string;
+  readonly unifiedOpenSearchRegion?: string;
+
   // LangChain Credentials
   readonly openai?: {
     readonly apiKey: string; // OPENAI_API_KEY

--- a/packages/cdk/lib/create-stacks.ts
+++ b/packages/cdk/lib/create-stacks.ts
@@ -4,6 +4,7 @@ import { GenerativeAiUseCasesStack } from './stacks/common/generative-ai-use-cas
 import { CloudFrontWafStack } from './stacks/common/cloud-front-waf-stack';
 import { DashboardStack } from './stacks/common/dashboard-stack';
 import { AgentStack } from './stacks/common/agent-stack';
+import { UnifiedOpenSearchStack } from './stacks/common/unified-opensearch-stack';
 import { RagKnowledgeBaseStack } from './stacks/common/rag-knowledge-base-stack';
 import { GuardrailStack } from './stacks/common/guardrail-stack';
 import { ProcessedStackInput } from './stack-input';
@@ -41,9 +42,28 @@ export const createStacks = (app: cdk.App, params: ProcessedStackInput) => {
         })
       : null;
 
-  // RAG Knowledge Base
-  const ragKnowledgeBaseStack =
+  // Unified OpenSearch Stack
+  // Creates a single managed OpenSearch domain for both:
+  // - Bedrock Knowledge Base (vector search)
+  // - Tenant assistant RAG documents
+  // This replaces both OpenSearch Serverless and per-tenant OpenSearch domains
+  const unifiedOpenSearchStack =
     params.ragKnowledgeBaseEnabled && !params.ragKnowledgeBaseId
+      ? new UnifiedOpenSearchStack(app, `UnifiedOpenSearchStack${params.env}`, {
+          env: {
+            account: params.account,
+            region: params.modelRegion,
+          },
+          params: params,
+          crossRegionReferences: true,
+        })
+      : null;
+
+  // RAG Knowledge Base (now uses Unified OpenSearch instead of Serverless)
+  const ragKnowledgeBaseStack =
+    params.ragKnowledgeBaseEnabled &&
+    !params.ragKnowledgeBaseId &&
+    unifiedOpenSearchStack
       ? new RagKnowledgeBaseStack(app, `RagKnowledgeBaseStack${params.env}`, {
           env: {
             account: params.account,
@@ -51,6 +71,14 @@ export const createStacks = (app: cdk.App, params: ProcessedStackInput) => {
           },
           params: params,
           crossRegionReferences: true,
+          // Pass unified OpenSearch configuration
+          unifiedOpenSearchDomainArn: unifiedOpenSearchStack.domainArn,
+          unifiedOpenSearchDomainEndpoint: `https://${unifiedOpenSearchStack.domainEndpoint}`,
+          knowledgeBaseRole: unifiedOpenSearchStack.knowledgeBaseRole,
+          vectorIndexName: unifiedOpenSearchStack.bedrockKnowledgeBaseIndexName,
+          vectorField: unifiedOpenSearchStack.vectorField,
+          metadataField: unifiedOpenSearchStack.metadataField,
+          textField: unifiedOpenSearchStack.textField,
         })
       : null;
 
@@ -126,6 +154,13 @@ export const createStacks = (app: cdk.App, params: ProcessedStackInput) => {
       knowledgeBaseId: ragKnowledgeBaseStack?.knowledgeBaseId,
       knowledgeBaseDataSourceBucketName:
         ragKnowledgeBaseStack?.dataSourceBucketName,
+      // Unified OpenSearch (for assistant RAG)
+      unifiedOpenSearchEndpoint: unifiedOpenSearchStack
+        ? `https://${unifiedOpenSearchStack.domainEndpoint}`
+        : undefined,
+      unifiedOpenSearchRegion: unifiedOpenSearchStack
+        ? params.modelRegion
+        : undefined,
       // Agent
       agents: agentStack?.agents,
       // Video Generation
@@ -166,6 +201,7 @@ export const createStacks = (app: cdk.App, params: ProcessedStackInput) => {
 
   return {
     cloudFrontWafStack,
+    unifiedOpenSearchStack,
     ragKnowledgeBaseStack,
     agentStack,
     guardrail,

--- a/packages/cdk/lib/create-tenant-stacks.ts
+++ b/packages/cdk/lib/create-tenant-stacks.ts
@@ -4,9 +4,6 @@ import { TenantS3Stack } from './stacks/tenant/tenant-s3-stack';
 import { TenantIAMStack } from './stacks/tenant/tenant-iam-stack';
 import { TenantPptxStack } from './stacks/tenant/tenant-pptx-stack';
 import { TenantVpcStack } from './stacks/tenant/tenant-vpc-stack';
-import { TenantOpenSearchStack } from './stacks/tenant/tenant-opensearch-stack';
-import * as opensearch from 'aws-cdk-lib/aws-opensearchservice';
-import * as ec2 from 'aws-cdk-lib/aws-ec2';
 
 export interface NetworkConfig {
   vpcCidr: string;
@@ -14,13 +11,6 @@ export interface NetworkConfig {
   natGateways: number;
 }
 
-export interface OpenSearchConfig {
-  capacity: opensearch.CapacityConfig;
-  ebsVolumeSize: number;
-  ebsVolumeType: ec2.EbsDeviceVolumeType;
-  availabilityZoneCount: number;
-  automatedSnapshotStartHour: number;
-}
 export interface IpAccessControlConfig {
   enabled: boolean;
   allowedIpV4AddressRanges: string[];
@@ -38,13 +28,13 @@ export interface TenantStackInput {
   userPoolId?: string;
   identityPoolId?: string;
   userPoolClientId?: string;
-  openSearchConfig: OpenSearchConfig;
+  // OpenSearch is now unified - no per-tenant OpenSearch configuration needed
+  // The unified OpenSearch endpoint is provided via environment variables
   networkConfig: NetworkConfig;
   ipAccessControl?: IpAccessControlConfig;
   controlPlaneRegion?: string;
   controlPlaneAccount?: string;
   tenantsTableName?: string;
-  openSearchIndexName?: string;
 }
 
 export const createTenantStacks = (app: cdk.App, params: TenantStackInput) => {
@@ -93,7 +83,8 @@ export const createTenantStacks = (app: cdk.App, params: TenantStackInput) => {
     }
   );
 
-  // Tenant VPC Stack (for networking infrastructure)
+  // Tenant VPC Stack (for networking infrastructure - used by OpenFGA, RDS, etc.)
+  // Note: OpenSearch is now unified and doesn't require per-tenant VPC
   const tenantVpcStack = new TenantVpcStack(
     app,
     `TenantVpcStack${params.environment}-${params.tenantId}`,
@@ -110,38 +101,12 @@ export const createTenantStacks = (app: cdk.App, params: TenantStackInput) => {
     }
   );
 
-  // Tenant Managed OpenSearch Stack
-  const tenantOpenSearchStack = new TenantOpenSearchStack(
-    app,
-    `TenantOpenSearchStack${params.environment}-${params.tenantId}`,
-    {
-      env: {
-        account: params.account,
-        region: params.region,
-      },
-      tenantId: params.tenantId,
-      environment: params.environment,
-      vpc: tenantVpcStack.vpc,
-      subnets: tenantVpcStack.privateSubnets,
-      capacity: params.openSearchConfig.capacity,
-      ebsVolumeSize: params.openSearchConfig.ebsVolumeSize,
-      ebsVolumeType: params.openSearchConfig.ebsVolumeType,
-      availabilityZoneCount: params.openSearchConfig.availabilityZoneCount,
-      automatedSnapshotStartHour:
-        params.openSearchConfig.automatedSnapshotStartHour,
-      removalPolicy: params.removalPolicy
-        ? cdk.RemovalPolicy.DESTROY
-        : cdk.RemovalPolicy.RETAIN,
-      tenantRoleArn: tenantIAMStack.tenantRole.role.roleArn,
-      tenantsTableName: params.tenantsTableName,
-      controlPlaneRegion: params.controlPlaneRegion,
-      openSearchIndexName: params.openSearchIndexName,
-    }
-  );
-
-  // Add dependencies to ensure IAM and VPC are created before OpenSearch
-  tenantOpenSearchStack.addDependency(tenantVpcStack);
-  tenantOpenSearchStack.addDependency(tenantIAMStack);
+  // Note: TenantOpenSearchStack has been removed.
+  // OpenSearch is now unified in UnifiedOpenSearchStack for both:
+  // - Bedrock Knowledge Base (vector search)
+  // - Tenant assistant RAG documents
+  // All tenants share the unified OpenSearch domain with data isolation
+  // via metadata.assistantId filtering.
 
   // Tenant PPTX Stack (optional)
   let tenantPptxStack;
@@ -166,7 +131,6 @@ export const createTenantStacks = (app: cdk.App, params: TenantStackInput) => {
     tenantDynamoDBStack,
     tenantS3Stack,
     tenantVpcStack,
-    tenantOpenSearchStack,
     tenantPptxStack,
   };
 };

--- a/packages/cdk/lib/stacks/common/assistant-api-stack.ts
+++ b/packages/cdk/lib/stacks/common/assistant-api-stack.ts
@@ -26,6 +26,9 @@ interface AssistantApiStackProps extends StackProps {
   guardrailVersion?: string;
   litellmEndpoint?: string | null;
   litellmProxy?: LitellmProxyServer | null;
+  // Unified OpenSearch endpoint for assistant RAG
+  unifiedOpenSearchEndpoint?: string;
+  unifiedOpenSearchRegion?: string;
 }
 
 class AssistantApiStack extends NestedStack {
@@ -47,6 +50,8 @@ class AssistantApiStack extends NestedStack {
       guardrailVersion,
       litellmEndpoint,
       litellmProxy,
+      unifiedOpenSearchEndpoint,
+      unifiedOpenSearchRegion,
     } = props;
 
     // Create authorizer for the nested stack
@@ -98,6 +103,10 @@ class AssistantApiStack extends NestedStack {
       guardrailIdentify: guardrailIdentifier,
       guardrailVersion: guardrailVersion,
       tenantManager,
+
+      // Unified OpenSearch for assistant RAG
+      unifiedOpenSearchEndpoint,
+      unifiedOpenSearchRegion,
 
       // API Gateway
       api: api.restApi,

--- a/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
@@ -34,6 +34,9 @@ export interface GenerativeAiUseCasesStackProps extends StackProps {
   // RAG Knowledge Base
   readonly knowledgeBaseId?: string;
   readonly knowledgeBaseDataSourceBucketName?: string;
+  // Unified OpenSearch (for assistant RAG)
+  readonly unifiedOpenSearchEndpoint?: string;
+  readonly unifiedOpenSearchRegion?: string;
   // Agent
   readonly agents?: Agent[];
   // Video Generation
@@ -191,6 +194,8 @@ export class GenerativeAiUseCasesStack extends Stack {
       guardrailVersion: props.guardrailVersion,
       litellmEndpoint: litellmEndpoint,
       litellmProxy: litellmProxy,
+      unifiedOpenSearchEndpoint: props.unifiedOpenSearchEndpoint,
+      unifiedOpenSearchRegion: props.unifiedOpenSearchRegion,
     });
 
     // MCP

--- a/packages/cdk/lib/stacks/common/rag-knowledge-base-stack.ts
+++ b/packages/cdk/lib/stacks/common/rag-knowledge-base-stack.ts
@@ -1,20 +1,13 @@
 import { Stack, StackProps, RemovalPolicy } from 'aws-cdk-lib';
 import { Construct } from 'constructs';
 import * as cdk from 'aws-cdk-lib';
-import * as lambda from 'aws-cdk-lib/aws-lambda';
 import * as bedrock from 'aws-cdk-lib/aws-bedrock';
-import * as oss from 'aws-cdk-lib/aws-opensearchserverless';
 import * as s3 from 'aws-cdk-lib/aws-s3';
 import * as s3Deploy from 'aws-cdk-lib/aws-s3-deployment';
 import * as iam from 'aws-cdk-lib/aws-iam';
 import { ProcessedStackInput } from '../../stack-input';
-import { LAMBDA_RUNTIME_NODEJS } from '../../../consts';
-
-const UUID = '339C5FED-A1B5-43B6-B40A-5E8E59E5734D';
 
 // Embedding models supported by Bedrock
-// Dimension is passed as a prop of the Custom resource, but there is an issue that the type is automatically converted, so it is set to string instead of number.
-// https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1037
 const MODEL_VECTOR_MAPPING: { [key: string]: string } = {
   'amazon.titan-embed-text-v1': '1536',
   'amazon.titan-embed-text-v2:0': '1024',
@@ -69,61 +62,30 @@ EPS: $1.25
 | | 12/31 ended year | |
 
 2021	2022
-Cash Flow:		
+Cash Flow:
 Operating Activity	$ 46,327	$ 46,752
 Investing Activity	(58,154)	(37,601)
 Financial Activity	6,291	9,718`;
 
 const EMBEDDING_MODELS = Object.keys(MODEL_VECTOR_MAPPING);
 
-interface OpenSearchServerlessIndexProps {
-  readonly collectionId: string;
-  readonly vectorIndexName: string;
-  readonly vectorField: string;
-  readonly metadataField: string;
-  readonly textField: string;
-  readonly vectorDimension: string;
-  readonly ragKnowledgeBaseBinaryVector: boolean;
-}
-
-class OpenSearchServerlessIndex extends Construct {
-  public readonly customResourceHandler: lambda.IFunction;
-  public readonly customResource: cdk.CustomResource;
-
-  constructor(
-    scope: Construct,
-    id: string,
-    props: OpenSearchServerlessIndexProps
-  ) {
-    super(scope, id);
-
-    const customResourceHandler = new lambda.SingletonFunction(
-      this,
-      'OpenSearchServerlessIndex',
-      {
-        runtime: LAMBDA_RUNTIME_NODEJS,
-        code: lambda.Code.fromAsset('custom-resources'),
-        handler: 'oss-index.handler',
-        uuid: UUID,
-        lambdaPurpose: 'OpenSearchServerlessIndex',
-        timeout: cdk.Duration.minutes(15),
-      }
-    );
-
-    const customResource = new cdk.CustomResource(this, 'CustomResource', {
-      serviceToken: customResourceHandler.functionArn,
-      resourceType: 'Custom::OssIndex',
-      properties: props,
-    });
-
-    this.customResourceHandler = customResourceHandler;
-    this.customResource = customResource;
-  }
-}
-
 export interface RagKnowledgeBaseStackProps extends StackProps {
   params: ProcessedStackInput;
-  collectionName?: string;
+  /**
+   * Unified OpenSearch domain ARN (from UnifiedOpenSearchStack)
+   */
+  unifiedOpenSearchDomainArn: string;
+  /**
+   * Unified OpenSearch domain endpoint (from UnifiedOpenSearchStack)
+   */
+  unifiedOpenSearchDomainEndpoint: string;
+  /**
+   * IAM role for Knowledge Base (from UnifiedOpenSearchStack)
+   */
+  knowledgeBaseRole: iam.IRole;
+  /**
+   * Vector index name for Bedrock Knowledge Base
+   */
   vectorIndexName?: string;
   vectorField?: string;
   metadataField?: string;
@@ -138,12 +100,9 @@ export class RagKnowledgeBaseStack extends Stack {
     super(scope, id, props);
 
     const {
-      env,
       embeddingModelId,
-      ragKnowledgeBaseStandbyReplicas,
       ragKnowledgeBaseAdvancedParsing,
       ragKnowledgeBaseAdvancedParsingModelId,
-      ragKnowledgeBaseBinaryVector,
       crossAccountBedrockRoleArn,
     } = props.params;
 
@@ -165,19 +124,6 @@ export class RagKnowledgeBaseStack extends Stack {
       );
     }
 
-    const collectionName =
-      props.collectionName ?? `generative-ai-use-cases-jp${env.toLowerCase()}`;
-    const vectorIndexName =
-      props.vectorIndexName ?? 'bedrock-knowledge-base-default';
-    const vectorField =
-      props.vectorField ?? 'bedrock-knowledge-base-default-vector';
-    const textField = props.textField ?? 'AMAZON_BEDROCK_TEXT_CHUNK';
-    const metadataField = props.metadataField ?? 'AMAZON_BEDROCK_METADATA';
-
-    const knowledgeBaseRole = new iam.Role(this, 'KnowledgeBaseRole', {
-      assumedBy: new iam.ServicePrincipal('bedrock.amazonaws.com'),
-    });
-
     if (
       ragKnowledgeBaseAdvancedParsing &&
       typeof ragKnowledgeBaseAdvancedParsingModelId !== 'string'
@@ -187,110 +133,18 @@ export class RagKnowledgeBaseStack extends Stack {
       );
     }
 
-    const collection = new oss.CfnCollection(this, 'Collection', {
-      name: collectionName,
-      description: 'GenU Collection',
-      type: 'VECTORSEARCH',
-      standbyReplicas: ragKnowledgeBaseStandbyReplicas ? 'ENABLED' : 'DISABLED',
-    });
+    // Default field names (must match UnifiedOpenSearchStack configuration)
+    const vectorIndexName =
+      props.vectorIndexName ?? 'bedrock-knowledge-base-default';
+    const vectorField =
+      props.vectorField ?? 'bedrock-knowledge-base-default-vector';
+    const textField = props.textField ?? 'AMAZON_BEDROCK_TEXT_CHUNK';
+    const metadataField = props.metadataField ?? 'AMAZON_BEDROCK_METADATA';
 
-    const ossIndex = new OpenSearchServerlessIndex(this, 'OssIndex', {
-      collectionId: collection.ref,
-      vectorIndexName,
-      vectorField,
-      textField,
-      metadataField,
-      vectorDimension: MODEL_VECTOR_MAPPING[embeddingModelId],
-      ragKnowledgeBaseBinaryVector,
-    });
+    // Use the Knowledge Base role from UnifiedOpenSearchStack
+    const knowledgeBaseRole = props.knowledgeBaseRole;
 
-    ossIndex.customResourceHandler.addToRolePolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        resources: [cdk.Token.asString(collection.getAtt('Arn'))],
-        actions: ['aoss:APIAccessAll'],
-      })
-    );
-
-    const accessPolicy = new oss.CfnAccessPolicy(this, 'AccessPolicy', {
-      name: collectionName,
-      policy: JSON.stringify([
-        {
-          Rules: [
-            {
-              Resource: [`collection/${collectionName}`],
-              Permission: [
-                'aoss:DescribeCollectionItems',
-                'aoss:CreateCollectionItems',
-                'aoss:UpdateCollectionItems',
-              ],
-              ResourceType: 'collection',
-            },
-            {
-              Resource: [`index/${collectionName}/*`],
-              Permission: [
-                'aoss:UpdateIndex',
-                'aoss:DescribeIndex',
-                'aoss:ReadDocument',
-                'aoss:WriteDocument',
-                'aoss:CreateIndex',
-                'aoss:DeleteIndex',
-              ],
-              ResourceType: 'index',
-            },
-          ],
-          Principal: [
-            knowledgeBaseRole.roleArn,
-            ossIndex.customResourceHandler.role?.roleArn,
-          ],
-          Description: '',
-        },
-      ]),
-      type: 'data',
-    });
-
-    const networkPolicy = new oss.CfnSecurityPolicy(this, 'NetworkPolicy', {
-      name: collectionName,
-      policy: JSON.stringify([
-        {
-          Rules: [
-            {
-              Resource: [`collection/${collectionName}`],
-              ResourceType: 'collection',
-            },
-            {
-              Resource: [`collection/${collectionName}`],
-              ResourceType: 'dashboard',
-            },
-          ],
-          AllowFromPublic: true,
-        },
-      ]),
-      type: 'network',
-    });
-
-    const encryptionPolicy = new oss.CfnSecurityPolicy(
-      this,
-      'EncryptionPolicy',
-      {
-        name: collectionName,
-        policy: JSON.stringify({
-          Rules: [
-            {
-              Resource: [`collection/${collectionName}`],
-              ResourceType: 'collection',
-            },
-          ],
-          AWSOwnedKey: true,
-        }),
-        type: 'encryption',
-      }
-    );
-
-    collection.node.addDependency(accessPolicy);
-    collection.node.addDependency(networkPolicy);
-    collection.node.addDependency(encryptionPolicy);
-
+    // Create S3 bucket for data source
     const accessLogsBucket = new s3.Bucket(this, 'DataSourceAccessLogsBucket', {
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
       encryption: s3.BucketEncryption.S3_MANAGED,
@@ -311,23 +165,8 @@ export class RagKnowledgeBaseStack extends Stack {
       enforceSSL: true,
     });
 
-    knowledgeBaseRole.addToPolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        resources: ['*'],
-        actions: ['bedrock:InvokeModel'],
-      })
-    );
-
-    knowledgeBaseRole.addToPolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        resources: [cdk.Token.asString(collection.getAtt('Arn'))],
-        actions: ['aoss:APIAccessAll'],
-      })
-    );
-
-    knowledgeBaseRole.addToPolicy(
+    // Grant S3 access to Knowledge Base role
+    knowledgeBaseRole.addToPrincipalPolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
         resources: [`arn:aws:s3:::${dataSourceBucket.bucketName}`],
@@ -335,7 +174,7 @@ export class RagKnowledgeBaseStack extends Stack {
       })
     );
 
-    knowledgeBaseRole.addToPolicy(
+    knowledgeBaseRole.addToPrincipalPolicy(
       new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
         resources: [`arn:aws:s3:::${dataSourceBucket.bucketName}/*`],
@@ -343,34 +182,28 @@ export class RagKnowledgeBaseStack extends Stack {
       })
     );
 
+    // Create Knowledge Base with Managed OpenSearch configuration
+    // Note: Using OPENSEARCH_MANAGED_CLUSTER instead of OPENSEARCH_SERVERLESS
     const knowledgeBase = new bedrock.CfnKnowledgeBase(this, 'KnowledgeBase', {
-      name: collectionName,
+      name: `genu-knowledge-base-${props.params.env.toLowerCase()}`,
       roleArn: knowledgeBaseRole.roleArn,
       knowledgeBaseConfiguration: {
         type: 'VECTOR',
         vectorKnowledgeBaseConfiguration: {
           embeddingModelArn: `arn:aws:bedrock:${this.region}::foundation-model/${embeddingModelId}`,
-          ...(ragKnowledgeBaseBinaryVector
-            ? {
-                embeddingModelConfiguration: {
-                  bedrockEmbeddingModelConfiguration: {
-                    embeddingDataType: 'BINARY',
-                  },
-                },
-              }
-            : {}),
         },
       },
       storageConfiguration: {
-        type: 'OPENSEARCH_SERVERLESS',
-        opensearchServerlessConfiguration: {
-          collectionArn: cdk.Token.asString(collection.getAtt('Arn')),
+        type: 'OPENSEARCH_MANAGED_CLUSTER',
+        opensearchManagedClusterConfiguration: {
+          domainArn: props.unifiedOpenSearchDomainArn,
+          domainEndpoint: props.unifiedOpenSearchDomainEndpoint,
+          vectorIndexName,
           fieldMapping: {
             metadataField,
             textField,
             vectorField,
           },
-          vectorIndexName,
         },
       },
     });
@@ -446,9 +279,6 @@ export class RagKnowledgeBaseStack extends Stack {
       knowledgeBaseId: knowledgeBase.ref,
       name: 's3-data-source',
     });
-
-    knowledgeBase.addDependency(collection);
-    knowledgeBase.node.addDependency(ossIndex.customResource);
 
     new s3Deploy.BucketDeployment(this, 'DeployDocs', {
       sources: [s3Deploy.Source.asset('./rag-docs')],

--- a/packages/cdk/lib/stacks/common/unified-opensearch-stack.ts
+++ b/packages/cdk/lib/stacks/common/unified-opensearch-stack.ts
@@ -1,0 +1,469 @@
+import * as cdk from 'aws-cdk-lib';
+import * as opensearch from 'aws-cdk-lib/aws-opensearchservice';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { Construct } from 'constructs';
+import { ProcessedStackInput } from '../../stack-input';
+import { LAMBDA_RUNTIME_NODEJS } from '../../../consts';
+
+// Embedding models supported by Bedrock
+const MODEL_VECTOR_MAPPING: { [key: string]: string } = {
+  'amazon.titan-embed-text-v1': '1536',
+  'amazon.titan-embed-text-v2:0': '1024',
+  'cohere.embed-multilingual-v3': '1024',
+  'cohere.embed-english-v3': '1024',
+};
+
+const UUID = 'A1B2C3D4-E5F6-7890-ABCD-EF1234567890';
+
+interface UnifiedOpenSearchIndexProps {
+  readonly domainEndpoint: string;
+  readonly domainArn: string;
+  readonly vectorIndexName: string;
+  readonly vectorField: string;
+  readonly metadataField: string;
+  readonly textField: string;
+  readonly vectorDimension: string;
+  readonly ragKnowledgeBaseBinaryVector: boolean;
+}
+
+class UnifiedOpenSearchIndex extends Construct {
+  public readonly customResourceHandler: lambda.IFunction;
+  public readonly customResource: cdk.CustomResource;
+
+  constructor(
+    scope: Construct,
+    id: string,
+    props: UnifiedOpenSearchIndexProps
+  ) {
+    super(scope, id);
+
+    const customResourceHandler = new lambda.SingletonFunction(
+      this,
+      'UnifiedOpenSearchIndex',
+      {
+        runtime: LAMBDA_RUNTIME_NODEJS,
+        code: lambda.Code.fromAsset('custom-resources'),
+        handler: 'unified-opensearch-index.handler',
+        uuid: UUID,
+        lambdaPurpose: 'UnifiedOpenSearchIndex',
+        timeout: cdk.Duration.minutes(15),
+      }
+    );
+
+    const customResource = new cdk.CustomResource(this, 'CustomResource', {
+      serviceToken: customResourceHandler.functionArn,
+      resourceType: 'Custom::UnifiedOsIndex',
+      properties: props,
+    });
+
+    this.customResourceHandler = customResourceHandler;
+    this.customResource = customResource;
+  }
+}
+
+export interface UnifiedOpenSearchStackProps extends cdk.StackProps {
+  params: ProcessedStackInput;
+  domainName?: string;
+  bedrockKnowledgeBaseIndexName?: string;
+  assistantDocsIndexName?: string;
+  vectorField?: string;
+  metadataField?: string;
+  textField?: string;
+}
+
+/**
+ * Stack that creates a unified managed OpenSearch domain with public endpoint
+ * for both Bedrock Knowledge Base and tenant assistant RAG functionality.
+ *
+ * Key features:
+ * - Public endpoint (required for Bedrock Knowledge Base integration)
+ * - IAM-based access control (Fine-Grained Access Control)
+ * - SigV4 authentication
+ * - Two indexes: one for Bedrock KB, one for assistant docs
+ */
+export class UnifiedOpenSearchStack extends cdk.Stack {
+  /**
+   * The OpenSearch domain created by this stack
+   */
+  public readonly domain: opensearch.Domain;
+
+  /**
+   * The domain endpoint
+   */
+  public readonly domainEndpoint: string;
+
+  /**
+   * The domain ARN
+   */
+  public readonly domainArn: string;
+
+  /**
+   * IAM role for Bedrock Knowledge Base access
+   */
+  public readonly knowledgeBaseRole: iam.Role;
+
+  /**
+   * IAM role for OpenSearch master user (FGAC admin)
+   */
+  public readonly openSearchAdminRole: iam.Role;
+
+  /**
+   * Index name for Bedrock Knowledge Base
+   */
+  public readonly bedrockKnowledgeBaseIndexName: string;
+
+  /**
+   * Index name for assistant documents
+   */
+  public readonly assistantDocsIndexName: string;
+
+  /**
+   * Vector field name
+   */
+  public readonly vectorField: string;
+
+  /**
+   * Metadata field name
+   */
+  public readonly metadataField: string;
+
+  /**
+   * Text field name
+   */
+  public readonly textField: string;
+
+  constructor(
+    scope: Construct,
+    id: string,
+    props: UnifiedOpenSearchStackProps
+  ) {
+    super(scope, id, props);
+
+    const { env, embeddingModelId, ragKnowledgeBaseBinaryVector } =
+      props.params;
+
+    // Default values
+    const domainName =
+      props.domainName ?? `genu-unified-os-${env.toLowerCase()}`;
+    this.bedrockKnowledgeBaseIndexName =
+      props.bedrockKnowledgeBaseIndexName ?? 'bedrock-knowledge-base-default';
+    this.assistantDocsIndexName =
+      props.assistantDocsIndexName ?? 'assistant-docs';
+    this.vectorField =
+      props.vectorField ?? 'bedrock-knowledge-base-default-vector';
+    this.metadataField = props.metadataField ?? 'AMAZON_BEDROCK_METADATA';
+    this.textField = props.textField ?? 'AMAZON_BEDROCK_TEXT_CHUNK';
+
+    // Validate embedding model
+    if (
+      typeof embeddingModelId !== 'string' ||
+      !MODEL_VECTOR_MAPPING[embeddingModelId]
+    ) {
+      throw new Error(
+        `Invalid embeddingModelId: ${embeddingModelId}. Valid models: ${Object.keys(MODEL_VECTOR_MAPPING).join(', ')}`
+      );
+    }
+
+    // Create IAM role for OpenSearch admin (FGAC master user)
+    // This role can be assumed by Lambda functions that need to manage indexes
+    this.openSearchAdminRole = new iam.Role(this, 'OpenSearchAdminRole', {
+      assumedBy: new iam.CompositePrincipal(
+        new iam.ServicePrincipal('lambda.amazonaws.com'),
+        new iam.AccountRootPrincipal()
+      ),
+      description:
+        'Admin role for OpenSearch FGAC - can be assumed by Lambda and account principals',
+    });
+
+    // Create IAM role for Bedrock Knowledge Base
+    this.knowledgeBaseRole = new iam.Role(this, 'KnowledgeBaseRole', {
+      assumedBy: new iam.ServicePrincipal('bedrock.amazonaws.com'),
+      description:
+        'Role for Bedrock Knowledge Base to access unified OpenSearch domain',
+    });
+
+    // Grant Bedrock InvokeModel permissions
+    this.knowledgeBaseRole.addToPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        resources: ['*'],
+        actions: ['bedrock:InvokeModel'],
+      })
+    );
+
+    // Create OpenSearch domain with public endpoint
+    // Note: Bedrock Knowledge Base requires public access - VPC endpoints are not supported
+    this.domain = new opensearch.Domain(this, 'UnifiedOpenSearchDomain', {
+      version: opensearch.EngineVersion.OPENSEARCH_2_19,
+      domainName,
+      // Cost-optimized capacity: t3.small.search x 2 nodes
+      capacity: {
+        dataNodeInstanceType: 't3.small.search',
+        dataNodes: 2,
+        multiAzWithStandbyEnabled: false,
+      },
+      ebs: {
+        enabled: true,
+        volumeSize: 20,
+        volumeType: cdk.aws_ec2.EbsDeviceVolumeType.GP3,
+      },
+      // Zone awareness for high availability
+      zoneAwareness: {
+        enabled: true,
+        availabilityZoneCount: 2,
+      },
+      // Security settings
+      encryptionAtRest: {
+        enabled: true,
+      },
+      nodeToNodeEncryption: true,
+      enforceHttps: true,
+      // Fine-Grained Access Control with IAM
+      // Use dedicated admin role as master user for proper FGAC management
+      fineGrainedAccessControl: {
+        masterUserArn: this.openSearchAdminRole.roleArn,
+      },
+      // Logging
+      logging: {
+        slowSearchLogEnabled: true,
+        appLogEnabled: true,
+        slowIndexLogEnabled: true,
+      },
+      // Removal policy
+      removalPolicy: props.params.enableAutoDelete
+        ? cdk.RemovalPolicy.DESTROY
+        : cdk.RemovalPolicy.RETAIN,
+    });
+
+    // Store domain endpoint and ARN
+    this.domainEndpoint = this.domain.domainEndpoint;
+    this.domainArn = this.domain.domainArn;
+
+    // Grant OpenSearch access to admin role (for index management)
+    this.openSearchAdminRole.addToPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        resources: [`${this.domain.domainArn}/*`],
+        actions: [
+          'es:ESHttpGet',
+          'es:ESHttpPost',
+          'es:ESHttpPut',
+          'es:ESHttpDelete',
+          'es:ESHttpHead',
+        ],
+      })
+    );
+
+    // Grant OpenSearch access to Knowledge Base role
+    this.knowledgeBaseRole.addToPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        resources: [`${this.domain.domainArn}/*`],
+        actions: [
+          'es:ESHttpGet',
+          'es:ESHttpPost',
+          'es:ESHttpPut',
+          'es:ESHttpDelete',
+          'es:ESHttpHead',
+        ],
+      })
+    );
+
+    // Create access policy for the domain
+    // Allow access from:
+    // 1. OpenSearch admin role (FGAC master user)
+    // 2. Bedrock Knowledge Base service role
+    // 3. Account root (for Lambda functions with appropriate IAM policies)
+    const accessPolicy = new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      principals: [
+        this.openSearchAdminRole,
+        this.knowledgeBaseRole,
+        new iam.ServicePrincipal('bedrock.amazonaws.com'),
+        new iam.AccountRootPrincipal(),
+      ],
+      actions: [
+        'es:ESHttpGet',
+        'es:ESHttpPost',
+        'es:ESHttpPut',
+        'es:ESHttpDelete',
+        'es:ESHttpHead',
+      ],
+      resources: [`${this.domain.domainArn}/*`],
+    });
+
+    this.domain.addAccessPolicies(accessPolicy);
+
+    // Add DescribeDomain permission for Bedrock Knowledge Base validation
+    const describeDomainPolicy = new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      principals: [new iam.ServicePrincipal('bedrock.amazonaws.com')],
+      actions: ['es:DescribeDomain'],
+      resources: [this.domain.domainArn],
+    });
+
+    this.domain.addAccessPolicies(describeDomainPolicy);
+
+    // Create indexes using custom resource
+    const vectorDimension = MODEL_VECTOR_MAPPING[embeddingModelId];
+
+    // Create Bedrock Knowledge Base index
+    const bedrockIndex = new UnifiedOpenSearchIndex(this, 'BedrockKBIndex', {
+      domainEndpoint: `https://${this.domain.domainEndpoint}`,
+      domainArn: this.domain.domainArn,
+      vectorIndexName: this.bedrockKnowledgeBaseIndexName,
+      vectorField: this.vectorField,
+      metadataField: this.metadataField,
+      textField: this.textField,
+      vectorDimension,
+      ragKnowledgeBaseBinaryVector,
+    });
+
+    // Grant OpenSearch access to index creation Lambda
+    bedrockIndex.customResourceHandler.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        resources: [`${this.domain.domainArn}/*`],
+        actions: [
+          'es:ESHttpGet',
+          'es:ESHttpPost',
+          'es:ESHttpPut',
+          'es:ESHttpDelete',
+          'es:ESHttpHead',
+        ],
+      })
+    );
+
+    bedrockIndex.customResource.node.addDependency(this.domain);
+
+    // Create assistant docs index
+    const assistantIndex = new UnifiedOpenSearchIndex(
+      this,
+      'AssistantDocsIndex',
+      {
+        domainEndpoint: `https://${this.domain.domainEndpoint}`,
+        domainArn: this.domain.domainArn,
+        vectorIndexName: this.assistantDocsIndexName,
+        vectorField: 'embedding', // Different field name for assistant docs
+        metadataField: 'metadata',
+        textField: 'text',
+        vectorDimension,
+        ragKnowledgeBaseBinaryVector: false, // Assistant docs don't use binary vectors
+      }
+    );
+
+    assistantIndex.customResourceHandler.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        resources: [`${this.domain.domainArn}/*`],
+        actions: [
+          'es:ESHttpGet',
+          'es:ESHttpPost',
+          'es:ESHttpPut',
+          'es:ESHttpDelete',
+          'es:ESHttpHead',
+        ],
+      })
+    );
+
+    assistantIndex.customResource.node.addDependency(this.domain);
+    assistantIndex.customResource.node.addDependency(
+      bedrockIndex.customResource
+    );
+
+    // Export outputs
+    new cdk.CfnOutput(this, 'DomainEndpoint', {
+      value: `https://${this.domainEndpoint}`,
+      description: 'Unified OpenSearch domain endpoint',
+      exportName: `${this.stackName}-DomainEndpoint`,
+    });
+
+    new cdk.CfnOutput(this, 'DomainArn', {
+      value: this.domainArn,
+      description: 'Unified OpenSearch domain ARN',
+      exportName: `${this.stackName}-DomainArn`,
+    });
+
+    new cdk.CfnOutput(this, 'DomainName', {
+      value: this.domain.domainName,
+      description: 'Unified OpenSearch domain name',
+      exportName: `${this.stackName}-DomainName`,
+    });
+
+    new cdk.CfnOutput(this, 'KnowledgeBaseRoleArn', {
+      value: this.knowledgeBaseRole.roleArn,
+      description: 'IAM role ARN for Bedrock Knowledge Base',
+      exportName: `${this.stackName}-KnowledgeBaseRoleArn`,
+    });
+
+    new cdk.CfnOutput(this, 'BedrockKnowledgeBaseIndexName', {
+      value: this.bedrockKnowledgeBaseIndexName,
+      description: 'Index name for Bedrock Knowledge Base',
+      exportName: `${this.stackName}-BedrockKBIndexName`,
+    });
+
+    new cdk.CfnOutput(this, 'AssistantDocsIndexName', {
+      value: this.assistantDocsIndexName,
+      description: 'Index name for assistant documents',
+      exportName: `${this.stackName}-AssistantDocsIndexName`,
+    });
+
+    // Add tags
+    cdk.Tags.of(this).add('Environment', env);
+    cdk.Tags.of(this).add('Purpose', 'UnifiedOpenSearch');
+    cdk.Tags.of(this).add('ManagedBy', 'CDK');
+
+    // Set stack description
+    this.templateOptions.description =
+      'Creates unified managed OpenSearch domain for Bedrock Knowledge Base and tenant assistant RAG';
+  }
+
+  /**
+   * Grant read permissions to a principal
+   */
+  public grantRead(grantee: iam.IGrantable): iam.Grant {
+    return this.domain.grantRead(grantee);
+  }
+
+  /**
+   * Grant write permissions to a principal
+   */
+  public grantWrite(grantee: iam.IGrantable): iam.Grant {
+    return this.domain.grantWrite(grantee);
+  }
+
+  /**
+   * Grant read/write permissions to a principal
+   */
+  public grantReadWrite(grantee: iam.IGrantable): iam.Grant {
+    return this.domain.grantReadWrite(grantee);
+  }
+
+  /**
+   * Grant index permissions to a principal
+   */
+  public grantIndexRead(indexName: string, grantee: iam.IGrantable): iam.Grant {
+    return this.domain.grantIndexRead(indexName, grantee);
+  }
+
+  /**
+   * Grant index write permissions to a principal
+   */
+  public grantIndexWrite(
+    indexName: string,
+    grantee: iam.IGrantable
+  ): iam.Grant {
+    return this.domain.grantIndexWrite(indexName, grantee);
+  }
+
+  /**
+   * Grant index read/write permissions to a principal
+   */
+  public grantIndexReadWrite(
+    indexName: string,
+    grantee: iam.IGrantable
+  ): iam.Grant {
+    return this.domain.grantIndexReadWrite(indexName, grantee);
+  }
+}

--- a/packages/cdk/lib/stacks/tenant/tenant-opensearch-stack.ts
+++ b/packages/cdk/lib/stacks/tenant/tenant-opensearch-stack.ts
@@ -1,3 +1,18 @@
+/**
+ * @deprecated This stack is deprecated and no longer used.
+ *
+ * OpenSearch is now unified in UnifiedOpenSearchStack (packages/cdk/lib/stacks/common/unified-opensearch-stack.ts).
+ * All tenants share the unified OpenSearch domain with data isolation via metadata.assistantId filtering.
+ *
+ * This file is kept for backward compatibility during migration.
+ * It can be safely removed after all existing deployments have been migrated.
+ *
+ * Migration path:
+ * 1. Deploy UnifiedOpenSearchStack (created automatically when ragKnowledgeBaseEnabled is true)
+ * 2. Migrate existing data from per-tenant OpenSearch domains to unified domain
+ * 3. Remove TenantOpenSearchStack from tenant deployments
+ * 4. Delete this file
+ */
 import * as cdk from 'aws-cdk-lib';
 import * as opensearch from 'aws-cdk-lib/aws-opensearchservice';
 import * as ec2 from 'aws-cdk-lib/aws-ec2';


### PR DESCRIPTION
## Summary

- 各テナントごとに個別のOpenSearchドメインを作成する方式から、全テナント共有の統一OpenSearchドメイン（UnifiedOpenSearchStack）へ移行
- アシスタントRAG機能のOpenSearchアクセスを統一エンドポイント経由に変更し、メタデータ（tenantId, assistantId）によるデータ分離を実装
- テナント登録時のOpenSearch設定を非推奨化（後方互換性は維持）

## Changes

- `UnifiedOpenSearchStack`: 統一OpenSearchドメインを管理する新規スタックを追加
- `unified-opensearch-index.js`: マネージドOpenSearch用のインデックス作成カスタムリソースを追加
- `assistantSearch.ts`: 統一OpenSearchエンドポイントを使用するよう変更、tenantIdによるフィルタリングを追加
- `assistant.ts`, `props.ts`: 統一OpenSearchエンドポイント環境変数を追加
- `generative-ai-use-cases-tenant.ts`: テナント単位のOpenSearch設定を削除

## Test plan

- [ ] 統一OpenSearchスタックが正常にデプロイされることを確認
- [ ] アシスタントRAG機能でドキュメントのインデックス・検索が動作することを確認
- [ ] 異なるテナント間でデータ分離が正しく機能することを確認
- [ ] 既存テナントの後方互換性を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
