### PR TITLE
:recycle: refactor(e2e): テスト後の自動クリーンアップ追加

### DIFF
--- a/packages/cdk/.env.e2e.example
+++ b/packages/cdk/.env.e2e.example
@@ -1,80 +1,76 @@
-# E2E Test Environment Configuration
-# Copy this file to .env.e2e and fill in the values
-# Usage: npm run test:e2e
+# E2Eテスト環境設定
+# このファイルを .env.e2e にコピーして値を設定してください
+# 使用方法: npm run test:e2e
 
 # ============================================
-# Required Configuration
+# 必須設定
 # ============================================
 
-# Environment name (used to find CloudFormation stack)
-# Stack name will be: GenerativeAiUseCasesStack{E2E_ENV_NAME}
-# Example: "Dev" -> GenerativeAiUseCasesStackDev
-# Leave empty for default stack name: GenerativeAiUseCasesStack
+# 環境名（CloudFormationスタック名の特定に使用）
+# スタック名: GenerativeAiUseCasesStack{E2E_ENV_NAME}
+# 例: "Dev" -> GenerativeAiUseCasesStackDev
+# デフォルトスタック名を使用する場合は空欄: GenerativeAiUseCasesStack
 E2E_ENV_NAME=
 
-# Tenant ID for multi-tenant RDS access
-# This determines which tenant's database the tests will use
+# マルチテナントRDSアクセス用テナントID
+# テストで使用するテナントのデータベースを指定します
 E2E_TENANT_ID=
 
 # ============================================
-# AWS Credentials (choose one method)
+# AWS認証情報（プロファイル認証）
 # ============================================
 
-# Method 1: Use AWS Access Keys (recommended for E2E tests)
-AWS_ACCESS_KEY_ID=
-AWS_SECRET_ACCESS_KEY=
+# ~/.aws/credentials のAWSプロファイル名
+# 注意: SSO/login_sessionプロファイルはAWS SDKでサポートされていません
+AWS_PROFILE=
 
-# Method 2: Use AWS Profile (must have credentials in ~/.aws/credentials)
-# Note: SSO/login_session profiles are NOT supported by AWS SDK
-# AWS_PROFILE=
-
-# AWS Region (optional, defaults to ap-northeast-1)
-AWS_REGION=us-east-1
+# AWSリージョン（オプション、デフォルト: ap-northeast-1）
+AWS_REGION=ap-northeast-1
 
 # ============================================
-# Auto-fetched from CloudFormation (optional override)
+# CloudFormationから自動取得（オプション上書き）
 # ============================================
-# The following values are automatically fetched from CloudFormation stack outputs.
-# Only set these if you want to override the auto-fetched values.
+# 以下の値はCloudFormationスタック出力から自動取得されます。
+# 自動取得値を上書きする場合のみ設定してください。
 
 # E2E_API_BASE_URL=
 # E2E_COGNITO_USER_POOL_ID=
 # E2E_COGNITO_CLIENT_ID=
 
-# Note: Admin user credentials are NOT needed!
-# The test framework automatically creates a temporary Cognito admin user
-# with [E2E-TEST] prefix and cleans it up after tests complete.
+# 注意: 管理者ユーザー認証情報は不要です！
+# テストフレームワークは[E2E-TEST]プレフィックス付きの
+# 一時的なCognito管理者ユーザーを自動作成・自動削除します。
 
 # ============================================
-# Stripe Configuration (for subscription flow tests)
+# Stripe設定（サブスクリプションフローテスト用）
 # ============================================
 
-# Stripe Price ID for testing checkout flows
-# Get this from Stripe Dashboard (test mode): Products -> Select product -> Pricing -> Price ID
-# Example: price_1234567890abcdef
-# If not set, Stripe checkout flow tests will be skipped
+# チェックアウトフローテスト用のStripe Price ID
+# Stripeダッシュボード（テストモード）から取得: Products -> 製品選択 -> Pricing -> Price ID
+# 例: price_1234567890abcdef
+# 未設定の場合、Stripeチェックアウトフローテストはスキップされます
 E2E_TEST_STRIPE_PRICE_ID=
 
 # ============================================
-# Stripe CLI Forwarding (for webhook E2E tests)
+# Stripe CLIフォワーディング（Webhook E2Eテスト用）
 # ============================================
 #
