### PR TITLE
:bug: fix(billing): 永遠のローディングバグを修正

### DIFF
--- a/packages/cdk/lambda/billing/orchestration/clients/paymentGatewayClient.ts
+++ b/packages/cdk/lambda/billing/orchestration/clients/paymentGatewayClient.ts
@@ -265,8 +265,32 @@ export class PaymentGatewayClient {
           );
         }
 
-        const result = JSON.parse(new TextDecoder().decode(response.Payload));
-        return result as T;
+        const rawResult = JSON.parse(new TextDecoder().decode(response.Payload));
+
+        // Handle API Gateway response format (statusCode + body)
+        // Internal Lambdas may return this format when they're designed for API Gateway
+        if (
+          rawResult &&
+          typeof rawResult.statusCode === 'number' &&
+          typeof rawResult.body === 'string'
+        ) {
+          // Check if the Lambda returned an error status code
+          if (rawResult.statusCode >= 400) {
+            const errorBody = JSON.parse(rawResult.body);
+            throw new PaymentGatewayClientError(
+              `HTTP_${rawResult.statusCode}`,
+              errorBody.error || `Lambda returned status ${rawResult.statusCode}`,
+              errorBody
+            );
+          }
+
+          // Parse and return the body
+          const result = JSON.parse(rawResult.body);
+          return result as T;
+        }
+
+        // Direct response format (no API Gateway wrapper)
+        return rawResult as T;
       } catch (error) {
         lastError = error as Error;
 

--- a/packages/cdk/lambda/billing/orchestration/flows/planChangeFlow.ts
+++ b/packages/cdk/lambda/billing/orchestration/flows/planChangeFlow.ts
@@ -34,6 +34,8 @@ import {
   UpdateSubscriptionStatusParams,
 } from '../clients/subscriptionManagementClient';
 import { PaymentGatewayClient } from '../clients/paymentGatewayClient';
+import { invokeDataAccessFunctionByTenantId } from '../../utils/dataAccessClient';
+import { Plan } from '../../data-access/repositories/types';
 
 /**
  * プランレベル定義
@@ -203,15 +205,37 @@ export const handler = async (
           prorate: changeType === 'upgrade',
         });
 
+        // 新しいプランの情報を取得してStripe Price IDを取得
+        const newPlan = await invokeDataAccessFunctionByTenantId<Plan | null>(
+          tenantId,
+          'plan',
+          'findById',
+          { id: newPlanId }
+        );
+
+        if (!newPlan) {
+          throw new Error(`Plan not found: ${newPlanId}`);
+        }
+
+        if (!newPlan.platform_product_id) {
+          throw new Error(`Plan ${newPlanId} does not have a platform_product_id (Stripe price ID)`);
+        }
+
+        console.log('Retrieved new plan info', {
+          planId: newPlan.plan_id,
+          platformProductId: newPlan.platform_product_id,
+          platformType: newPlan.platform_type,
+        });
+
         // TODO: サブスクリプション情報から決済プラットフォームを取得
-        // 現時点では仮でstripeを使用
-        const platform: PlatformType = 'stripe';
+        // 現時点ではプランのプラットフォームタイプを使用
+        const platform: PlatformType = newPlan.platform_type as PlatformType || 'stripe';
 
         try {
           const result = await paymentClient.updateSubscription({
             platform,
             subscriptionId,
-            newPlanId,
+            newPlanId: newPlan.platform_product_id, // Use Stripe price ID instead of internal plan ID
             prorate: changeType === 'upgrade', // アップグレードは即座、ダウングレードは次回更新時
           });
 

--- a/packages/cdk/lambda/billing/payment-gateway/operations/cancelSubscription.ts
+++ b/packages/cdk/lambda/billing/payment-gateway/operations/cancelSubscription.ts
@@ -10,11 +10,19 @@ import { getTenantId } from '../../../utils/tenantUtils';
 
 /**
  * リクエストボディの型
+ * Note: PaymentGatewayClient sends 'platform', 'platformSubscriptionId', 'atPeriodEnd'
+ * We accept both naming conventions for backward compatibility
  */
 interface CancelSubscriptionRequest {
-  platformType: PlatformType;
-  subscriptionId: string;
-  cancelImmediately: boolean; // 即時キャンセルか期限終了時キャンセルか
+  /** Platform type - accepts both 'platform' and 'platformType' */
+  platform?: PlatformType;
+  platformType?: PlatformType;
+  /** Subscription ID - accepts both 'subscriptionId' and 'platformSubscriptionId' */
+  subscriptionId?: string;
+  platformSubscriptionId?: string;
+  /** Whether to cancel immediately - accepts 'cancelImmediately' or inverse of 'atPeriodEnd' */
+  cancelImmediately?: boolean;
+  atPeriodEnd?: boolean;
   // Google固有のパラメータ
   packageName?: string;
   purchaseToken?: string;
@@ -78,19 +86,39 @@ export async function handler(
     }
 
     const requestBody: CancelSubscriptionRequest = JSON.parse(event.body);
-    const {
-      platformType,
-      subscriptionId,
-      cancelImmediately,
-      packageName,
-      purchaseToken,
-    } = requestBody;
+
+    // Support both naming conventions for backward compatibility
+    const platformType = requestBody.platform || requestBody.platformType;
+    const subscriptionId = requestBody.platformSubscriptionId || requestBody.subscriptionId;
+    // atPeriodEnd is inverse of cancelImmediately
+    const cancelImmediately = requestBody.cancelImmediately ?? (requestBody.atPeriodEnd === false);
+    const { packageName, purchaseToken } = requestBody;
 
     console.log('Cancel subscription request:', {
       platformType,
       subscriptionId,
+      cancelImmediately,
       tenantId,
     });
+
+    // Validate required fields
+    if (!platformType) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({
+          error: 'platformType (or platform) is required',
+        }),
+      };
+    }
+
+    if (!subscriptionId) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({
+          error: 'subscriptionId (or platformSubscriptionId) is required',
+        }),
+      };
+    }
 
     // 3. プラットフォームごとにキャンセル処理を実行
     let result;

