### PR TITLE
🩹 利用プラン確認で生年月日登録を取得

### DIFF
--- a/packages/cdk/lambda/billing/user-api/subscriptions/getCurrentSubscription.ts
+++ b/packages/cdk/lambda/billing/user-api/subscriptions/getCurrentSubscription.ts
@@ -14,8 +14,6 @@ import {
   SecretsManagerClient,
   GetSecretValueCommand,
 } from '@aws-sdk/client-secrets-manager';
-import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
-import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
 import { invokeDataAccessFunction } from '../../utils/dataAccessClient';
 import {
   Plan,
@@ -28,7 +26,7 @@ import {
   notFound404Response,
   internalServerError500Response,
 } from '../../../utils/apiResponse';
-import { getTenantId, getUsername, getUserSub } from '../../../utils/tenantUtils';
+import { getTenantId, getUsername, getBirthdateFromClaims } from '../../../utils/tenantUtils';
 
 /**
  * 支払い方法（カード）の型
@@ -73,15 +71,6 @@ interface CurrentPlanResponse {
 }
 
 /**
- * DynamoDBクライアント
- */
-const dynamoClient = new DynamoDBClient({});
-const docClient = DynamoDBDocumentClient.from(dynamoClient);
-
-const USER_REGISTRATION_METADATA_TABLE_NAME =
-  process.env.USER_REGISTRATION_METADATA_TABLE_NAME || '';
-
-/**
  * Stripe APIキーのキャッシュ
  */
 let stripeApiKeyCache: { [key: string]: string } = {};
@@ -116,36 +105,6 @@ async function getStripeApiKey(tenantId: string): Promise<string | null> {
     return secret.apiKey;
   } catch (error) {
     console.error('Failed to retrieve Stripe API key:', error);
-    return null;
-  }
-}
-
-/**
- * USER_REGISTRATION_METADATAテーブルからユーザーの生年月日を取得する
- */
-async function getBirthdateFromMetadata(userId: string): Promise<string | null> {
-  if (!USER_REGISTRATION_METADATA_TABLE_NAME) {
-    console.log('USER_REGISTRATION_METADATA_TABLE_NAME is not configured');
-    return null;
-  }
-
-  try {
-    const result = await docClient.send(
-      new GetCommand({
-        TableName: USER_REGISTRATION_METADATA_TABLE_NAME,
-        Key: { userId },
-        ProjectionExpression: 'birthdate',
-      })
-    );
-
-    if (result.Item && result.Item.birthdate) {
-      return result.Item.birthdate;
-    }
-
-    console.log('Birthdate not found for user:', userId);
-    return null;
-  } catch (error) {
-    console.error('Failed to retrieve birthdate from metadata:', error);
     return null;
   }
 }
@@ -615,9 +574,8 @@ export const handler = async (
       );
     }
 
-    // 9. 生年月日を取得（subをキーとして使用 - setBirthdateと同じキーを使用）
-    const userSub = getUserSub(event);
-    const birthdate = await getBirthdateFromMetadata(userSub);
+    // 9. 生年月日を取得（Cognito ユーザー属性から直接取得）
+    const birthdate = getBirthdateFromClaims(event);
 
     // 10. レスポンスの構築
     const response: CurrentPlanResponse = {

--- a/packages/cdk/lambda/billing/user-api/subscriptions/getCurrentSubscription.ts
+++ b/packages/cdk/lambda/billing/user-api/subscriptions/getCurrentSubscription.ts
@@ -28,7 +28,7 @@ import {
   notFound404Response,
   internalServerError500Response,
 } from '../../../utils/apiResponse';
-import { getTenantId, getUsername } from '../../../utils/tenantUtils';
+import { getTenantId, getUsername, getUserSub } from '../../../utils/tenantUtils';
 
 /**
  * 支払い方法（カード）の型
@@ -615,8 +615,9 @@ export const handler = async (
       );
     }
 
-    // 9. 生年月日を取得
-    const birthdate = await getBirthdateFromMetadata(userId);
+    // 9. 生年月日を取得（subをキーとして使用 - setBirthdateと同じキーを使用）
+    const userSub = getUserSub(event);
+    const birthdate = await getBirthdateFromMetadata(userSub);
 
     // 10. レスポンスの構築
     const response: CurrentPlanResponse = {

--- a/packages/cdk/lambda/billing/user-api/subscriptions/getCurrentSubscription.ts
+++ b/packages/cdk/lambda/billing/user-api/subscriptions/getCurrentSubscription.ts
@@ -14,6 +14,8 @@ import {
   SecretsManagerClient,
   GetSecretValueCommand,
 } from '@aws-sdk/client-secrets-manager';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
 import { invokeDataAccessFunction } from '../../utils/dataAccessClient';
 import {
   Plan,
@@ -67,7 +69,17 @@ interface CurrentPlanResponse {
   amount: number;
   currency: string;
   interval: string;
+  birthdate: string | null;
 }
+
+/**
+ * DynamoDBクライアント
+ */
+const dynamoClient = new DynamoDBClient({});
+const docClient = DynamoDBDocumentClient.from(dynamoClient);
+
+const USER_REGISTRATION_METADATA_TABLE_NAME =
+  process.env.USER_REGISTRATION_METADATA_TABLE_NAME || '';
 
 /**
  * Stripe APIキーのキャッシュ
@@ -104,6 +116,36 @@ async function getStripeApiKey(tenantId: string): Promise<string | null> {
     return secret.apiKey;
   } catch (error) {
     console.error('Failed to retrieve Stripe API key:', error);
+    return null;
+  }
+}
+
+/**
+ * USER_REGISTRATION_METADATAテーブルからユーザーの生年月日を取得する
+ */
+async function getBirthdateFromMetadata(userId: string): Promise<string | null> {
+  if (!USER_REGISTRATION_METADATA_TABLE_NAME) {
+    console.log('USER_REGISTRATION_METADATA_TABLE_NAME is not configured');
+    return null;
+  }
+
+  try {
+    const result = await docClient.send(
+      new GetCommand({
+        TableName: USER_REGISTRATION_METADATA_TABLE_NAME,
+        Key: { userId },
+        ProjectionExpression: 'birthdate',
+      })
+    );
+
+    if (result.Item && result.Item.birthdate) {
+      return result.Item.birthdate;
+    }
+
+    console.log('Birthdate not found for user:', userId);
+    return null;
+  } catch (error) {
+    console.error('Failed to retrieve birthdate from metadata:', error);
     return null;
   }
 }
@@ -573,7 +615,10 @@ export const handler = async (
       );
     }
 