-# Webhook E2E tests require Stripe CLI forwarding to receive real webhooks:
+# Webhook E2Eテストには実際のWebhookを受信するためにStripe CLIフォワーディングが必要です:
 #
-# 1. Install Stripe CLI: https://stripe.com/docs/stripe-cli
+# 1. Stripe CLIをインストール: https://stripe.com/docs/stripe-cli
 #
-# 2. Login to Stripe CLI:
+# 2. Stripe CLIにログイン:
 #    stripe login
 #
-# 3. Start webhook forwarding (replace {tenantId} with your E2E_TENANT_ID):
+# 3. Webhookフォワーディングを開始（{tenantId}をE2E_TENANT_IDに置き換え）:
 #    stripe listen --forward-to https://{api-url}/billing/webhook/{tenantId}/stripe
 #
-# 4. Copy the webhook signing secret from the CLI output:
+# 4. CLI出力からWebhook署名シークレットをコピー:
 #    > Ready! Your webhook signing secret is whsec_xxxxx
 #
-# 5. Update this value AND store in Secrets Manager:
-#    - Set E2E_STRIPE_WEBHOOK_SECRET below
-#    - Update AWS Secrets Manager: {tenantId}/billing/stripe with { "webhookSecret": "whsec_xxxxx" }
+# 5. この値を更新し、Secrets Managerにも保存:
+#    - 以下のE2E_STRIPE_WEBHOOK_SECRETを設定
+#    - AWS Secrets Managerを更新: {tenantId}/billing/stripe に { "webhookSecret": "whsec_xxxxx" }
 #
-# If not set, webhook event processing tests will be skipped (signature validation tests still run)
+# 未設定の場合、Webhookイベント処理テストはスキップされます（署名検証テストは実行されます）
 E2E_STRIPE_WEBHOOK_SECRET=

--- a/packages/cdk/test/e2e/globalSetup.ts
+++ b/packages/cdk/test/e2e/globalSetup.ts
@@ -3,10 +3,12 @@
  *
  * This runs ONCE before any test files are loaded.
  * Sets AWS_PROFILE and AWS_REGION so AWS SDK clients work correctly.
+ * Returns a teardown function that runs after all tests complete.
  */
 
 import * as fs from 'fs';
 import * as path from 'path';
+import globalTeardown from './globalTeardown';
 
 const CDK_ROOT = path.join(__dirname, '..', '..');
 const ENV_FILE = path.join(CDK_ROOT, '.env.e2e');
@@ -35,7 +37,7 @@ function loadEnvFile(): Record<string, string> {
   return config;
 }
 