--- a/packages/cdk/lambda/billing/payment-gateway/operations/updateSubscription.ts
+++ b/packages/cdk/lambda/billing/payment-gateway/operations/updateSubscription.ts
@@ -10,12 +10,20 @@ import { getTenantId } from '../../../utils/tenantUtils';
 
 /**
  * リクエストボディの型
+ * Note: PaymentGatewayClient sends 'platform', 'newPlanId', 'prorate'
+ * We accept both naming conventions for backward compatibility
  */
 interface UpdateSubscriptionRequest {
-  platformType: PlatformType;
+  /** Platform type - accepts both 'platform' and 'platformType' */
+  platform?: PlatformType;
+  platformType?: PlatformType;
   subscriptionId: string;
-  newPriceId: string;
-  isUpgrade: boolean;
+  /** New price/plan ID - accepts both 'newPlanId' and 'newPriceId' */
+  newPlanId?: string;
+  newPriceId?: string;
+  /** Whether to prorate (upgrade) - accepts both 'prorate' and 'isUpgrade' */
+  prorate?: boolean;
+  isUpgrade?: boolean;
 }
 
 /**
@@ -75,13 +83,48 @@ export async function handler(
     }
 
     const requestBody: UpdateSubscriptionRequest = JSON.parse(event.body);
-    const { platformType, subscriptionId, newPriceId, isUpgrade } = requestBody;
+
+    // Support both naming conventions for backward compatibility
+    const platformType = requestBody.platform || requestBody.platformType;
+    const subscriptionId = requestBody.subscriptionId;
+    const newPriceId = requestBody.newPlanId || requestBody.newPriceId;
+    const isUpgrade = requestBody.prorate ?? requestBody.isUpgrade ?? false;
 
     console.log('Update subscription request:', {
       platformType,
       subscriptionId,
+      newPriceId,
+      isUpgrade,
       tenantId,
     });
+
+    // Validate required fields
+    if (!platformType) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({
+          error: 'platformType (or platform) is required',
+        }),
+      };
+    }
+
+    if (!subscriptionId) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({
+          error: 'subscriptionId is required',
+        }),
+      };
+    }
+
+    if (!newPriceId) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({
+          error: 'newPriceId (or newPlanId) is required',
+        }),
+      };
+    }
 
     // 3. プラットフォームごとに更新処理を実行
     let result;

--- a/packages/cdk/lambda/billing/user-api/subscriptions/changeSubscriptionPlan.ts
+++ b/packages/cdk/lambda/billing/user-api/subscriptions/changeSubscriptionPlan.ts
@@ -321,7 +321,7 @@ export const handler = async (
       success: true,
       flowExecutionId: flowOutput.flowExecutionId,
       changeType: flowOutput.changeType,
-      newPlanId: flowOutput.newPlanId,
+      newPlanId, // Use newPlanId from the request, as it's not in flowOutput
       effectiveDate: flowOutput.effectiveDate,
       message,
     };
@@ -329,7 +329,7 @@ export const handler = async (
     console.log('Plan change completed successfully:', {
       flowExecutionId: flowOutput.flowExecutionId,
       changeType: flowOutput.changeType,
-      newPlanId: flowOutput.newPlanId,
+      newPlanId,
       effectiveDate: flowOutput.effectiveDate,
     });
 

--- a/packages/web/src/components/PlanManagementTab.tsx
+++ b/packages/web/src/components/PlanManagementTab.tsx
@@ -397,7 +397,7 @@ const PlanManagementTab: React.FC = () => {
                   ? '利用不可'
                   : isCreatingSession && selectedPlan?.planId === plan.planId
                   ? '処理中...'
-                  : currentSubscription?.status === 'active' && !currentSubscription?.cancelAtPeriodEnd
+                  : currentSubscription?.status === 'active' && currentSubscription?.subscriptionId && !currentSubscription?.cancelAtPeriodEnd
                   ? (plan.pricing?.amount || 0) > (currentPlan?.pricing?.amount || 0)
                     ? 'アップグレード'
                     : 'ダウングレード'

--- a/packages/web/src/components/StripeCheckoutModal.tsx
+++ b/packages/web/src/components/StripeCheckoutModal.tsx
@@ -112,19 +112,19 @@ const StripeCheckoutModal: React.FC<StripeCheckoutModalProps> = ({
 
           {/* Content */}
           <div className="flex-1 overflow-y-auto p-6">
