### PR TITLE
🩹 エラーメッセージを回答のテキストではなくエラーとしてフロントに渡すようにする

### DIFF
--- a/packages/cdk/lambda/assistantMessageStreamHandler.ts
+++ b/packages/cdk/lambda/assistantMessageStreamHandler.ts
@@ -12,6 +12,7 @@ import {
   AssistantMessageSource,
   Model,
   UnrecordedMessage,
+  ErrorCode,
 } from 'generative-ai-use-cases';
 import { similaritySearch } from './repository/assistantSearch';
 import { streamingChunk } from './utils/streamingChunk';
@@ -69,8 +70,12 @@ export const handler = awslambda.streamifyResponse(
     if (!idToken) {
       responseStream.write(
         streamingChunk({
-          text: 'ID token is required for authorization',
+          text: '',
           stopReason: 'error',
+          error: {
+            code: 'INVALID_TOKEN' as ErrorCode,
+            message: 'ID token is required for authorization',
+          },
         })
       );
       responseStream.end();
@@ -84,8 +89,12 @@ export const handler = awslambda.streamifyResponse(
       console.error('Access check failed:', error);
       responseStream.write(
         streamingChunk({
-          text: 'Authorization check failed',
+          text: '',
           stopReason: 'error',
+          error: {
+            code: 'INTERNAL_ERROR' as ErrorCode,
+            message: 'Authorization check failed',
+          },
         })
       );
       responseStream.end();
@@ -93,30 +102,39 @@ export const handler = awslambda.streamifyResponse(
     }
 
     if (!accessCheckResult.allowed) {
-      let errorText: string;
+      let errorCode: ErrorCode;
+      let errorMessage: string;
       switch (accessCheckResult.reason) {
         case 'quota_exceeded':
           console.warn(
             `User has exceeded quota for assistant:chat`
           );
-          errorText = 'アシスタントの利用回数の上限に達しました';
+          errorCode = 'QUOTA_EXCEEDED';
+          errorMessage = 'アシスタントの利用回数の上限に達しました';
           break;
         case 'no_permission':
           console.warn(
             `User does not have access to assistant:chat`
           );
-          errorText = 'アシスタントを使用する権限がありません';
+          errorCode = 'NO_PERMISSION';
+          errorMessage = 'アシスタントを使用する権限がありません';
           break;
         case 'invalid_token':
-          errorText = 'Invalid or expired ID token';
+          errorCode = 'INVALID_TOKEN';
+          errorMessage = 'Invalid or expired ID token';
           break;
         default:
-          errorText = 'You do not have permission to use the assistant';
+          errorCode = 'NO_PERMISSION';
+          errorMessage = 'You do not have permission to use the assistant';
       }
       responseStream.write(
         streamingChunk({
-          text: errorText,
+          text: '',
           stopReason: 'error',
+          error: {
+            code: errorCode,
+            message: errorMessage,
+          },
         })
       );
       responseStream.end();
@@ -202,8 +220,12 @@ export const handler = awslambda.streamifyResponse(
       if (!assistant) {
         responseStream.write(
           streamingChunk({
-            text: 'Assistant not found',
+            text: '',
             stopReason: 'error',
+            error: {
+              code: 'ASSISTANT_NOT_FOUND' as ErrorCode,
+              message: 'Assistant not found',
+            },
           })
         );
         responseStream.end();
@@ -214,8 +236,12 @@ export const handler = awslambda.streamifyResponse(
       if (!canAccessAssistant(assistant, userId, requestContext)) {
         responseStream.write(
           streamingChunk({
-            text: 'Access denied to this assistant',
+            text: '',
             stopReason: 'error',
+            error: {
+              code: 'ACCESS_DENIED' as ErrorCode,
+              message: 'Access denied to this assistant',
+            },
           })
         );
         responseStream.end();
@@ -225,8 +251,12 @@ export const handler = awslambda.streamifyResponse(
       if (!assistant.modelId) {
         responseStream.write(
           streamingChunk({
-            text: 'Assistant has no model configured',
+            text: '',
             stopReason: 'error',
+            error: {
+              code: 'MODEL_NOT_CONFIGURED' as ErrorCode,
+              message: 'Assistant has no model configured',
+            },
           })
         );
         responseStream.end();
@@ -241,8 +271,12 @@ export const handler = awslambda.streamifyResponse(
       ) {
         responseStream.write(
           streamingChunk({
-            text: 'Assistant is currently indexing documents. Please wait until indexing completes.',
+            text: '',
             stopReason: 'error',
+            error: {
+              code: 'DOCUMENT_INDEXING' as ErrorCode,
+              message: 'Assistant is currently indexing documents. Please wait until indexing completes.',
+            },
           })
         );
         responseStream.end();
@@ -252,8 +286,12 @@ export const handler = awslambda.streamifyResponse(
       if (!assistant.instruction) {
         responseStream.write(
           streamingChunk({
-            text: 'Assistant has no system prompt configured',
+            text: '',
             stopReason: 'error',
+            error: {
+              code: 'SYSTEM_PROMPT_NOT_SET' as ErrorCode,
+              message: 'Assistant has no system prompt configured',
+            },
           })
         );
         responseStream.end();
@@ -499,8 +537,12 @@ ${assistant.instruction}
     } catch {
       responseStream.write(
         streamingChunk({
-          text: 'An error occurred during streaming',
+          text: '',
           stopReason: 'error',
+          error: {
+            code: 'INTERNAL_ERROR' as ErrorCode,
+            message: 'An error occurred during streaming',
+          },
         })
       );
       responseStream.end();

--- a/packages/cdk/lambda/predictStream.ts
+++ b/packages/cdk/lambda/predictStream.ts
@@ -1,5 +1,5 @@
 import { Handler, Context } from 'aws-lambda';
-import { PredictRequest } from 'generative-ai-use-cases';
+import { PredictRequest, ErrorCode } from 'generative-ai-use-cases';
 import api from './utils/api';
 import { defaultModel } from './utils/models';
 import {
@@ -33,8 +33,12 @@ export const handler = awslambda.streamifyResponse(
       // Authorization check: Verify ID token and check LLM access with quota
       if (!event.idToken) {
         const errorMessage = JSON.stringify({
-          text: 'ID token is required for authorization',
+          text: '',
           stopReason: 'error',
+          error: {
+            code: 'INVALID_TOKEN' as ErrorCode,
+            message: 'ID token is required for authorization',
+          },
         });
         responseStream.write(errorMessage);
         responseStream.end();
@@ -50,33 +54,42 @@ export const handler = awslambda.streamifyResponse(
 
       if (!accessCheckResult.allowed) {
         const userId = accessCheckResult.userContext?.userId || 'unknown';
-        let errorText: string;
+        let errorCode: ErrorCode;
+        let errorMessage: string;
 
         switch (accessCheckResult.reason) {
           case 'quota_exceeded':
             console.warn(
               `User ${userId} has exceeded quota for model ${model.modelId}`
             );
-            errorText = `利用回数の上限に達しました: ${model.modelId}`;
+            errorCode = 'QUOTA_EXCEEDED';
+            errorMessage = `利用回数の上限に達しました: ${model.modelId}`;
             break;
           case 'no_permission':
             console.warn(
               `User ${userId} does not have access to model ${model.modelId}`
             );
-            errorText = `このモデルを使用する権限がありません: ${model.modelId}`;
+            errorCode = 'NO_PERMISSION';
+            errorMessage = `このモデルを使用する権限がありません: ${model.modelId}`;
             break;
           case 'invalid_token':
-            errorText = 'Invalid or expired ID token';
+            errorCode = 'INVALID_TOKEN';
+            errorMessage = 'Invalid or expired ID token';
             break;
           default:
-            errorText = `You do not have permission to use the model: ${model.modelId}`;
+            errorCode = 'NO_PERMISSION';
+            errorMessage = `You do not have permission to use the model: ${model.modelId}`;
         }
 
-        const errorMessage = JSON.stringify({
-          text: errorText,
+        const errorResponse = JSON.stringify({
+          text: '',
           stopReason: 'error',
+          error: {
+            code: errorCode,
+            message: errorMessage,
+          },
         });
-        responseStream.write(errorMessage);
+        responseStream.write(errorResponse);
         responseStream.end();
         return;
       }
@@ -121,11 +134,15 @@ export const handler = awslambda.streamifyResponse(
       responseStream.end();
     } catch (error) {
       console.error('PredictStream error:', error);
-      const errorMessage = JSON.stringify({
-        text: 'Internal Server Error',
+      const errorResponse = JSON.stringify({
+        text: '',
         stopReason: 'error',
+        error: {
+          code: 'INTERNAL_ERROR' as ErrorCode,
+          message: 'Internal Server Error',
+        },
       });
-      responseStream.write(errorMessage);
+      responseStream.write(errorResponse);
       responseStream.end();
     }
   }

--- a/packages/cdk/lambda/utils/bedrockApi.ts
+++ b/packages/cdk/lambda/utils/bedrockApi.ts
@@ -14,6 +14,7 @@ import {
 import {
   ApiInterface,
   BedrockImageGenerationResponse,
+  ErrorCode,
   GenerateImageParams,
   GenerateVideoParams,
   Model,
@@ -156,22 +157,34 @@ const bedrockApi: Omit<ApiInterface, 'invokeFlow'> = {
         e instanceof ServiceQuotaExceededException
       ) {
         yield streamingChunk({
-          text: 'The server is currently experiencing high access. Please try again later.',
+          text: '',
           stopReason: 'error',
+          error: {
+            code: 'THROTTLED' as ErrorCode,
+            message: 'The server is currently experiencing high access. Please try again later.',
+          },
         });
       } else if (e instanceof AccessDeniedException) {
         const modelAccessURL = `https://${region}.console.aws.amazon.com/bedrock/home?region=${region}#/modelaccess`;
         yield streamingChunk({
-          text: `The selected model is not enabled. Please enable the model in the [Bedrock console Model Access screen](${modelAccessURL}).`,
+          text: '',
           stopReason: 'error',
+          error: {
+            code: 'MODEL_NOT_ENABLED' as ErrorCode,
+            message: `The selected model is not enabled. Please enable the model in the [Bedrock console Model Access screen](${modelAccessURL}).`,
+          },
         });
       } else {
         console.error(e);
         yield streamingChunk({
-          text:
-            'An error occurred. Please report the following error to the administrator.\n' +
-            e,
+          text: '',
           stopReason: 'error',
+          error: {
+            code: 'INTERNAL_ERROR' as ErrorCode,
+            message:
+              'An error occurred. Please report the following error to the administrator.\n' +
+              e,
+          },
         });
       }
     }

--- a/packages/cdk/lambda/utils/liteLlmApi.ts
+++ b/packages/cdk/lambda/utils/liteLlmApi.ts
@@ -1,5 +1,6 @@
 import {
   ApiInterface,
+  ErrorCode,
   ExtraData,
   GenerateImageParams,
   GenerateVideoParams,
@@ -270,98 +271,142 @@ const liteLlmApi: ApiInterface = {
     const litellmEndpoint = process.env.LITELLM_ENDPOINT;
 
     if (!litellmEndpoint) {
-      throw new Error('LITELLM_ENDPOINT environment variable is not set');
+      yield streamingChunk({
+        text: '',
+        stopReason: 'error',
+        error: {
+          code: 'INTERNAL_ERROR' as ErrorCode,
+          message: 'LITELLM_ENDPOINT environment variable is not set',
+        },
+      });
+      return;
     }
-
-    const openAIMessages = await createOpenAIChatCompletionMessages(messages);
-    const requestBody = {
-      model: model.modelId,
-      messages: openAIMessages,
-      stream: true,
-    };
-
-    const signedRequest = await createSignedRequest(
-      litellmEndpoint,
-      requestBody
-    );
-
-    const fullUrl = litellmEndpoint.endsWith('/')
-      ? litellmEndpoint + 'chat/completions'
-      : litellmEndpoint + '/chat/completions';
-
-    const response = await fetch(fullUrl, {
-      method: signedRequest.method,
-      headers: signedRequest.headers,
-      body: JSON.stringify(requestBody),
-    });
-
-    if (!response.ok) {
-      const errorText = await response.text();
-      throw new Error(
-        `LiteLLM API request failed: ${response.status} - ${errorText}`
-      );
-    }
-
-    const reader = response.body?.getReader();
-    if (!reader) {
-      throw new Error('Failed to get response reader');
-    }
-
-    const decoder = new TextDecoder();
-    let buffer = '';
 
     try {
-      while (true) {
-        const { done, value } = await reader.read();
+      const openAIMessages = await createOpenAIChatCompletionMessages(messages);
+      const requestBody = {
+        model: model.modelId,
+        messages: openAIMessages,
+        stream: true,
+      };
 
-        if (done) {
-          break;
+      const signedRequest = await createSignedRequest(
+        litellmEndpoint,
+        requestBody
+      );
+
+      const fullUrl = litellmEndpoint.endsWith('/')
+        ? litellmEndpoint + 'chat/completions'
+        : litellmEndpoint + '/chat/completions';
+
+      const response = await fetch(fullUrl, {
+        method: signedRequest.method,
+        headers: signedRequest.headers,
+        body: JSON.stringify(requestBody),
+      });
+
+      if (!response.ok) {
+        const errorText = await response.text();
+        console.error(`LiteLLM API request failed: ${response.status} - ${errorText}`);
+
+        // Determine error code based on status
+        let errorCode: ErrorCode = 'INTERNAL_ERROR';
+        if (response.status === 429) {
+          errorCode = 'THROTTLED';
+        } else if (response.status === 401 || response.status === 403) {
+          errorCode = 'NO_PERMISSION';
         }
 
-        if (value) {
-          const decodedChunk = decoder.decode(value, { stream: true });
-          buffer += decodedChunk;
-          const lines = buffer.split('\n');
-          buffer = lines.pop() || '';
+        yield streamingChunk({
+          text: '',
+          stopReason: 'error',
+          error: {
+            code: errorCode,
+            message: `LiteLLM API request failed: ${response.status} - ${errorText}`,
+          },
+        });
+        return;
+      }
 
-          for (const line of lines) {
-            if (line.trim() === '') continue;
+      const reader = response.body?.getReader();
+      if (!reader) {
+        yield streamingChunk({
+          text: '',
+          stopReason: 'error',
+          error: {
+            code: 'INTERNAL_ERROR' as ErrorCode,
+            message: 'Failed to get response reader',
+          },
+        });
+        return;
+      }
 
-            if (line.startsWith('data: ')) {
-              const data = line.slice(6);
+      const decoder = new TextDecoder();
+      let buffer = '';
 
-              if (data === '[DONE]') {
-                yield streamingChunk({
-                  text: '',
-                  stopReason: StopReason.STOP_SEQUENCE,
-                });
-                return;
-              }
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
 
-              try {
-                const parsed = JSON.parse(data);
-                const choice = parsed.choices?.[0];
+          if (done) {
+            break;
+          }
 
-                if (choice?.finish_reason) {
-                  const stopReason = convertFinishReason(choice.finish_reason);
+          if (value) {
+            const decodedChunk = decoder.decode(value, { stream: true });
+            buffer += decodedChunk;
+            const lines = buffer.split('\n');
+            buffer = lines.pop() || '';
+
+            for (const line of lines) {
+              if (line.trim() === '') continue;
+
+              if (line.startsWith('data: ')) {
+                const data = line.slice(6);
+
+                if (data === '[DONE]') {
                   yield streamingChunk({
                     text: '',
-                    stopReason: stopReason,
+                    stopReason: StopReason.STOP_SEQUENCE,
                   });
-                } else if (choice?.delta?.content) {
-                  yield streamingChunk({
-                    text: choice.delta.content,
-                  });
+                  return;
                 }
-              } catch (e) {
-                console.warn('Failed to parse SSE data:', e);
+
+                try {
+                  const parsed = JSON.parse(data);
+                  const choice = parsed.choices?.[0];
+
+                  if (choice?.finish_reason) {
+                    const stopReason = convertFinishReason(choice.finish_reason);
+                    yield streamingChunk({
+                      text: '',
+                      stopReason: stopReason,
+                    });
+                  } else if (choice?.delta?.content) {
+                    yield streamingChunk({
+                      text: choice.delta.content,
+                    });
+                  }
+                } catch (e) {
+                  console.warn('Failed to parse SSE data:', e);
+                }
               }
             }
           }
         }
+      } finally {
+        reader.releaseLock();
       }
-    } finally {
-      reader.releaseLock();
+    } catch (e) {
+      console.error('LiteLLM streaming error:', e);
+      yield streamingChunk({
+        text: '',
+        stopReason: 'error',
+        error: {
+          code: 'INTERNAL_ERROR' as ErrorCode,
+          message: `An error occurred during LiteLLM streaming: ${e}`,
+        },
+      });
     }
   },
   generateImage: function (

--- a/packages/types/src/protocol.d.ts
+++ b/packages/types/src/protocol.d.ts
@@ -11,6 +11,26 @@ import {
   RetrieveCommandOutput,
 } from '@aws-sdk/client-kendra';
 import { StopReason } from '@aws-sdk/client-bedrock-runtime';
+
+// エラーコード定義
+export type ErrorCode =
+  | 'QUOTA_EXCEEDED' // 利用回数上限
+  | 'NO_PERMISSION' // 権限なし
+  | 'INVALID_TOKEN' // トークン無効
+  | 'INTERNAL_ERROR' // 内部エラー
+  | 'THROTTLED' // スロットリング
+  | 'MODEL_NOT_ENABLED' // モデル未有効化
+  | 'ASSISTANT_NOT_FOUND' // アシスタントが見つからない
+  | 'ACCESS_DENIED' // アクセス拒否
+  | 'MODEL_NOT_CONFIGURED' // モデル未設定
+  | 'DOCUMENT_INDEXING' // ドキュメントインデックス中
+  | 'SYSTEM_PROMPT_NOT_SET'; // システムプロンプト未設定
+
+// 構造化エラー情報
+export type StreamingError = {
+  code: ErrorCode;
+  message: string;
+};
 import {
   FlowInputContent,
   RetrieveCommandOutput as RetrieveCommandOutputKnowledgeBase,
@@ -29,6 +49,8 @@ export type StreamingChunk = {
     daily?: { current: number; limit: number; remaining: number };
     monthly?: { current: number; limit: number; remaining: number };
   };
+  // 構造化エラー情報
+  error?: StreamingError;
 };
 
 export type Pagination<T> = {


### PR DESCRIPTION
## 変更の概要

- 生成時のエラーを回答のテキストではなく、エラーとしてフロントに返す

<!-- どのような変更を行ったかを書く -->

## 申し送り事項

<!-- レビュワーに伝えておきたい事柄等を書く（Draftの理由など） -->

## Checklist（レビュワー用）

- [ ] `npm run lint`でエラーが出ない
- [ ] TypeScriptのビルドで型エラーが出ない
- [ ] 手元でフォーマットした際に差分が出ない
