### PR TITLE
:sparkles: feat(billing): サブスクリプション支払い方法更新API実装

### DIFF
--- a/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
+++ b/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
@@ -1063,6 +1063,14 @@ async function handlePaymentMethodUpdated(
   const extracted = stripeData._extracted ?? {};
   const { setupIntentId, platformSubscriptionId, customerId } = extracted;
 
+  console.log('Extracted data from event', {
+    setupIntentId,
+    platformSubscriptionId,
+    customerId,
+    hasExtracted: !!stripeData._extracted,
+    eventDataKeys: Object.keys(eventData),
+  });
+
   if (!setupIntentId) {
     throw new Error('SetupIntent ID not found in event data');
   }

--- a/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
+++ b/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
@@ -1008,6 +1008,8 @@ const stripeApiKeyCache: Record<string, string> = {};
 
 /**
  * Secrets ManagerからStripe APIキーを取得する
+ * コントロールプレーン（genu account）のSecrets Managerから取得
+ * テナント固有のシークレット名: {tenantId}/billing/stripe
  */
 async function getStripeApiKey(tenantId: string): Promise<string> {
   if (stripeApiKeyCache[tenantId]) {
@@ -1015,10 +1017,11 @@ async function getStripeApiKey(tenantId: string): Promise<string> {
   }
 
   const secretName = `${tenantId}/billing/stripe`;
-  const client = new SecretsManagerClient({});
-  const command = new GetSecretValueCommand({ SecretId: secretName });
 
   try {
+    // コントロールプレーンのSecrets Managerから取得（receiveWebhookと同じ方式）
+    const client = new SecretsManagerClient({ region: process.env.AWS_REGION });
+    const command = new GetSecretValueCommand({ SecretId: secretName });
     const response = await client.send(command);
 
     if (!response.SecretString) {

--- a/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
+++ b/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
@@ -988,7 +988,7 @@ function extractUserId(
 /**
  * Stripe APIキーのキャッシュ
  */
-let stripeApiKeyCache: { [key: string]: string } = {};
+const stripeApiKeyCache: Record<string, string> = {};
 
 /**
  * Secrets ManagerからStripe APIキーを取得する
@@ -1042,8 +1042,9 @@ async function handlePaymentMethodUpdated(
 
   console.log('Processing payment_method.updated event', { eventId, tenantId, platform });
 
-  // イベントデータから抽出情報を取得
-  const extracted = (eventData as any)._extracted || {};
+  // イベントデータから抽出情報を取得（Stripeプラットフォームのみ対応）
+  const stripeData: StripeEventData = eventData;
+  const extracted = stripeData._extracted ?? {};
   const { setupIntentId, platformSubscriptionId, customerId } = extracted;
 
   if (!setupIntentId) {

--- a/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
+++ b/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
@@ -107,16 +107,27 @@ interface WebhookEventFlowOutput {
 }
 
 /**
+ * EventBridgeイベントのdetailペイロード
+ * Payment Gatewayから送信されるEventDetail形式
+ */
+interface EventDetailPayload {
+  eventId: string;
+  tenantId: string;
+  platform: PlatformType;
+  eventData: Record<string, unknown>;
+}
+
+/**
  * EventBridgeイベント構造
  * EventBridgeから渡されるイベント全体を表す型
  */
 interface EventBridgeEvent {
   /** イベントソース（例: "billing.payment-gateway"） */
   source: string;
-  /** イベント詳細タイプ（例: "Stripe Webhook Event"） */
+  /** イベント詳細タイプ（ビジネスイベントタイプ: "payment_method.updated" など） */
   'detail-type': string;
-  /** イベントペイロード */
-  detail: WebhookEventFlowInput;
+  /** イベントペイロード（EventDetail形式） */
+  detail: EventDetailPayload;
 }
 
 /**
@@ -131,14 +142,18 @@ export const handler = async (
   event: EventBridgeEvent
 ): Promise<WebhookEventFlowOutput> => {
   // EventBridgeイベントからdetailを抽出
-  const input: WebhookEventFlowInput = event.detail;
-  const { eventId, tenantId, platform, eventType, eventData } = input;
+  // Note: event['detail-type'] contains the business event type (e.g., 'payment_method.updated')
+  //       event.detail contains the EventDetail object with originalEventType
+  const input = event.detail;
+  const { eventId, tenantId, platform, eventData } = input;
+  // Use detail-type as the business event type (already normalized by eventMapper)
+  const businessEventType = event['detail-type'];
 
   console.log('Webhook event flow started', {
     eventId,
     tenantId,
     platform,
-    eventType,
+    businessEventType,
   });
 
   // クライアントのインスタンス化
@@ -148,11 +163,12 @@ export const handler = async (
 
   // イベントタイプごとに処理を分岐
   try {
-    // イベントタイプの正規化（プラットフォーム固有のイベント名を共通イベント名にマッピング）
-    const normalizedEventType = normalizeEventType(platform, eventType);
+    // EventBridgeのdetail-typeは既にビジネスイベントタイプに正規化されている
+    // Stripeの場合: eventMapperで checkout.session.completed → payment_method.updated に変換済み
+    const normalizedEventType = normalizeEventType(platform, businessEventType as WebhookEventType);
 
     console.log('Normalized event type', {
-      originalEventType: eventType,
+      businessEventType,
       normalizedEventType,
       platform,
     });
@@ -198,7 +214,7 @@ export const handler = async (
 
       default:
         console.warn('Unknown event type, skipping processing', {
-          eventType,
+          businessEventType,
           normalizedEventType,
           platform,
         });
@@ -210,7 +226,7 @@ export const handler = async (
           eventId,
           errorDetails: {
             errorCode: 'UNKNOWN_EVENT_TYPE',
-            errorMessage: `Unknown event type: ${eventType}`,
+            errorMessage: `Unknown event type: ${businessEventType}`,
           },
         };
     }
@@ -221,7 +237,7 @@ export const handler = async (
       eventId,
       tenantId,
       platform,
-      eventType,
+      businessEventType,
       error: err.message,
       stack: err.stack,
     });
@@ -302,7 +318,7 @@ function normalizeEventType(
  * @returns 処理結果
  */
 async function handlePaymentSucceeded(
-  input: WebhookEventFlowInput,
+  input: EventDetailPayload,
   orchestrator: FlowOrchestrator,
   planClient: PlanManagementClient,
   subscriptionClient: SubscriptionManagementClient
@@ -447,7 +463,7 @@ async function handlePaymentSucceeded(
  * @returns 処理結果
  */
 async function handlePaymentFailed(
-  input: WebhookEventFlowInput,
+  input: EventDetailPayload,
   orchestrator: FlowOrchestrator,
   subscriptionClient: SubscriptionManagementClient
 ): Promise<WebhookEventFlowOutput> {
@@ -542,7 +558,7 @@ async function handlePaymentFailed(
  * @returns 処理結果
  */
 async function handleSubscriptionCanceled(
-  input: WebhookEventFlowInput,
+  input: EventDetailPayload,
   orchestrator: FlowOrchestrator,
   subscriptionClient: SubscriptionManagementClient
 ): Promise<WebhookEventFlowOutput> {
@@ -639,7 +655,7 @@ async function handleSubscriptionCanceled(
  * @returns 処理結果
  */
 async function handleRefundCreated(
-  input: WebhookEventFlowInput,
+  input: EventDetailPayload,
   orchestrator: FlowOrchestrator,
   planClient: PlanManagementClient,
   subscriptionClient: SubscriptionManagementClient
@@ -1033,7 +1049,7 @@ async function getStripeApiKey(tenantId: string): Promise<string> {
  * @returns 処理結果
  */
 async function handlePaymentMethodUpdated(
-  input: WebhookEventFlowInput,
+  input: EventDetailPayload,
   orchestrator: FlowOrchestrator,
   tenantId: string
 ): Promise<WebhookEventFlowOutput> {

--- a/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
+++ b/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
@@ -30,6 +30,11 @@
  * - 最大リトライ回数3回、指数バックオフ（EventBridge側で制御される）
  */
 
+import Stripe from 'stripe';
+import {
+  SecretsManagerClient,
+  GetSecretValueCommand,
+} from '@aws-sdk/client-secrets-manager';
 import { FlowOrchestrator } from '../services/flowOrchestrator';
 import {
   WebhookEventFlowInput,
@@ -184,6 +189,13 @@ export const handler = async (
           subscriptionClient
         );
 
+      case 'payment_method.updated':
+        return await handlePaymentMethodUpdated(
+          input,
+          orchestrator,
+          tenantId
+        );
+
       default:
         console.warn('Unknown event type, skipping processing', {
           eventType,
@@ -234,10 +246,10 @@ export const handler = async (
 function normalizeEventType(
   platform: PlatformType,
   eventType: WebhookEventType
-): 'payment.succeeded' | 'payment.failed' | 'subscription.canceled' | 'refund.created' | 'unknown' {
+): 'payment.succeeded' | 'payment.failed' | 'subscription.canceled' | 'refund.created' | 'payment_method.updated' | 'unknown' {
   // Stripeのイベントはそのまま使用
   if (platform === 'stripe') {
-    return eventType as 'payment.succeeded' | 'payment.failed' | 'subscription.canceled' | 'refund.created';
+    return eventType as 'payment.succeeded' | 'payment.failed' | 'subscription.canceled' | 'refund.created' | 'payment_method.updated';
   }
 
   // Appleのイベントをマッピング
@@ -971,4 +983,153 @@ function extractUserId(
   // Apple/Googleの場合は、イベントデータからユーザIDを直接取得できない
   // サブスクリプション情報から取得する必要がある
   return undefined;
+}
+
+/**
+ * Stripe APIキーのキャッシュ
+ */
+let stripeApiKeyCache: { [key: string]: string } = {};
+
+/**
+ * Secrets ManagerからStripe APIキーを取得する
+ */
+async function getStripeApiKey(tenantId: string): Promise<string> {
+  if (stripeApiKeyCache[tenantId]) {
+    return stripeApiKeyCache[tenantId];
+  }
+
+  const secretName = `${tenantId}/billing/stripe`;
+  const client = new SecretsManagerClient({});
+  const command = new GetSecretValueCommand({ SecretId: secretName });
+
+  try {
+    const response = await client.send(command);
+
+    if (!response.SecretString) {
+      throw new Error(`Secret ${secretName} is empty`);
+    }
+
+    const secret = JSON.parse(response.SecretString);
+    stripeApiKeyCache[tenantId] = secret.apiKey;
+
+    return secret.apiKey;
+  } catch (error) {
+    console.error('Failed to retrieve Stripe API key:', error);
+    throw new Error('Failed to retrieve payment configuration');
+  }
+}
+
+/**
+ * payment_method.updated（支払い方法更新）イベントを処理
+ *
+ * 処理ステップ:
+ * 1. SetupIntentから新しい支払い方法IDを取得
+ * 2. サブスクリプションのdefault_payment_methodを更新
+ * 3. 顧客のinvoice_settings.default_payment_methodを更新（オプション）
+ *
+ * @param input Webhookイベント入力
+ * @param orchestrator フローオーケストレーター
+ * @param tenantId テナントID
+ * @returns 処理結果
+ */
+async function handlePaymentMethodUpdated(
+  input: WebhookEventFlowInput,
+  orchestrator: FlowOrchestrator,
+  tenantId: string
+): Promise<WebhookEventFlowOutput> {
+  const { eventId, platform, eventData } = input;
+  const userId = extractUserId(platform, eventData);
+
+  console.log('Processing payment_method.updated event', { eventId, tenantId, platform });
+
+  // イベントデータから抽出情報を取得
+  const extracted = (eventData as any)._extracted || {};
+  const { setupIntentId, platformSubscriptionId, customerId } = extracted;
+
+  if (!setupIntentId) {
+    throw new Error('SetupIntent ID not found in event data');
+  }
+
+  if (!platformSubscriptionId) {
+    throw new Error('Platform subscription ID not found in event data');
+  }
+
+  // ステップ設定
+  const steps: StepConfig[] = [
+    {
+      stepName: 'update_subscription_payment_method',
+      stepType: 'api_call',
+      targetService: 'Stripe',
+      executeFunction: async () => {
+        console.log('Updating subscription payment method', {
+          tenantId,
+          platformSubscriptionId,
+          setupIntentId,
+        });
+
+        // Stripe APIキーを取得
+        const apiKey = await getStripeApiKey(tenantId);
+        const stripe = new Stripe(apiKey, { apiVersion: '2025-10-29.clover' });
+
+        // SetupIntentから支払い方法IDを取得
+        const setupIntent = await stripe.setupIntents.retrieve(setupIntentId);
+        const newPaymentMethodId =
+          typeof setupIntent.payment_method === 'string'
+            ? setupIntent.payment_method
+            : setupIntent.payment_method?.id;
+
+        if (!newPaymentMethodId) {
+          throw new Error('Payment method not found on SetupIntent');
+        }
+
+        console.log('Retrieved payment method from SetupIntent', {
+          setupIntentId,
+          newPaymentMethodId,
+        });
+
+        // サブスクリプションのdefault_payment_methodを更新
+        await stripe.subscriptions.update(platformSubscriptionId, {
+          default_payment_method: newPaymentMethodId,
+        });
+
+        console.log('Subscription payment method updated', {
+          platformSubscriptionId,
+          newPaymentMethodId,
+        });
+
+        // 顧客のinvoice_settings.default_payment_methodも更新（オプション）
+        if (customerId) {
+          await stripe.customers.update(customerId, {
+            invoice_settings: {
+              default_payment_method: newPaymentMethodId,
+            },
+          });
+
+          console.log('Customer invoice settings updated', {
+            customerId,
+            newPaymentMethodId,
+          });
+        }
+
+        return {
+          success: true,
+          newPaymentMethodId,
+          platformSubscriptionId,
+        };
+      },
+      retryable: true,
+      maxRetries: 3,
+    },
+  ];
+
+  // フロー実行
+  return await executeWebhookEventFlow(
+    orchestrator,
+    'webhook_event',
+    userId || 'unknown',
+    `${platform}_webhook`,
+    input,
+    steps,
+    eventId
+  );
 }

--- a/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
+++ b/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
@@ -198,6 +198,7 @@ export const handler = async (
         );
 
       case 'refund.created':
+      case 'payment.refunded':
         return await handleRefundCreated(
           input,
           orchestrator,
@@ -262,10 +263,10 @@ export const handler = async (
 function normalizeEventType(
   platform: PlatformType,
   eventType: WebhookEventType
-): 'payment.succeeded' | 'payment.failed' | 'subscription.canceled' | 'refund.created' | 'payment_method.updated' | 'unknown' {
+): 'payment.succeeded' | 'payment.failed' | 'subscription.canceled' | 'refund.created' | 'payment.refunded' | 'payment_method.updated' | 'unknown' {
   // Stripeのイベントはそのまま使用
   if (platform === 'stripe') {
-    return eventType as 'payment.succeeded' | 'payment.failed' | 'subscription.canceled' | 'refund.created' | 'payment_method.updated';
+    return eventType as 'payment.succeeded' | 'payment.failed' | 'subscription.canceled' | 'refund.created' | 'payment.refunded' | 'payment_method.updated';
   }
 
   // Appleのイベントをマッピング

--- a/packages/cdk/lambda/billing/orchestration/repositories/flowStepExecutionRepository.ts
+++ b/packages/cdk/lambda/billing/orchestration/repositories/flowStepExecutionRepository.ts
@@ -14,6 +14,7 @@ import {
   QueryCommand,
 } from '@aws-sdk/lib-dynamodb';
 import { StepExecution, StepStatus } from '../types';
+import { createTenantDynamoDBClientForBackgroundJob } from '../../../utils/tenantDynamoDBClient';
 
 /**
  * FlowStepExecutionRepository
@@ -24,17 +25,35 @@ import { StepExecution, StepStatus } from '../types';
  * Primary Key: flowExecutionId (PK), stepSequence (SK)
  */
 export class FlowStepExecutionRepository {
-  private readonly docClient: DynamoDBDocumentClient;
+  private docClient: DynamoDBDocumentClient | null = null;
   private readonly tenantId: string;
 
   constructor(tenantId: string, client?: DynamoDBClient) {
-    const dynamoClient = client || new DynamoDBClient({});
-    this.docClient = DynamoDBDocumentClient.from(dynamoClient, {
-      marshallOptions: {
-        removeUndefinedValues: true,
-      },
-    });
     this.tenantId = tenantId;
+    // クライアントが指定された場合は同期的に使用（テスト用）
+    if (client) {
+      this.docClient = DynamoDBDocumentClient.from(client, {
+        marshallOptions: {
+          removeUndefinedValues: true,
+        },
+      });
+    }
+  }
+
+  /**
+   * DynamoDB Document Clientを取得（遅延初期化）
+   * createTenantDynamoDBClientForBackgroundJobを使用してテナント固有のクライアントを作成
+   */
+  private async getDocClient(): Promise<DynamoDBDocumentClient> {
+    if (!this.docClient) {
+      const dynamoClient = await createTenantDynamoDBClientForBackgroundJob(this.tenantId);
+      this.docClient = DynamoDBDocumentClient.from(dynamoClient, {
+        marshallOptions: {
+          removeUndefinedValues: true,
+        },
+      });
+    }
+    return this.docClient;
   }
 
   /**
@@ -51,6 +70,8 @@ export class FlowStepExecutionRepository {
    * @throws {Error} If the DynamoDB operation fails
    */
   async create(stepExecution: StepExecution): Promise<void> {
+    const docClient = await this.getDocClient();
+
     try {
       // Set TTL to 1 year from now (Unix timestamp in seconds)
       const ttl = Math.floor(Date.now() / 1000) + 365 * 24 * 60 * 60;
@@ -65,7 +86,7 @@ export class FlowStepExecutionRepository {
         Item: item,
       });
 
-      await this.docClient.send(command);
+      await docClient.send(command);
       console.log(
         `Created step execution: ${stepExecution.flowExecutionId}/${stepExecution.stepSequence} for tenant: ${this.tenantId}`
       );
@@ -100,6 +121,8 @@ export class FlowStepExecutionRepository {
       duration?: number;
     }
   ): Promise<void> {
+    const docClient = await this.getDocClient();
+
     try {
       // Build update expression dynamically
       const updateExpressions: string[] = [];
@@ -157,7 +180,7 @@ export class FlowStepExecutionRepository {
         ExpressionAttributeValues: expressionAttributeValues,
       });
 
-      await this.docClient.send(command);
+      await docClient.send(command);
       console.log(
         `Updated step execution: ${flowExecutionId}/${stepSequence} for tenant: ${this.tenantId}`
       );
@@ -180,6 +203,8 @@ export class FlowStepExecutionRepository {
    * @throws {Error} If the DynamoDB operation fails
    */
   async listByFlowExecution(flowExecutionId: string): Promise<StepExecution[]> {
+    const docClient = await this.getDocClient();
+
     try {
       const command = new QueryCommand({
         TableName: this.getTableName(),
@@ -190,7 +215,7 @@ export class FlowStepExecutionRepository {
         ScanIndexForward: true, // Sort by stepSequence ASC
       });
 
-      const response = await this.docClient.send(command);
+      const response = await docClient.send(command);
 
       return (response.Items || []) as StepExecution[];
     } catch (error) {

--- a/packages/cdk/lambda/billing/orchestration/types/eventTypes.ts
+++ b/packages/cdk/lambda/billing/orchestration/types/eventTypes.ts
@@ -20,6 +20,7 @@ export type WebhookEventType =
   | 'payment.failed'
   | 'subscription.canceled'
   | 'refund.created'
+  | 'payment_method.updated'
   // Apple events (App Store Server Notifications)
   | 'RENEWAL'
   | 'DID_FAIL_TO_RENEW'
@@ -86,6 +87,19 @@ export interface StripeEventData {
 
   /** 請求書ID */
   invoiceId?: string;
+
+  /** SetupIntent ID（payment_method.updated時） */
+  setupIntentId?: string;
+
+  /** プラットフォームサブスクリプションID（payment_method.updated時） */
+  platformSubscriptionId?: string;
+
+  /** 抽出された詳細情報（payment_method.updated時） */
+  _extracted?: {
+    setupIntentId?: string;
+    platformSubscriptionId?: string;
+    customerId?: string;
+  };
 
   /** その他のStripe固有データ */
   [key: string]: unknown;

--- a/packages/cdk/lambda/billing/payment-gateway/types/businessEvent.ts
+++ b/packages/cdk/lambda/billing/payment-gateway/types/businessEvent.ts
@@ -1,11 +1,12 @@
 /**
- * ビジネスイベントタイプ（統括責務が処理する4つのイベント）
+ * ビジネスイベントタイプ（統括責務が処理する5つのイベント）
  */
 export type BusinessEventType =
   | 'payment.succeeded' // 支払い更新成功
   | 'payment.failed' // 支払い失敗
   | 'subscription.canceled' // サブスクリプションキャンセル
-  | 'payment.refunded'; // 返金
+  | 'payment.refunded' // 返金
+  | 'payment_method.updated'; // 支払い方法更新
 
 /**
  * イベント詳細情報
@@ -46,6 +47,12 @@ export interface EventDetail {
 
   /** エラーメッセージ（payment.failed時に含まれる） */
   errorMessage?: string;
+
+  /** 新しい支払い方法ID（payment_method.updated時に含まれる） */
+  newPaymentMethodId?: string;
+
+  /** プラットフォーム固有のサブスクリプションID（payment_method.updated時に含まれる） */
+  platformSubscriptionId?: string;
 
   /** プラットフォーム固有の生イベントデータ（詳細調査用） */
   eventData: Record<string, any>;

--- a/packages/cdk/lambda/billing/payment-gateway/webhook/stripe/eventExtractor.ts
+++ b/packages/cdk/lambda/billing/payment-gateway/webhook/stripe/eventExtractor.ts
@@ -29,6 +29,9 @@ export async function extractEventDetail(
     case 'charge.refunded':
       return extractFromChargeRefunded(stripeEvent, tenantId);
 
+    case 'checkout.session.completed':
+      return extractFromCheckoutSessionCompleted(stripeEvent, tenantId);
+
     default:
       throw new Error(`Unsupported event type: ${eventType}`);
   }
@@ -241,5 +244,71 @@ function extractFromChargeRefunded(
     currency,
     platformPaymentId,
     eventData: stripeEvent,
+  };
+}
+
+/**
+ * checkout.session.completed（setup mode）からの情報抽出
+ *
+ * 支払い方法更新のためのCheckout Session完了イベントを処理します。
+ */
+function extractFromCheckoutSessionCompleted(
+  stripeEvent: Stripe.Event,
+  tenantId: string
+): Partial<EventDetail> {
+  const session = stripeEvent.data.object as Stripe.Checkout.Session;
+
+  // setup modeのみ処理
+  if (session.mode !== 'setup') {
+    throw new Error(`Unsupported checkout session mode: ${session.mode}`);
+  }
+
+  // SetupIntentのIDを取得
+  const setupIntentId =
+    typeof session.setup_intent === 'string'
+      ? session.setup_intent
+      : session.setup_intent?.id;
+
+  if (!setupIntentId) {
+    throw new Error('SetupIntent ID not found in checkout session');
+  }
+
+  // メタデータからサブスクリプション情報を取得
+  const metadata = session.metadata || {};
+  const subscriptionId = metadata.subscription_id || '';
+  const platformSubscriptionId = metadata.platform_subscription_id || '';
+  const userId = metadata.user_id || '';
+
+  // 顧客IDを取得
+  const customerId =
+    typeof session.customer === 'string'
+      ? session.customer
+      : session.customer?.id;
+
+  if (!subscriptionId) {
+    console.warn('subscription_id not found in session metadata');
+  }
+
+  if (!userId) {
+    console.warn('user_id not found in session metadata');
+  }
+
+  return {
+    platform: 'stripe',
+    tenantId,
+    eventId: stripeEvent.id,
+    originalEventType: stripeEvent.type,
+    subscriptionId,
+    userId,
+    platformPaymentId: setupIntentId, // SetupIntent IDを格納
+    platformSubscriptionId,
+    eventData: {
+      ...stripeEvent,
+      _extracted: {
+        setupIntentId,
+        platformSubscriptionId,
+        customerId,
+      },
+    },
   };
 }

--- a/packages/cdk/lambda/billing/payment-gateway/webhook/stripe/eventExtractor.ts
+++ b/packages/cdk/lambda/billing/payment-gateway/webhook/stripe/eventExtractor.ts
@@ -2,6 +2,15 @@ import Stripe from 'stripe';
 import { EventDetail } from '../../types/businessEvent';
 
 /**
+ * Checkout Session型ガード
+ */
+function isCheckoutSession(
+  obj: Stripe.Event.Data.Object
+): obj is Stripe.Checkout.Session {
+  return 'object' in obj && obj.object === 'checkout.session';
+}
+
+/**
  * Stripeイベントから必須情報を抽出
  * @param stripeEvent Stripeイベントオブジェクト
  * @param tenantId テナントID
@@ -256,34 +265,37 @@ function extractFromCheckoutSessionCompleted(
   stripeEvent: Stripe.Event,
   tenantId: string
 ): Partial<EventDetail> {
-  const session = stripeEvent.data.object as Stripe.Checkout.Session;
+  const eventObject = stripeEvent.data.object;
+  if (!isCheckoutSession(eventObject)) {
+    throw new Error('Event object is not a Checkout Session');
+  }
 
   // setup modeのみ処理
-  if (session.mode !== 'setup') {
-    throw new Error(`Unsupported checkout session mode: ${session.mode}`);
+  if (eventObject.mode !== 'setup') {
+    throw new Error(`Unsupported checkout session mode: ${eventObject.mode}`);
   }
 
   // SetupIntentのIDを取得
   const setupIntentId =
-    typeof session.setup_intent === 'string'
-      ? session.setup_intent
-      : session.setup_intent?.id;
+    typeof eventObject.setup_intent === 'string'
+      ? eventObject.setup_intent
+      : eventObject.setup_intent?.id;
 
   if (!setupIntentId) {
     throw new Error('SetupIntent ID not found in checkout session');
   }
 
   // メタデータからサブスクリプション情報を取得
-  const metadata = session.metadata || {};
-  const subscriptionId = metadata.subscription_id || '';
-  const platformSubscriptionId = metadata.platform_subscription_id || '';
-  const userId = metadata.user_id || '';
+  const metadata = eventObject.metadata ?? {};
+  const subscriptionId = metadata.subscription_id ?? '';
+  const platformSubscriptionId = metadata.platform_subscription_id ?? '';
+  const userId = metadata.user_id ?? '';
 
   // 顧客IDを取得
   const customerId =
-    typeof session.customer === 'string'
-      ? session.customer
-      : session.customer?.id;
+    typeof eventObject.customer === 'string'
+      ? eventObject.customer
+      : eventObject.customer?.id;
 
   if (!subscriptionId) {
     console.warn('subscription_id not found in session metadata');

--- a/packages/cdk/lambda/billing/payment-gateway/webhook/stripe/eventMapper.ts
+++ b/packages/cdk/lambda/billing/payment-gateway/webhook/stripe/eventMapper.ts
@@ -1,25 +1,66 @@
+import Stripe from 'stripe';
 import { BusinessEventType } from '../../types/businessEvent';
 
 /**
- * Stripeイベントタイプ → ビジネスイベントタイプのマッピング
+ * マッピング関数の型（動的マッピング用）
  */
-const STRIPE_TO_BUSINESS_EVENT_MAP: Record<string, BusinessEventType> = {
+type EventMapper = (event: Stripe.Event) => BusinessEventType | null;
+
+/**
+ * Stripeイベントタイプ → ビジネスイベントタイプのマッピング
+ * 静的マッピングと動的マッピング（関数）の両方をサポート
+ */
+const STRIPE_TO_BUSINESS_EVENT_MAP: Record<
+  string,
+  BusinessEventType | EventMapper
+> = {
   'invoice.payment_succeeded': 'payment.succeeded',
   'invoice.paid': 'payment.succeeded', // 補助的なマッピング
   'invoice.payment_failed': 'payment.failed',
   'customer.subscription.deleted': 'subscription.canceled',
   'charge.refunded': 'payment.refunded',
+  // checkout.session.completedは動的にマッピング（setup modeのみ処理）
+  'checkout.session.completed': (event: Stripe.Event): BusinessEventType | null => {
+    const session = event.data.object as Stripe.Checkout.Session;
+    // setup modeかつpurposeがupdate_payment_methodの場合のみ処理
+    if (
+      session.mode === 'setup' &&
+      session.metadata?.purpose === 'update_payment_method'
+    ) {
+      return 'payment_method.updated';
+    }
+    // subscriptionモードのcheckoutはinvoiceイベントで処理されるためスキップ
+    return null;
+  },
 };
 
 /**
  * Stripeイベントタイプをビジネスイベントタイプにマッピング
  * @param stripeEventType Stripeイベントタイプ
+ * @param stripeEvent Stripeイベントオブジェクト（動的マッピング用、オプション）
  * @returns ビジネスイベントタイプ、またはnull（マッピング対象外）
  */
 export function mapStripeEventToBusinessEvent(
-  stripeEventType: string
+  stripeEventType: string,
+  stripeEvent?: Stripe.Event
 ): BusinessEventType | null {
-  return STRIPE_TO_BUSINESS_EVENT_MAP[stripeEventType] || null;
+  const mapping = STRIPE_TO_BUSINESS_EVENT_MAP[stripeEventType];
+
+  if (!mapping) {
+    return null;
+  }
+
+  // 関数の場合は動的にマッピング
+  if (typeof mapping === 'function') {
+    if (!stripeEvent) {
+      // イベントオブジェクトがない場合はマッピング不可
+      return null;
+    }
+    return mapping(stripeEvent);
+  }
+
+  // 静的マッピングの場合はそのまま返す
+  return mapping;
 }
 
 /**

--- a/packages/cdk/lambda/billing/payment-gateway/webhook/stripe/eventMapper.ts
+++ b/packages/cdk/lambda/billing/payment-gateway/webhook/stripe/eventMapper.ts
@@ -7,6 +7,15 @@ import { BusinessEventType } from '../../types/businessEvent';
 type EventMapper = (event: Stripe.Event) => BusinessEventType | null;
 
 /**
+ * Checkout Session型ガード
+ */
+function isCheckoutSession(
+  obj: Stripe.Event.Data.Object
+): obj is Stripe.Checkout.Session {
+  return 'object' in obj && obj.object === 'checkout.session';
+}
+
+/**
  * Stripeイベントタイプ → ビジネスイベントタイプのマッピング
  * 静的マッピングと動的マッピング（関数）の両方をサポート
  */
@@ -21,11 +30,14 @@ const STRIPE_TO_BUSINESS_EVENT_MAP: Record<
   'charge.refunded': 'payment.refunded',
   // checkout.session.completedは動的にマッピング（setup modeのみ処理）
   'checkout.session.completed': (event: Stripe.Event): BusinessEventType | null => {
-    const session = event.data.object as Stripe.Checkout.Session;
+    const eventObject = event.data.object;
+    if (!isCheckoutSession(eventObject)) {
+      return null;
+    }
     // setup modeかつpurposeがupdate_payment_methodの場合のみ処理
     if (
-      session.mode === 'setup' &&
-      session.metadata?.purpose === 'update_payment_method'
+      eventObject.mode === 'setup' &&
+      eventObject.metadata?.purpose === 'update_payment_method'
     ) {
       return 'payment_method.updated';
     }

--- a/packages/cdk/lambda/billing/payment-gateway/webhook/stripe/receiveWebhook.ts
+++ b/packages/cdk/lambda/billing/payment-gateway/webhook/stripe/receiveWebhook.ts
@@ -151,8 +151,8 @@ export async function handler(
 
     console.log(`Webhook event saved: ${eventId}`);
 
-    // ビジネスイベントにマッピング
-    const businessEventType = mapStripeEventToBusinessEvent(eventType);
+    // ビジネスイベントにマッピング（動的マッピング用にイベントオブジェクトも渡す）
+    const businessEventType = mapStripeEventToBusinessEvent(eventType, stripeEvent);
 
     if (!businessEventType) {
       // マッピング対象外のイベントはスキップ（またはログのみ記録）

--- a/packages/cdk/lambda/billing/user-api/subscriptions/createCustomerPortal.ts
+++ b/packages/cdk/lambda/billing/user-api/subscriptions/createCustomerPortal.ts
@@ -13,6 +13,14 @@ const lambdaClient = new LambdaClient({});
 /**
  * Lambda関数のメインハンドラー
  * Stripe Customer Portalセッションを作成するラッパー
+ *
+ * @deprecated Use createPaymentMethodUpdateSession for updating payment methods.
+ * This API will be removed in a future version.
+ *
+ * Note: Customer Portal updates the customer's default payment method,
+ * but does NOT update the subscription's payment method immediately.
+ * The subscription continues using its original payment method until
+ * the next billing cycle.
  */
 export async function handler(
   event: APIGatewayProxyEvent

--- a/packages/cdk/lambda/billing/user-api/subscriptions/createPaymentMethodUpdateSession.ts
+++ b/packages/cdk/lambda/billing/user-api/subscriptions/createPaymentMethodUpdateSession.ts
@@ -1,0 +1,333 @@
+/**
+ * Payment Method Update Session Creation API
+ *
+ * ユーザがサブスクリプションの支払い方法を更新するための
+ * Stripe Checkout Session（setup mode）を作成します。
+ *
+ * Customer Portalとは異なり、このAPIで作成されたセッションを完了すると、
+ * 即座にサブスクリプションのdefault_payment_methodが更新されます。
+ */
+
+import Stripe from 'stripe';
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import {
+  SecretsManagerClient,
+  GetSecretValueCommand,
+} from '@aws-sdk/client-secrets-manager';
+import { getTenantId, getUsername } from '../../../utils/tenantUtils';
+import { invokeDataAccessFunction } from '../../utils/dataAccessClient';
+import { Subscription } from '../../data-access/repositories/types';
+import {
+  ok200Response,
+  badRequest400Response,
+  unauthorized401Response,
+  notFound404Response,
+  forbidden403Response,
+  internalServerError500Response,
+} from '../../../utils/apiResponse';
+
+/**
+ * リクエストボディの型
+ */
+interface CreatePaymentMethodUpdateSessionRequest {
+  subscriptionId: string; // 内部サブスクリプションID
+}
+
+/**
+ * レスポンスボディの型
+ */
+interface CreatePaymentMethodUpdateSessionResponse {
+  url: string; // Checkout URL（リダイレクト用）
+  session_id: string; // セッションID
+  client_secret: string; // Embedded Checkout用
+}
+
+/**
+ * シークレットのキャッシュ
+ */
+let stripeApiKeyCache: { [key: string]: string } = {};
+
+/**
+ * Secrets ManagerからStripe APIキーを取得する
+ */
+async function getStripeApiKey(tenantId: string): Promise<string> {
+  if (stripeApiKeyCache[tenantId]) {
+    return stripeApiKeyCache[tenantId];
+  }
+
+  const secretName = `${tenantId}/billing/stripe`;
+  const client = new SecretsManagerClient({});
+  const command = new GetSecretValueCommand({ SecretId: secretName });
+
+  try {
+    const response = await client.send(command);
+
+    if (!response.SecretString) {
+      throw new Error(`Secret ${secretName} is empty`);
+    }
+
+    const secret = JSON.parse(response.SecretString);
+    stripeApiKeyCache[tenantId] = secret.apiKey;
+
+    return secret.apiKey;
+  } catch (error) {
+    console.error('Failed to retrieve Stripe API key:', error);
+    throw new Error('Failed to retrieve payment configuration');
+  }
+}
+
+/**
+ * リクエストヘッダーからフロントエンドのベースURLを取得する
+ * Origin > Referer の優先順位で取得し、取得できない場合はエラーをスローする
+ */
+function getBaseUrlFromRequest(event: APIGatewayProxyEvent): string {
+  const headers = event.headers;
+
+  // Originヘッダーから取得（CORS リクエストの場合）
+  const origin = headers['origin'] || headers['Origin'];
+  if (origin) {
+    return origin;
+  }
+
+  // Refererヘッダーから取得（フォールバック）
+  const referer = headers['referer'] || headers['Referer'];
+  if (referer) {
+    try {
+      const url = new URL(referer);
+      return `${url.protocol}//${url.host}`;
+    } catch {
+      // Refererのパースに失敗した場合は続行
+    }
+  }
+
+  // どちらも取得できない場合はエラー
+  throw new Error('Unable to determine frontend base URL from request headers');
+}
+
+/**
+ * Stripeサブスクリプションから顧客IDを取得する
+ */
+async function getStripeCustomerId(
+  stripe: Stripe,
+  platformSubscriptionId: string
+): Promise<string> {
+  const subscription = await stripe.subscriptions.retrieve(platformSubscriptionId);
+
+  const customer = subscription.customer;
+  if (!customer) {
+    throw new Error('No customer found on subscription');
+  }
+
+  if (typeof customer === 'string') {
+    return customer;
+  }
+
+  if ('id' in customer) {
+    return customer.id;
+  }
+
+  throw new Error('Unable to extract customer ID from subscription');
+}
+
+/**
+ * Lambda関数のメインハンドラー
+ */
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  console.log('User API: Create Payment Method Update Session request received');
+
+  try {
+    // 1. 認証情報からユーザIDとテナントIDを取得
+    const userId = getUsername(event);
+    const tenantId = getTenantId(event);
+
+    if (!userId || userId === 'unknown' || !tenantId) {
+      console.error('Missing authentication information');
+      return unauthorized401Response({
+        message: '認証が必要です',
+        code: 'UNAUTHORIZED',
+        details: undefined,
+      });
+    }
+
+    console.log('Request context:', { userId, tenantId });
+
+    // 2. リクエストボディを取得
+    if (!event.body) {
+      return badRequest400Response({
+        message: 'リクエストボディが必要です',
+        code: 'MISSING_BODY',
+        details: undefined,
+      });
+    }
+
+    let requestBody: CreatePaymentMethodUpdateSessionRequest;
+    try {
+      requestBody = JSON.parse(event.body);
+    } catch (error) {
+      return badRequest400Response({
+        message: 'リクエストボディが不正なJSON形式です',
+        code: 'INVALID_JSON',
+        details: undefined,
+      });
+    }
+
+    const { subscriptionId } = requestBody;
+
+    if (!subscriptionId) {
+      return badRequest400Response({
+        message: '必須パラメータが指定されていません',
+        code: 'MISSING_PARAMETER',
+        details: {
+          field: 'subscriptionId',
+          reason: 'subscriptionIdは必須です',
+        },
+      });
+    }
+
+    console.log('Creating payment method update session for subscription:', subscriptionId);
+
+    // 3. サブスクリプション情報を取得
+    const subscription = await invokeDataAccessFunction<Subscription | null>(
+      event,
+      'subscription',
+      'findById',
+      { subscriptionId }
+    );
+
+    if (!subscription) {
+      console.error('Subscription not found:', subscriptionId);
+      return notFound404Response({
+        message: '指定されたサブスクリプションが見つかりません',
+        code: 'SUBSCRIPTION_NOT_FOUND',
+        details: {
+          subscriptionId,
+        },
+      });
+    }
+
+    // 4. サブスクリプションの所有者確認
+    if (subscription.user_id !== userId) {
+      console.error('Subscription does not belong to user:', {
+        subscriptionUserId: subscription.user_id,
+        requestUserId: userId,
+      });
+      return forbidden403Response({
+        message: 'このサブスクリプションにアクセスする権限がありません',
+        code: 'FORBIDDEN',
+        details: undefined,
+      });
+    }
+
+    // 5. サブスクリプションのステータス確認
+    const activeStatuses = ['active', 'past_due', 'scheduled_cancellation'];
+    if (!activeStatuses.includes(subscription.subscription_status)) {
+      console.error('Subscription is not active:', {
+        subscriptionId,
+        status: subscription.subscription_status,
+      });
+      return badRequest400Response({
+        message: 'このサブスクリプションは現在有効ではありません',
+        code: 'SUBSCRIPTION_NOT_ACTIVE',
+        details: {
+          subscriptionId,
+          status: subscription.subscription_status,
+        },
+      });
+    }
+
+    // 6. プラットフォームタイプ確認
+    if (subscription.platform_type !== 'stripe') {
+      console.error('Invalid platform type:', {
+        subscriptionId,
+        platformType: subscription.platform_type,
+      });
+      return badRequest400Response({
+        message: 'この操作はStripeのサブスクリプションでのみ利用可能です',
+        code: 'INVALID_PLATFORM',
+        details: {
+          subscriptionId,
+          platformType: subscription.platform_type,
+        },
+      });
+    }
+
+    console.log('Subscription validation successful:', {
+      subscriptionId: subscription.subscription_id,
+      platformSubscriptionId: subscription.platform_subscription_id,
+      status: subscription.subscription_status,
+    });
+
+    // 7. Stripe APIキーを取得
+    const apiKey = await getStripeApiKey(tenantId);
+    const stripe = new Stripe(apiKey, { apiVersion: '2025-10-29.clover' });
+
+    // 8. Stripe顧客IDを取得
+    const customerId = await getStripeCustomerId(
+      stripe,
+      subscription.platform_subscription_id
+    );
+
+    console.log('Stripe customer ID retrieved:', { customerId });
+
+    // 9. return URLを設定（Embedded Checkout用）
+    const baseUrl = getBaseUrlFromRequest(event);
+    const returnUrl = `${baseUrl}/billing/payment-method-updated?session_id={CHECKOUT_SESSION_ID}`;
+
+    console.log('Return URL configured:', { baseUrl, returnUrl });
+
+    // 10. Checkout Sessionを作成（setup mode）
+    const session = await stripe.checkout.sessions.create({
+      mode: 'setup',
+      ui_mode: 'embedded',
+      customer: customerId,
+      payment_method_types: ['card'],
+      return_url: returnUrl,
+      setup_intent_data: {
+        metadata: {
+          subscription_id: subscription.subscription_id,
+          platform_subscription_id: subscription.platform_subscription_id,
+          user_id: userId,
+          tenant_id: tenantId,
+        },
+      },
+      metadata: {
+        subscription_id: subscription.subscription_id,
+        purpose: 'update_payment_method',
+      },
+      locale: 'ja',
+    });
+
+    console.log('Payment Method Update Checkout Session created:', session.id);
+
+    // 11. レスポンスを返す
+    const response: CreatePaymentMethodUpdateSessionResponse = {
+      url: session.url || '',
+      session_id: session.id,
+      client_secret: session.client_secret || '',
+    };
+
+    return ok200Response(response);
+  } catch (error) {
+    console.error('Error creating payment method update session:', error);
+
+    // Stripeのエラーを適切に処理
+    if (error instanceof Stripe.errors.StripeError) {
+      return badRequest400Response({
+        message: error.message,
+        code: 'STRIPE_ERROR',
+        details: {
+          type: error.type,
+          code: error.code,
+        },
+      });
+    }
+
+    return internalServerError500Response({
+      message: 'サーバー内部エラーが発生しました',
+      code: 'INTERNAL_SERVER_ERROR',
+      details: undefined,
+    });
+  }
+};

--- a/packages/cdk/lambda/billing/user-api/subscriptions/createPaymentMethodUpdateSession.ts
+++ b/packages/cdk/lambda/billing/user-api/subscriptions/createPaymentMethodUpdateSession.ts
@@ -288,6 +288,7 @@ export const handler = async (
       customer: customerId,
       payment_method_types: ['card'],
       return_url: returnUrl,
+      redirect_on_completion: 'if_required',
       setup_intent_data: {
         metadata: {
           subscription_id: subscription.subscription_id,

--- a/packages/cdk/lambda/billing/user-api/subscriptions/createPaymentMethodUpdateSession.ts
+++ b/packages/cdk/lambda/billing/user-api/subscriptions/createPaymentMethodUpdateSession.ts
@@ -31,6 +31,7 @@ import {
  */
 interface CreatePaymentMethodUpdateSessionRequest {
   subscriptionId: string; // 内部サブスクリプションID
+  returnUrl: string; // Embedded Checkout完了後のリダイレクトURL
 }
 
 /**
@@ -40,19 +41,41 @@ interface CreatePaymentMethodUpdateSessionResponse {
   url: string; // Checkout URL（リダイレクト用）
   session_id: string; // セッションID
   client_secret: string; // Embedded Checkout用
+  publishable_key: string; // Stripe Publishable Key（Embedded Checkout用）
+}
+
+/**
+ * Stripe認証情報の型
+ */
+interface StripeCredentials {
+  apiKey: string;
+  publishableKey: string;
+}
+
+/**
+ * リクエストボディをパースする
+ */
+function parseRequestBody(
+  body: string
+): CreatePaymentMethodUpdateSessionRequest | { error: true } {
+  try {
+    return JSON.parse(body);
+  } catch {
+    return { error: true };
+  }
 }
 
 /**
  * シークレットのキャッシュ
  */
-let stripeApiKeyCache: { [key: string]: string } = {};
+const stripeCredentialsCache: Record<string, StripeCredentials> = {};
 
 /**
- * Secrets ManagerからStripe APIキーを取得する
+ * Secrets ManagerからStripe認証情報を取得する
  */
-async function getStripeApiKey(tenantId: string): Promise<string> {
-  if (stripeApiKeyCache[tenantId]) {
-    return stripeApiKeyCache[tenantId];
+async function getStripeCredentials(tenantId: string): Promise<StripeCredentials> {
+  if (stripeCredentialsCache[tenantId]) {
+    return stripeCredentialsCache[tenantId];
   }
 
   const secretName = `${tenantId}/billing/stripe`;
@@ -67,41 +90,17 @@ async function getStripeApiKey(tenantId: string): Promise<string> {
     }
 
     const secret = JSON.parse(response.SecretString);
-    stripeApiKeyCache[tenantId] = secret.apiKey;
+    const credentials: StripeCredentials = {
+      apiKey: secret.apiKey,
+      publishableKey: secret.publishableKey,
+    };
+    stripeCredentialsCache[tenantId] = credentials;
 
-    return secret.apiKey;
+    return credentials;
   } catch (error) {
-    console.error('Failed to retrieve Stripe API key:', error);
+    console.error('Failed to retrieve Stripe credentials:', error);
     throw new Error('Failed to retrieve payment configuration');
   }
-}
-
-/**
- * リクエストヘッダーからフロントエンドのベースURLを取得する
- * Origin > Referer の優先順位で取得し、取得できない場合はエラーをスローする
- */
-function getBaseUrlFromRequest(event: APIGatewayProxyEvent): string {
-  const headers = event.headers;
-
-  // Originヘッダーから取得（CORS リクエストの場合）
-  const origin = headers['origin'] || headers['Origin'];
-  if (origin) {
-    return origin;
-  }
-
-  // Refererヘッダーから取得（フォールバック）
-  const referer = headers['referer'] || headers['Referer'];
-  if (referer) {
-    try {
-      const url = new URL(referer);
-      return `${url.protocol}//${url.host}`;
-    } catch {
-      // Refererのパースに失敗した場合は続行
-    }
-  }
-
-  // どちらも取得できない場合はエラー
-  throw new Error('Unable to determine frontend base URL from request headers');
 }
 
 /**
@@ -162,10 +161,8 @@ export const handler = async (
       });
     }
 
-    let requestBody: CreatePaymentMethodUpdateSessionRequest;
-    try {
-      requestBody = JSON.parse(event.body);
-    } catch (error) {
+    const parseResult = parseRequestBody(event.body);
+    if ('error' in parseResult) {
       return badRequest400Response({
         message: 'リクエストボディが不正なJSON形式です',
         code: 'INVALID_JSON',
@@ -173,7 +170,7 @@ export const handler = async (
       });
     }
 
-    const { subscriptionId } = requestBody;
+    const { subscriptionId, returnUrl } = parseResult;
 
     if (!subscriptionId) {
       return badRequest400Response({
@@ -182,6 +179,17 @@ export const handler = async (
         details: {
           field: 'subscriptionId',
           reason: 'subscriptionIdは必須です',
+        },
+      });
+    }
+
+    if (!returnUrl) {
+      return badRequest400Response({
+        message: '必須パラメータが指定されていません',
+        code: 'MISSING_PARAMETER',
+        details: {
+          field: 'returnUrl',
+          reason: 'returnUrlは必須です',
         },
       });
     }
@@ -259,9 +267,9 @@ export const handler = async (
       status: subscription.subscription_status,
     });
 
-    // 7. Stripe APIキーを取得
-    const apiKey = await getStripeApiKey(tenantId);
-    const stripe = new Stripe(apiKey, { apiVersion: '2025-10-29.clover' });
+    // 7. Stripe認証情報を取得
+    const credentials = await getStripeCredentials(tenantId);
+    const stripe = new Stripe(credentials.apiKey, { apiVersion: '2025-10-29.clover' });
 
     // 8. Stripe顧客IDを取得
     const customerId = await getStripeCustomerId(
@@ -271,11 +279,7 @@ export const handler = async (
 
     console.log('Stripe customer ID retrieved:', { customerId });
 
-    // 9. return URLを設定（Embedded Checkout用）
-    const baseUrl = getBaseUrlFromRequest(event);
-    const returnUrl = `${baseUrl}/billing/payment-method-updated?session_id={CHECKOUT_SESSION_ID}`;
-
-    console.log('Return URL configured:', { baseUrl, returnUrl });
+    console.log('Return URL configured:', { returnUrl });
 
     // 10. Checkout Sessionを作成（setup mode）
     const session = await stripe.checkout.sessions.create({
@@ -294,6 +298,8 @@ export const handler = async (
       },
       metadata: {
         subscription_id: subscription.subscription_id,
+        platform_subscription_id: subscription.platform_subscription_id,
+        user_id: userId,
         purpose: 'update_payment_method',
       },
       locale: 'ja',
@@ -306,6 +312,7 @@ export const handler = async (
       url: session.url || '',
       session_id: session.id,
       client_secret: session.client_secret || '',
+      publishable_key: credentials.publishableKey,
     };
 
     return ok200Response(response);

--- a/packages/cdk/lib/construct/api/orchestration.ts
+++ b/packages/cdk/lib/construct/api/orchestration.ts
@@ -257,13 +257,19 @@ class OrchestrationApi extends Construct {
     // EventBridge Rules for Webhook Event Flow
     // ========================================
 
-    // Stripe Webhook Event Rule
+    // Stripe Webhook Event Rule - matches business event types
     const stripeWebhookRule = new Rule(this, 'StripeWebhookRule', {
       ruleName: `${environment}-stripe-webhook-to-orchestration`,
       eventBus,
       eventPattern: {
         source: ['billing.payment-gateway'],
-        detailType: ['Stripe Webhook Event'],
+        detailType: [
+          'payment.succeeded',
+          'payment.failed',
+          'subscription.canceled',
+          'payment.refunded',
+          'payment_method.updated',
+        ],
         detail: {
           platform: ['stripe'],
         },

--- a/packages/cdk/lib/construct/api/user-billing-api.ts
+++ b/packages/cdk/lib/construct/api/user-billing-api.ts
@@ -77,6 +77,7 @@ class UserBillingApi extends Construct {
   public readonly cancelSubscriptionFunction?: NodejsFunction;
   public readonly changeSubscriptionPlanFunction?: NodejsFunction;
   public readonly createCustomerPortalFunction: NodejsFunction;
+  public readonly createPaymentMethodUpdateSessionFunction: NodejsFunction;
   public readonly getStoreInfoFunction: NodejsFunction;
   public readonly getUsageStatusFunction: NodejsFunction;
 
@@ -571,6 +572,10 @@ class UserBillingApi extends Construct {
     // ========================================
     // API 8: Customer Portalセッション作成API
     // POST /api/subscriptions/customer-portal
+    //
+    // @deprecated Use createPaymentMethodUpdateSession for updating payment methods.
+    // Customer Portal updates the customer's default payment method,
+    // but does NOT immediately update the subscription's payment method.
     // ========================================
 
     this.createCustomerPortalFunction = new NodejsFunction(
@@ -715,6 +720,83 @@ class UserBillingApi extends Construct {
     );
 
     // ========================================
+    // API 11: 支払い方法更新セッション作成API
+    // POST /api/subscriptions/update-payment-method
+    //
+    // サブスクリプションの支払い方法を即座に更新するための
+    // Stripe Checkout Session（setup mode）を作成します。
+    // ========================================
+
+    this.createPaymentMethodUpdateSessionFunction = new NodejsFunction(
+      this,
+      'CreatePaymentMethodUpdateSession',
+      {
+        runtime: LAMBDA_RUNTIME_NODEJS,
+        entry:
+          './lambda/billing/user-api/subscriptions/createPaymentMethodUpdateSession.ts',
+        timeout: Duration.seconds(30),
+        memorySize: 256,
+        environment: commonEnvironment,
+      }
+    );
+
+    // Grant Tenants table read access
+    tenantManager.tenantsTable.grantReadData(
+      this.createPaymentMethodUpdateSessionFunction
+    );
+
+    // Secrets Manager読み取り権限（Stripe APIキー取得用）
+    this.createPaymentMethodUpdateSessionFunction.addToRolePolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: ['secretsmanager:GetSecretValue'],
+        resources: ['arn:aws:secretsmanager:*:*:secret:*/billing/stripe*'],
+      })
+    );
+
+    // Lambda呼び出し権限（データアクセス層用）
+    this.createPaymentMethodUpdateSessionFunction.addToRolePolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: ['lambda:InvokeFunction'],
+        resources: [
+          `arn:aws:lambda:*:*:function:${environment}-*-subscription-data-access`,
+        ],
+      })
+    );
+
+    // IAM Role Assume権限（テナント専用クレデンシャル取得用）
+    this.createPaymentMethodUpdateSessionFunction.addToRolePolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: ['sts:AssumeRole'],
+        resources: ['arn:aws:iam::*:role/TenantRole-*'],
+      })
+    );
+
+    // Grant STS AssumeRoleWithWebIdentity permission
+    this.createPaymentMethodUpdateSessionFunction.addToRolePolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: ['sts:AssumeRoleWithWebIdentity'],
+        resources: ['*'],
+      })
+    );
+
+    // API Gatewayエンドポイント
+    const updatePaymentMethodResource = subscriptionsResource.addResource(
+      'update-payment-method'
+    );
+    updatePaymentMethodResource.addMethod(
+      'POST',
+      new LambdaIntegration(this.createPaymentMethodUpdateSessionFunction),
+      {
+        authorizer: authorizer,
+        authorizationType: AuthorizationType.COGNITO,
+      }
+    );
+
+    // ========================================
     // ログ出力
     // ========================================
 
@@ -728,7 +810,8 @@ class UserBillingApi extends Construct {
       console.log('  - POST /api/subscriptions/cancel');
       console.log('  - POST /api/subscriptions/change-plan');
     }
-    console.log('  - POST /api/subscriptions/customer-portal');
+    console.log('  - POST /api/subscriptions/customer-portal (deprecated)');
+    console.log('  - POST /api/subscriptions/update-payment-method');
     console.log('  - GET /api/store-info');
     console.log('  - POST /api/usage/status');
   }

--- a/packages/cdk/lib/construct/tenant-role.ts
+++ b/packages/cdk/lib/construct/tenant-role.ts
@@ -271,6 +271,17 @@ export class TenantRole extends Construct {
                 `arn:aws:rds-db:${props.region}:${props.account}:dbuser:*/*`,
               ],
             }),
+
+            // Secrets Manager access for tenant-specific secrets (e.g., Stripe API keys)
+            new PolicyStatement({
+              sid: 'SecretsManagerTenantAccess',
+              effect: Effect.ALLOW,
+              actions: ['secretsmanager:GetSecretValue'],
+              resources: [
+                // Allow reading tenant-specific billing secrets
+                `arn:aws:secretsmanager:${props.region}:${props.account}:secret:${props.tenantId}/billing/*`,
+              ],
+            }),
           ],
         }),
       },

--- a/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
@@ -147,6 +147,18 @@ export class GenerativeAiUseCasesStack extends Stack {
       })
     );
 
+    // Billing permission: Secrets Manager read for tenant Stripe API keys
+    // Required for webhookEventFlow Lambda to call Stripe API
+    backgroundJobRole.addToPolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['secretsmanager:GetSecretValue'],
+        resources: [
+          `arn:aws:secretsmanager:${params.region}:${params.account}:secret:*/billing/stripe*`,
+        ],
+      })
+    );
+
     // PPTX resources moved to per-tenant stacks (TenantPptxStack and TenantS3Stack)
     // Each tenant now has their own isolated PPTX database and S3 buckets
 

--- a/packages/web/src/hooks/useSubscriptionApi.ts
+++ b/packages/web/src/hooks/useSubscriptionApi.ts
@@ -96,6 +96,17 @@ export interface CustomerPortalResponse {
   url: string;
 }
 
+export interface UpdatePaymentMethodRequest {
+  subscriptionId: string;
+  returnUrl?: string;
+}
+
+export interface UpdatePaymentMethodResponse {
+  url: string;
+  session_id: string;
+  client_secret: string;
+}
+
 const useSubscriptionApi = () => {
   const { api } = useBillingHttp();
 
@@ -204,12 +215,26 @@ const useSubscriptionApi = () => {
         return response.data;
       },
 
-      // Create Customer Portal session
+      /**
+       * @deprecated Use createPaymentMethodUpdateSession for updating payment methods.
+       * Customer Portal updates customer's default but NOT subscription's payment method.
+       */
       createCustomerPortalSession: async (
         request: CustomerPortalRequest
       ): Promise<CustomerPortalResponse> => {
         const response = await api.post<CustomerPortalResponse>(
           '/api/subscriptions/customer-portal',
+          request
+        );
+        return response.data;
+      },
+
+      // Create Payment Method Update Session (Stripe Checkout with setup mode)
+      createPaymentMethodUpdateSession: async (
+        request: UpdatePaymentMethodRequest
+      ): Promise<UpdatePaymentMethodResponse> => {
+        const response = await api.post<UpdatePaymentMethodResponse>(
+          '/api/subscriptions/update-payment-method',
           request
         );
         return response.data;

--- a/packages/web/src/hooks/useSubscriptionApi.ts
+++ b/packages/web/src/hooks/useSubscriptionApi.ts
@@ -105,6 +105,7 @@ export interface UpdatePaymentMethodResponse {
   url: string;
   session_id: string;
   client_secret: string;
+  publishable_key: string;
 }
 
 const useSubscriptionApi = () => {


### PR DESCRIPTION
## 概要

Stripeのサブスクリプションに紐づく支払い方法を更新するための新しいAPIを実装しました。

### 背景・課題

既存の`createCustomerPortalSession` APIは、Stripe Customer Portalにリダイレクトして顧客のデフォルト支払い方法を更新しますが、**サブスクリプションの支払い方法は即座に更新されません**。サブスクリプションは次の請求サイクルまで元の支払い方法を使用し続けます。

### 解決策

Stripe Checkout Sessionの`mode: 'setup'`を使用して：
1. ユーザーが新しい支払い方法を追加
2. Webhook（`checkout.session.completed`）で即座にサブスクリプションの`default_payment_method`を更新

## 変更内容

### 新規ファイル
- `packages/cdk/lambda/billing/user-api/subscriptions/createPaymentMethodUpdateSession.ts`
  - `POST /api/subscriptions/update-payment-method` エンドポイント用Lambdaハンドラー

### 変更ファイル
| ファイル | 変更内容 |
|---------|---------|
| `user-billing-api.ts` | 新規APIエンドポイントとLambda関数を追加 |
| `businessEvent.ts` | `payment_method.updated` イベントタイプを追加 |
| `eventMapper.ts` | `checkout.session.completed`（setup mode）の条件付きマッピングを追加 |
| `eventExtractor.ts` | checkout sessionイベントの抽出処理を追加 |
| `receiveWebhook.ts` | マッパー呼び出しを更新（フルイベントを渡す） |
| `webhookEventFlow.ts` | `handlePaymentMethodUpdated` ハンドラーを追加 |
| `eventTypes.ts` | `payment_method.updated` をWebhookEventTypeに追加 |
| `useSubscriptionApi.ts` | フロントエンド型とAPIメソッドを追加 |
| `createCustomerPortal.ts` | 非推奨マークを追加 |

## APIインターフェース

### リクエスト
\`\`\`typescript
POST /api/subscriptions/update-payment-method
{
  "subscriptionId": "sub_xxx",
  "returnUrl": "https://..."
}
\`\`\`

### レスポンス
\`\`\`typescript
{
  "url": "https://checkout.stripe.com/...",
  "session_id": "cs_xxx",
  "client_secret": "cs_xxx_secret_xxx"
}
\`\`\`

## テスト計画

- [ ] 有効なサブスクリプションでチェックアウトセッションURLが返される
- [ ] 存在しないサブスクリプションでリクエストが拒否される
- [ ] 別ユーザー所有のサブスクリプションでリクエストが拒否される
- [ ] Stripe以外のサブスクリプションでリクエストが拒否される
- [ ] Webhookが正しくsetup modeの\`checkout.session.completed\`を識別する
- [ ] Webhookがサブスクリプションの\`default_payment_method\`を更新する
- [ ] Webhookが顧客の\`invoice_settings.default_payment_method\`を更新する

🤖 Generated with [Claude Code](https://claude.com/claude-code)