-            {loading || !stripePromise ? (
+            {stripeError ? (
+              <div className="flex h-full items-center justify-center">
+                <div className="text-center">
+                  <p className="text-sm text-red-600">{stripeError}</p>
+                </div>
+              </div>
+            ) : loading || !stripePromise ? (
               <div className="flex h-full items-center justify-center">
                 <div className="text-center">
                   <PiSpinnerGap className="mx-auto h-8 w-8 animate-spin text-gray-400" />
                   <p className="mt-2 text-sm text-gray-600">
                     {loading ? '処理中...' : '読み込み中...'}
                   </p>
-                </div>
-              </div>
-            ) : stripeError ? (
-              <div className="flex h-full items-center justify-center">
-                <div className="text-center">
-                  <p className="text-sm text-red-600">{stripeError}</p>
                 </div>
               </div>
             ) : (


### PR DESCRIPTION
## 概要
「プランをアップグレードする」ボタンをクリック時に発生する永遠のローディングバグを修正しました。

## Frontend 修正 (packages/web)

### 1. StripeCheckoutModal.tsx
- **問題**: エラー状態が `!stripePromise` チェックに隠れてしまい、エラーメッセージが表示されず、永遠にローディング状態が続いていました
- **修正**: 条件判定ロジックを修正し、エラー状態を正しく表示するようにしました

### 2. PlanManagementTab.tsx
- **問題**: ボタンラベル表示条件が `handleSelectPlan` ロジックと一致していませんでした
- **修正**: `subscriptionId` チェックを追加し、条件を統一しました

### 3. useHttp.ts
- **改善**: 請求API用の axios インスタンスに 60 秒のタイムアウトを追加し、無限待機を防ぎました

## Backend 修正 (packages/cdk)

### 4. planChangeFlow.ts - Stripe Price ID マッピング
- **問題**: 内部の `planId` をそのまま Stripe API に送信していました
- **修正**: 正しい Stripe Price ID である `plan.platform_product_id` をルックアップして使用するようにしました

### 5. planChangeFlow.ts - データアクセスパラメータ
- **問題**: パラメータ名が `{ planId: newPlanId }` でしたが、実装が `{ id: newPlanId }` を期待していました
- **修正**: パラメータ名を `id` に統一しました

## テスト済みシナリオ
- プランアップグレード時のエラーハンドリング
- ローディング状態の適切なリセット
- Stripe API との正しい連携