-export default function globalSetup() {
+export default function globalSetup(): () => Promise<void> {
   const envConfig = loadEnvFile();
 
   // Set AWS credentials config
@@ -57,4 +59,7 @@ export default function globalSetup() {
   }
 
   console.log(`Global Setup: AWS_PROFILE=${process.env.AWS_PROFILE || '(default)'}, AWS_REGION=${process.env.AWS_REGION}`);
+
+  // Return teardown function to be called after all tests complete
+  return globalTeardown;
 }

--- a/packages/cdk/test/e2e/globalTeardown.ts
+++ b/packages/cdk/test/e2e/globalTeardown.ts
@@ -1,0 +1,486 @@
+/**
+ * E2E Global Teardown
+ *
+ * This runs ONCE after all test files have completed.
+ * Cleans up all test data:
+ * - Deletes all test users from Cognito (email prefix: e2e-test)
+ * - Deprecates all test plans via API (internal_name prefix: [E2E-TEST])
+ *
+ * NOTE: This file must NOT import from files that use vitest
+ * because globalSetup/globalTeardown run in a different context.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  CloudFormationClient,
+  DescribeStacksCommand,
+} from '@aws-sdk/client-cloudformation';
+import {
+  CognitoIdentityProviderClient,
+  ListUsersCommand,
+  AdminDeleteUserCommand,
+  InitiateAuthCommand,
+  AuthFlowType,
+  AdminCreateUserCommand,
+  AdminSetUserPasswordCommand,
+  MessageActionType,
+} from '@aws-sdk/client-cognito-identity-provider';
+import { fromIni } from '@aws-sdk/credential-providers';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
+
+const CDK_ROOT = path.join(__dirname, '..', '..');
+const ENV_FILE = path.join(CDK_ROOT, '.env.e2e');
+const DEFAULT_REGION = 'ap-northeast-1';
+const BASE_STACK_NAME = 'GenerativeAiUseCasesStack';
+
+// Test data prefixes (duplicated from testDataFactory to avoid vitest import chain)
+const E2E_TEST_EMAIL_PREFIX = 'e2e-test';
+const E2E_TEST_PREFIX = '[E2E-TEST]';
+
+function loadEnvFile(): Record<string, string> {
+  const config: Record<string, string> = {};
+
+  if (!fs.existsSync(ENV_FILE)) {
+    return config;
+  }
+
+  const content = fs.readFileSync(ENV_FILE, 'utf-8');
+  content.split('\n').forEach((line) => {
+    const match = line.match(/^([^#=]+)=(.*)$/);
+    if (match) {
+      const key = match[1].trim();
+      const value = match[2].trim();
+      if (value) {
+        config[key] = value;
+      }
+    }
+  });
+
+  return config;
+}
+
+function getCredentialProvider(): AwsCredentialIdentityProvider | undefined {
+  if (process.env.AWS_PROFILE) {
+    return fromIni({ profile: process.env.AWS_PROFILE });
+  }
+  return undefined;
+}
+
+async function getCloudFormationOutputs(
+  stackName: string,
+  region: string
+): Promise<Record<string, string>> {
+  const credentials = getCredentialProvider();
+  const client = new CloudFormationClient({
+    region,
+    ...(credentials && { credentials }),
+  });
+  const command = new DescribeStacksCommand({ StackName: stackName });
+
+  const response = await client.send(command);
+  const outputs: Record<string, string> = {};
+
+  response.Stacks?.[0]?.Outputs?.forEach(
+    (output: { OutputKey?: string; OutputValue?: string }) => {
+      if (output.OutputKey && output.OutputValue) {
+        outputs[output.OutputKey] = output.OutputValue;
+      }
+    }
+  );
+
+  return outputs;
+}
+
+/**
+ * Simple API client for teardown (standalone, no vitest imports)
+ */
+class TeardownApiClient {
+  private baseUrl: string;
+  private authToken: string;
+
+  constructor(baseUrl: string, authToken: string) {
+    this.baseUrl = baseUrl.replace(/\/$/, '');
+    this.authToken = authToken;
+  }
+
+  async get<T>(path: string): Promise<{ status: number; data: T }> {
+    const response = await fetch(`${this.baseUrl}${path}`, {
+      method: 'GET',
+      headers: {
+        Authorization: this.authToken,
+        'Content-Type': 'application/json',
+      },
+    });
+    const data = (await response.json()) as T;
+    return { status: response.status, data };
+  }
+
+  async patch<T>(
+    path: string,
+    body: unknown
+  ): Promise<{ status: number; data: T }> {
+    const response = await fetch(`${this.baseUrl}${path}`, {
+      method: 'PATCH',
+      headers: {
+        Authorization: this.authToken,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    const data = (await response.json()) as T;
+    return { status: response.status, data };
+  }
+}
+
+/**
+ * Delete all test users from Cognito
+ */
+async function deleteAllTestUsers(
+  userPoolId: string,
+  region: string
+): Promise<{ deleted: number; failed: number }> {
+  const credentials = getCredentialProvider();
+  const client = new CognitoIdentityProviderClient({
+    region,
+    ...(credentials && { credentials }),
+  });
+
+  // List all test users
+  const users: string[] = [];
+  let paginationToken: string | undefined;
+
+  do {
+    const response = await client.send(
+      new ListUsersCommand({
+        UserPoolId: userPoolId,
+        Filter: `email ^= "${E2E_TEST_EMAIL_PREFIX}"`,
+        Limit: 60,
+        PaginationToken: paginationToken,
+      })
+    );
+
+    for (const user of response.Users || []) {
+      if (user.Username) {
+        users.push(user.Username);
+      }
+    }
+
+    paginationToken = response.PaginationToken;
+  } while (paginationToken);
+
+  if (users.length === 0) {
+    console.log('No test users found to clean up.');
+    return { deleted: 0, failed: 0 };
+  }
+
+  console.log(`Found ${users.length} test users to clean up...`);
+
+  let deleted = 0;
+  let failed = 0;
+
+  for (const username of users) {
+    try {
+      await client.send(
+        new AdminDeleteUserCommand({
+          UserPoolId: userPoolId,
+          Username: username,
+        })
+      );
+      deleted++;
+      console.log(`  Deleted user: ${username}`);
+    } catch (error: any) {
+      if (error.name !== 'UserNotFoundException') {
+        console.warn(`  Failed to delete user ${username}:`, error.message);
+        failed++;
+      }
+    }
+  }
+
+  console.log(`User cleanup complete: ${deleted} deleted, ${failed} failed`);
+  return { deleted, failed };
+}
+
+/**
+ * Create a temporary admin user for cleanup operations
+ */
+async function createCleanupAdminUser(
+  userPoolId: string,
+  clientId: string,
+  tenantId: string,
+  region: string
+): Promise<{ token: string; username: string }> {
+  const credentials = getCredentialProvider();
+  const client = new CognitoIdentityProviderClient({
+    region,
+    ...(credentials && { credentials }),
+  });
+
+  const timestamp = Date.now();
+  const random = Math.random().toString(36).substring(2, 8);
+  const username = `${E2E_TEST_EMAIL_PREFIX}-cleanup-${timestamp}-${random}@example.com`;
+  const password = 'Cleanup1!Temp' + random;
+
+  // Create user
+  await client.send(
+    new AdminCreateUserCommand({
+      UserPoolId: userPoolId,
+      Username: username,
+      UserAttributes: [
+        { Name: 'email', Value: username },
+        { Name: 'email_verified', Value: 'true' },
+        { Name: 'custom:tenant_id', Value: tenantId },
+        { Name: 'custom:tenantAdmin', Value: 'true' },
+      ],
+      TemporaryPassword: password,
+      MessageAction: MessageActionType.SUPPRESS,
+    })
+  );
+
+  // Set permanent password
+  await client.send(
+    new AdminSetUserPasswordCommand({
+      UserPoolId: userPoolId,
+      Username: username,
+      Password: password,
+      Permanent: true,
+    })
+  );
+
+  // Get token
+  const authResponse = await client.send(
+    new InitiateAuthCommand({
+      AuthFlow: AuthFlowType.USER_PASSWORD_AUTH,
+      ClientId: clientId,
+      AuthParameters: {
+        USERNAME: username,
+        PASSWORD: password,
+      },
+    })
+  );
+
+  if (!authResponse.AuthenticationResult?.IdToken) {
+    throw new Error('Failed to get authentication token for cleanup user');
+  }
+
+  return {
+    token: authResponse.AuthenticationResult.IdToken,
+    username,
+  };
+}
+
+/**
+ * Delete a user from Cognito
+ */
+async function deleteUser(
+  userPoolId: string,
+  username: string,
+  region: string
+): Promise<void> {
+  const credentials = getCredentialProvider();
+  const client = new CognitoIdentityProviderClient({
+    region,
+    ...(credentials && { credentials }),
+  });
+
+  try {
+    await client.send(
+      new AdminDeleteUserCommand({
+        UserPoolId: userPoolId,
+        Username: username,
+      })
+    );
+  } catch (error: any) {
+    if (error.name !== 'UserNotFoundException') {
+      console.warn(`Failed to delete user ${username}:`, error.message);
+    }
+  }
+}
+
+/**
+ * Deprecate all test plans via API
+ */
+async function deprecateAllTestPlans(
+  apiClient: TeardownApiClient
+): Promise<{ deprecated: number; failed: number; skipped: number }> {
+  // List all plans
+  let plans: Array<{ plan_id: string; internal_name: string; status: string }> =
+    [];
+
+  try {
+    const response = await apiClient.get<{
+      plans: Array<{
+        plan_id: string;
+        internal_name: string;
+        status: string;
+      }>;
+    }>('/admin/billing/plans');
+
+    if (response.status === 200 && response.data.plans) {
+      // Filter plans by E2E test prefix
+      plans = response.data.plans.filter((plan) =>
+        plan.internal_name.startsWith(E2E_TEST_PREFIX)
+      );
+    }
+  } catch (error) {
+    console.warn('Error listing plans:', error);
+    return { deprecated: 0, failed: 0, skipped: 0 };
+  }
+
+  if (plans.length === 0) {
+    console.log('No test plans found to clean up.');
+    return { deprecated: 0, failed: 0, skipped: 0 };
+  }
+
+  console.log(`Found ${plans.length} test plans to clean up...`);
+
+  let deprecated = 0;
+  let failed = 0;
+  let skipped = 0;
+
+  for (const plan of plans) {
+    if (plan.status === 'deprecated') {
+      skipped++;
+      continue;
+    }
+
+    try {
+      // First close to new subscriptions
+      await apiClient.patch(`/admin/billing/plans/${plan.plan_id}/status`, {
+        new_status: 'closed_to_new',
+      });
+
+      // Then deprecate
+      const response = await apiClient.patch(
+        `/admin/billing/plans/${plan.plan_id}/status`,
+        { new_status: 'deprecated' }
+      );
+
+      if (response.status === 200) {
+        deprecated++;
+        console.log(
+          `  Deprecated plan: ${plan.internal_name} (${plan.plan_id})`
+        );
+      } else {
+        // Plan might already be deprecated
+        deprecated++;
+      }
+    } catch (error) {
+      failed++;
+      console.warn(
+        `  Failed to deprecate plan: ${plan.internal_name} (${plan.plan_id})`
+      );
+    }
+  }
+
+  console.log(
+    `Plan cleanup complete: ${deprecated} deprecated, ${skipped} already deprecated, ${failed} failed`
+  );
+  return { deprecated, failed, skipped };
+}
+
+export default async function globalTeardown() {
+  console.log('\n========================================');
+  console.log('Global Teardown: Cleaning up test data...');
+  console.log('========================================\n');
+
+  try {
+    // Load environment configuration
+    const envConfig = loadEnvFile();
+    const region =
+      envConfig.AWS_REGION || process.env.AWS_REGION || DEFAULT_REGION;
+    const envName = envConfig.E2E_ENV_NAME || process.env.E2E_ENV_NAME || '';
+    const tenantId = envConfig.E2E_TENANT_ID || process.env.E2E_TENANT_ID || '';
+    const stackName = envName
+      ? `${BASE_STACK_NAME}${envName}`
+      : BASE_STACK_NAME;
+
+    // Set AWS_PROFILE if configured
+    if (envConfig.AWS_PROFILE && !process.env.AWS_PROFILE) {
+      process.env.AWS_PROFILE = envConfig.AWS_PROFILE;
+    }
+
+    // Get configuration from environment or CloudFormation
+    let apiBaseUrl =
+      envConfig.E2E_API_BASE_URL || process.env.E2E_API_BASE_URL || '';
+    let cognitoUserPoolId =
+      envConfig.E2E_COGNITO_USER_POOL_ID ||
+      process.env.E2E_COGNITO_USER_POOL_ID ||
+      '';
+    let cognitoClientId =
+      envConfig.E2E_COGNITO_CLIENT_ID ||
+      process.env.E2E_COGNITO_CLIENT_ID ||
+      '';
+
+    // Fetch from CloudFormation if needed
+    if (!apiBaseUrl || !cognitoUserPoolId || !cognitoClientId) {
+      console.log(
+        `Fetching configuration from CloudFormation stack: ${stackName}`
+      );
+      try {
+        const outputs = await getCloudFormationOutputs(stackName, region);
+        if (!apiBaseUrl) {
+          apiBaseUrl = outputs['BillingApiEndpoint']?.replace(/\/$/, '') || '';
+        }
+        if (!cognitoUserPoolId) {
+          cognitoUserPoolId = outputs['UserPoolId'] || '';
+        }
+        if (!cognitoClientId) {
+          cognitoClientId = outputs['UserPoolClientId'] || '';
+        }
+      } catch (error) {
+        console.error('Failed to fetch CloudFormation outputs:', error);
+        console.warn('Skipping cleanup due to configuration error.');
+        return;
+      }
+    }
+
+    // Validate configuration
+    if (!cognitoUserPoolId || !cognitoClientId || !tenantId) {
+      console.warn('Missing required configuration for cleanup. Skipping.');
+      return;
+    }
+
+    // === Step 1: Clean up test users from Cognito ===
+    console.log('\n--- Cleaning up test users from Cognito ---');
+    await deleteAllTestUsers(cognitoUserPoolId, region);
+
+    // === Step 2: Clean up test plans via API ===
+    if (apiBaseUrl) {
+      console.log('\n--- Cleaning up test plans via API ---');
+
+      // Create a temporary admin user for API access
+      let cleanupUsername: string | undefined;
+      try {
+        console.log('Creating temporary admin user for plan cleanup...');
+        const { token, username } = await createCleanupAdminUser(
+          cognitoUserPoolId,
+          cognitoClientId,
+          tenantId,
+          region
+        );
+        cleanupUsername = username;
+
+        const apiClient = new TeardownApiClient(apiBaseUrl, token);
+        await deprecateAllTestPlans(apiClient);
+      } catch (error) {
+        console.error('Failed to clean up plans:', error);
+      } finally {
+        // Delete the cleanup user
+        if (cleanupUsername) {
+          console.log('Deleting temporary cleanup user...');
+          await deleteUser(cognitoUserPoolId, cleanupUsername, region);
+        }
+      }
+    } else {
+      console.warn('API Base URL not configured. Skipping plan cleanup.');
+    }
+
+    console.log('\n========================================');
+    console.log('Global Teardown: Complete');
+    console.log('========================================\n');
+  } catch (error) {
+    console.error('Global Teardown Error:', error);
+    // Don't throw - allow tests to complete even if cleanup fails
+  }
+}

--- a/packages/cdk/test/e2e/helpers/globalCleanupHelper.ts
+++ b/packages/cdk/test/e2e/helpers/globalCleanupHelper.ts
@@ -1,0 +1,306 @@
+/**
+ * Global Cleanup Helper for E2E Tests
+ *
+ * Provides cleanup functions that run after all tests complete.
+ * - Deletes all test users from Cognito (by email prefix)
+ * - Deprecates all test plans via API (by internal_name prefix)
+ */
+
+import {
+  CognitoIdentityProviderClient,
+  ListUsersCommand,
+  AdminDeleteUserCommand,
+  InitiateAuthCommand,
+  AuthFlowType,
+  AdminCreateUserCommand,
+  AdminSetUserPasswordCommand,
+  AdminGetUserCommand,
+  MessageActionType,
+} from '@aws-sdk/client-cognito-identity-provider';
+import { fromIni } from '@aws-sdk/credential-providers';
+import type { AwsCredentialIdentityProvider } from '@smithy/types';
+import { E2E_TEST_EMAIL_PREFIX, E2E_TEST_PREFIX } from './testDataFactory';
+import { ApiClient } from './apiClient';
+
+/**
+ * Get credential provider based on AWS_PROFILE
+ */
+function getCredentialProvider(): AwsCredentialIdentityProvider | undefined {
+  if (process.env.AWS_PROFILE) {
+    return fromIni({ profile: process.env.AWS_PROFILE });
+  }
+  return undefined;
+}
+
+/**
+ * Global cleanup helper for test users
+ */
+export class GlobalUserCleanup {
+  private client: CognitoIdentityProviderClient;
+  private userPoolId: string;
+
+  constructor(userPoolId: string, region: string) {
+    const credentials = getCredentialProvider();
+    this.client = new CognitoIdentityProviderClient({
+      region,
+      ...(credentials && { credentials }),
+    });
+    this.userPoolId = userPoolId;
+  }
+
+  /**
+   * List all test users by email prefix
+   */
+  async listTestUsers(): Promise<string[]> {
+    const users: string[] = [];
+    let paginationToken: string | undefined;
+
+    do {
+      const response = await this.client.send(
+        new ListUsersCommand({
+          UserPoolId: this.userPoolId,
+          Filter: `email ^= "${E2E_TEST_EMAIL_PREFIX}"`,
+          Limit: 60,
+          PaginationToken: paginationToken,
+        })
+      );
+
+      for (const user of response.Users || []) {
+        if (user.Username) {
+          users.push(user.Username);
+        }
+      }
+
+      paginationToken = response.PaginationToken;
+    } while (paginationToken);
+
+    return users;
+  }
+
+  /**
+   * Delete a user from Cognito
+   */
+  async deleteUser(username: string): Promise<boolean> {
+    try {
+      await this.client.send(
+        new AdminDeleteUserCommand({
+          UserPoolId: this.userPoolId,
+          Username: username,
+        })
+      );
+      return true;
+    } catch (error: any) {
+      if (error.name !== 'UserNotFoundException') {
+        console.warn(`Failed to delete user ${username}:`, error.message);
+      }
+      return false;
+    }
+  }
+
+  /**
+   * Delete all test users
+   */
+  async deleteAllTestUsers(): Promise<{ deleted: number; failed: number }> {
+    const users = await this.listTestUsers();
+
+    if (users.length === 0) {
+      console.log('No test users found to clean up.');
+      return { deleted: 0, failed: 0 };
+    }
+
+    console.log(`Found ${users.length} test users to clean up...`);
+
+    let deleted = 0;
+    let failed = 0;
+
+    for (const username of users) {
+      if (await this.deleteUser(username)) {
+        deleted++;
+        console.log(`  Deleted user: ${username}`);
+      } else {
+        failed++;
+      }
+    }
+
+    console.log(`User cleanup complete: ${deleted} deleted, ${failed} failed`);
+    return { deleted, failed };
+  }
+}
+
+/**
+ * Global cleanup helper for test plans
+ */
+export class GlobalPlanCleanup {
+  private apiClient: ApiClient;
+
+  constructor(apiClient: ApiClient) {
+    this.apiClient = apiClient;
+  }
+
+  /**
+   * List all test plans by prefix
+   */
+  async listTestPlans(): Promise<
+    Array<{ plan_id: string; internal_name: string; status: string }>
+  > {
+    try {
+      const response = await this.apiClient.get<{
+        plans: Array<{
+          plan_id: string;
+          internal_name: string;
+          status: string;
+        }>;
+      }>('/admin/billing/plans');
+
+      if (response.status !== 200 || !response.data.plans) {
+        console.warn('Failed to list plans:', response.status);
+        return [];
+      }
+
+      // Filter plans by E2E test prefix
+      return response.data.plans.filter((plan) =>
+        plan.internal_name.startsWith(E2E_TEST_PREFIX)
+      );
+    } catch (error) {
+      console.warn('Error listing plans:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Deprecate a plan (two-step process: active -> closed_to_new -> deprecated)
+   */
+  async deprecatePlan(planId: string): Promise<boolean> {
+    try {
+      // First close to new subscriptions
+      await this.apiClient.patch(`/admin/billing/plans/${planId}/status`, {
+        new_status: 'closed_to_new',
+      });
+
+      // Then deprecate
+      const response = await this.apiClient.patch(
+        `/admin/billing/plans/${planId}/status`,
+        { new_status: 'deprecated' }
+      );
+
+      return response.status === 200;
+    } catch (error) {
+      // Plan might already be deprecated
+      return true;
+    }
+  }
+
+  /**
+   * Deprecate all test plans
+   */
+  async deprecateAllTestPlans(): Promise<{
+    deprecated: number;
+    failed: number;
+    skipped: number;
+  }> {
+    const plans = await this.listTestPlans();
+
+    if (plans.length === 0) {
+      console.log('No test plans found to clean up.');
+      return { deprecated: 0, failed: 0, skipped: 0 };
+    }
+
+    console.log(`Found ${plans.length} test plans to clean up...`);
+
+    let deprecated = 0;
+    let failed = 0;
+    let skipped = 0;
+
+    for (const plan of plans) {
+      if (plan.status === 'deprecated') {
+        skipped++;
+        continue;
+      }
+
+      if (await this.deprecatePlan(plan.plan_id)) {
+        deprecated++;
+        console.log(
+          `  Deprecated plan: ${plan.internal_name} (${plan.plan_id})`
+        );
+      } else {
+        failed++;
+        console.warn(
+          `  Failed to deprecate plan: ${plan.internal_name} (${plan.plan_id})`
+        );
+      }
+    }
+
+    console.log(
+      `Plan cleanup complete: ${deprecated} deprecated, ${skipped} already deprecated, ${failed} failed`
+    );
+    return { deprecated, failed, skipped };
+  }
+}
+
+/**
+ * Create a temporary admin user for cleanup operations
+ */
+export async function createCleanupAdminUser(
+  userPoolId: string,
+  clientId: string,
+  tenantId: string,
+  region: string
+): Promise<{ token: string; username: string }> {
+  const credentials = getCredentialProvider();
+  const client = new CognitoIdentityProviderClient({
+    region,
+    ...(credentials && { credentials }),
+  });
+
+  const timestamp = Date.now();
+  const random = Math.random().toString(36).substring(2, 8);
+  const username = `${E2E_TEST_EMAIL_PREFIX}-cleanup-${timestamp}-${random}@example.com`;
+  const password = 'Cleanup1!Temp' + random;
+
+  // Create user
+  await client.send(
+    new AdminCreateUserCommand({
+      UserPoolId: userPoolId,
+      Username: username,
+      UserAttributes: [
+        { Name: 'email', Value: username },
+        { Name: 'email_verified', Value: 'true' },
+        { Name: 'custom:tenant_id', Value: tenantId },
+        { Name: 'custom:tenantAdmin', Value: 'true' },
+      ],
+      TemporaryPassword: password,
+      MessageAction: MessageActionType.SUPPRESS,
+    })
+  );
+
+  // Set permanent password
+  await client.send(
+    new AdminSetUserPasswordCommand({
+      UserPoolId: userPoolId,
+      Username: username,
+      Password: password,
+      Permanent: true,
+    })
+  );
+
+  // Get token
+  const authResponse = await client.send(
+    new InitiateAuthCommand({
+      AuthFlow: AuthFlowType.USER_PASSWORD_AUTH,
+      ClientId: clientId,
+      AuthParameters: {
+        USERNAME: username,
+        PASSWORD: password,
+      },
+    })
+  );
+
+  if (!authResponse.AuthenticationResult?.IdToken) {
+    throw new Error('Failed to get authentication token for cleanup user');
+  }
+
+  return {
+    token: authResponse.AuthenticationResult.IdToken,
+    username,
+  };
+}

--- a/packages/cdk/test/e2e/helpers/index.ts
+++ b/packages/cdk/test/e2e/helpers/index.ts
@@ -9,6 +9,12 @@ export type { ApiResponse, ApiError } from './apiClient';
 
 export { TestCleanupHelper, TestResourceTracker } from './cleanupHelper';
 
+export {
+  GlobalUserCleanup,
+  GlobalPlanCleanup,
+  createCleanupAdminUser,
+} from './globalCleanupHelper';
+
 export { TestUserManager, generateTestUserEmail } from './testUserHelper';
 export type { TestUserCredentials } from './testUserHelper';
 

--- a/packages/cdk/test/e2e/helpers/testUserHelper.ts
+++ b/packages/cdk/test/e2e/helpers/testUserHelper.ts
@@ -17,22 +17,16 @@ import {
   InitiateAuthCommand,
   AuthFlowType,
 } from '@aws-sdk/client-cognito-identity-provider';
-import { fromEnv, fromIni } from '@aws-sdk/credential-providers';
+import { fromIni } from '@aws-sdk/credential-providers';
 import type { AwsCredentialIdentityProvider } from '@smithy/types';
 import { testConfig } from '../setup';
 import { E2E_TEST_EMAIL_PREFIX } from './testDataFactory';
 
 /**
- * Get credential provider based on available configuration.
- * Priority: Environment variables > AWS Profile
+ * Get credential provider based on AWS_PROFILE configuration.
  */
 function getCredentialProvider(): AwsCredentialIdentityProvider | undefined {
-  // If AWS credentials are set as environment variables, use them
-  if (process.env.AWS_ACCESS_KEY_ID && process.env.AWS_SECRET_ACCESS_KEY) {
-    return fromEnv();
-  }
-
-  // If AWS_PROFILE is set, try to use it
+  // If AWS_PROFILE is set, use profile-based credentials
   if (process.env.AWS_PROFILE) {
     return fromIni({ profile: process.env.AWS_PROFILE });
   }

--- a/packages/cdk/vitest.config.e2e.ts
+++ b/packages/cdk/vitest.config.e2e.ts
@@ -30,6 +30,7 @@ export default defineConfig({
     globals: true,
     include: ['**/*.e2e.test.ts'],
     setupFiles: ['./setup.ts'],
+    globalSetup: ['./globalSetup.ts'],
     testTimeout: 30000,
     hookTimeout: 30000,
   },


### PR DESCRIPTION
## 変更内容

テスト終了後に一時ユーザーとプランを自動削除するクリーンアップ機能を追加しました。

### 変更の詳細

1. **globalTeardown.ts** - グローバルテアダウン処理の実装
   - Cognitoから全テストユーザーを削除（e2e-testメールプレフィックス）
   - API経由で全テストプランをデプリケート（[E2E-TEST]プレフィックス）

2. **globalCleanupHelper.ts** - 再利用可能なクリーンアップクラスの作成

3. **vitest.config.e2e.ts** - グローバルセットアップ設定を追加

4. **globalSetup.ts** - テアダウン関数を返すように修正

5. **.env.e2e.example** - AWS認証をプロファイル方式のみに変更
   - AWS_ACCESS_KEY_IDとAWS_SECRET_ACCESS_KEYを削除

6. **testUserHelper.ts** - プロファイル方式の認証情報提供に簡略化

7. **helpers/index.ts** - グローバルクリーンアップヘルパーのエクスポート追加