-    // 9. レスポンスの構築
+    // 9. 生年月日を取得
+    const birthdate = await getBirthdateFromMetadata(userId);
+
+    // 10. レスポンスの構築
     const response: CurrentPlanResponse = {
       planId: plan.plan_id,
       planName: plan.internal_name,
@@ -604,6 +649,7 @@ export const handler = async (
       amount: plan.internal_name === 'Freeプラン' ? 0 : 1000, // TODO: 価格情報を動的に取得
       currency: 'JPY',
       interval: 'month',
+      birthdate,
     };
 
     console.log('Returning current plan information:', {

--- a/packages/cdk/lambda/utils/tenantUtils.ts
+++ b/packages/cdk/lambda/utils/tenantUtils.ts
@@ -86,3 +86,18 @@ export const getUsername = (event: APIGatewayProxyEvent): string => {
 
   return username;
 };
+
+/**
+ * Extract user sub (unique user ID) from the API Gateway event authorizer context
+ * This is the Cognito user's unique identifier (UUID format)
+ */
+export const getUserSub = (event: APIGatewayProxyEvent): string => {
+  // Try to get sub from authorizer context (Lambda Request Authorizer - flat structure)
+  const sub =
+    event.requestContext?.authorizer?.['sub'] ||
+    // Try to get from parsed claims object (Lambda Request Authorizer - nested structure or Cognito User Pools)
+    parseClaims(event)?.['sub'] ||
+    'unknown';
+
+  return sub;
+};

--- a/packages/cdk/lambda/utils/tenantUtils.ts
+++ b/packages/cdk/lambda/utils/tenantUtils.ts
@@ -101,3 +101,18 @@ export const getUserSub = (event: APIGatewayProxyEvent): string => {
 
   return sub;
 };
+
+/**
+ * Extract birthdate from the API Gateway event authorizer context (Cognito claims)
+ * Returns the birthdate string if available, null otherwise
+ */
+export const getBirthdateFromClaims = (event: APIGatewayProxyEvent): string | null => {
+  // Try to get birthdate from authorizer context (Lambda Request Authorizer - flat structure)
+  const birthdate =
+    event.requestContext?.authorizer?.['birthdate'] ||
+    // Try to get from parsed claims object (Lambda Request Authorizer - nested structure or Cognito User Pools)
+    parseClaims(event)?.['birthdate'] ||
+    null;
+
+  return birthdate;
+};

--- a/packages/cdk/lib/construct/api/user-billing-api.ts
+++ b/packages/cdk/lib/construct/api/user-billing-api.ts
@@ -363,6 +363,9 @@ class UserBillingApi extends Construct {
     // GET /api/subscriptions/current
     // ========================================
 
+    // USER_REGISTRATION_METADATA テーブル名を構築
+    const userRegistrationMetadataTableName = `UserRegistrationMetadata-${environment}`;
+
     this.getCurrentSubscriptionFunction = new NodejsFunction(
       this,
       'GetCurrentSubscription',
@@ -371,7 +374,10 @@ class UserBillingApi extends Construct {
         entry: './lambda/billing/user-api/subscriptions/getCurrentSubscription.ts',
         timeout: Duration.seconds(10),
         memorySize: 256,
-        environment: commonEnvironment,
+        environment: {
+          ...commonEnvironment,
+          USER_REGISTRATION_METADATA_TABLE_NAME: userRegistrationMetadataTableName,
+        },
       }
     );
 
@@ -417,6 +423,17 @@ class UserBillingApi extends Construct {
         effect: Effect.ALLOW,
         actions: ['secretsmanager:GetSecretValue'],
         resources: ['arn:aws:secretsmanager:*:*:secret:*/billing/stripe*'],
+      })
+    );
+
+    // DynamoDB読み取り権限（USER_REGISTRATION_METADATAテーブル - 生年月日取得用）
+    this.getCurrentSubscriptionFunction.addToRolePolicy(
+      new PolicyStatement({
+        effect: Effect.ALLOW,
+        actions: ['dynamodb:GetItem'],
+        resources: [
+          `arn:aws:dynamodb:*:*:table/${userRegistrationMetadataTableName}`,
+        ],
       })
     );
 


### PR DESCRIPTION
## 変更の概要

- 利用プラン確認APIのレスポンスに登録した生年月日を返すようにする(未登録の時はNULL)

<!-- どのような変更を行ったかを書く -->

## 申し送り事項

<!-- レビュワーに伝えておきたい事柄等を書く（Draftの理由など） -->

## Checklist（レビュワー用）

- [ ] `npm run lint`でエラーが出ない
- [ ] TypeScriptのビルドで型エラーが出ない
- [ ] 手元でフォーマットした際に差分が出ない

## スクリーンショット
<img width="512" height="308" alt="image" src="https://github.com/user-attachments/assets/f5d9329c-9806-40c5-aea0-4a72f7e8e8c5" />
