### PR TITLE
🐛 fix(tenant): CloudFormation Early Validation エラーを回避するため CDK fromXxx メソッドを文字列参照に変更

### DIFF
--- a/packages/cdk/lib/construct/tenant-role.ts
+++ b/packages/cdk/lib/construct/tenant-role.ts
@@ -61,9 +61,10 @@ export class TenantRole extends Construct {
       : cognitoFederatedPrincipal;
 
     // Create tenant-specific IAM role
+    // Include environment in role name to avoid conflicts between environments (e.g., dev vs devel)
     this.role = new Role(this, `TenantRole`, {
-      roleName: `TenantRole-${props.tenantId}`,
-      description: `IAM role for tenant ${props.tenantId} - supports both same-account and cross-account access`,
+      roleName: `TenantRole-${props.env}-${props.tenantId}`,
+      description: `IAM role for tenant ${props.tenantId} (${props.env}) - supports both same-account and cross-account access`,
       assumedBy,
       inlinePolicies: {
         TenantResourceAccess: new PolicyDocument({

--- a/packages/cdk/lib/construct/tenant-role.ts
+++ b/packages/cdk/lib/construct/tenant-role.ts
@@ -9,13 +9,10 @@ import {
   ArnPrincipal,
 } from 'aws-cdk-lib/aws-iam';
 import { Tags } from 'aws-cdk-lib';
-import { IUserPool } from 'aws-cdk-lib/aws-cognito';
-import { IIdentityPool } from 'aws-cdk-lib/aws-cognito-identitypool';
 
 export interface TenantRoleProps {
   readonly tenantId: string;
-  readonly userPool: IUserPool;
-  readonly identityPool: IIdentityPool;
+  readonly identityPoolId: string;
   readonly userPoolClientId: string;
   readonly region: string;
   readonly account: string;
@@ -46,8 +43,7 @@ export class TenantRole extends Construct {
       'cognito-identity.amazonaws.com',
       {
         StringEquals: {
-          'cognito-identity.amazonaws.com:aud':
-            props.identityPool.identityPoolId,
+          'cognito-identity.amazonaws.com:aud': props.identityPoolId,
         },
         'ForAnyValue:StringLike': {
           'cognito-identity.amazonaws.com:amr': 'authenticated',

--- a/packages/cdk/lib/stacks/tenant/tenant-iam-stack.ts
+++ b/packages/cdk/lib/stacks/tenant/tenant-iam-stack.ts
@@ -1,10 +1,5 @@
 import * as cdk from 'aws-cdk-lib';
 import { Construct } from 'constructs';
-import { UserPool, IUserPool } from 'aws-cdk-lib/aws-cognito';
-import {
-  IdentityPool,
-  IIdentityPool,
-} from 'aws-cdk-lib/aws-cognito-identitypool';
 import { Runtime, Code } from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
 import { TenantRole } from '../../construct/tenant-role';
@@ -109,23 +104,12 @@ export class TenantIAMStack extends cdk.Stack {
       );
     }
 
-    // Import existing pools using the context values from main stack
-    const userPool = UserPool.fromUserPoolId(
-      this,
-      'ImportedUserPool',
-      userPoolId
-    );
-    const identityPool = IdentityPool.fromIdentityPoolId(
-      this,
-      'ImportedIdentityPool',
-      identityPoolId
-    );
-
     // Create the tenant role construct
+    // Note: We pass identityPoolId directly as a string instead of using IdentityPool.fromIdentityPoolId()
+    // to avoid CloudFormation Early Validation errors (AWS::EarlyValidation::ResourceExistenceCheck)
     this.tenantRole = new TenantRole(this, 'TenantRole', {
       tenantId: this.tenantId,
-      userPool: userPool,
-      identityPool: identityPool,
+      identityPoolId: identityPoolId,
       userPoolClientId: userPoolClientId,
       region: this.region,
       account: this.account,

--- a/packages/cdk/lib/stacks/tenant/tenant-iam-stack.ts
+++ b/packages/cdk/lib/stacks/tenant/tenant-iam-stack.ts
@@ -119,7 +119,7 @@ export class TenantIAMStack extends cdk.Stack {
 
     // Create a Lambda to call the registration API
     const registerTenantLambda = new NodejsFunction(this, 'RegisterTenant', {
-      functionName: `tenant-registration-caller-${this.tenantId}`,
+      functionName: `tenant-registration-caller-${environment}-${this.tenantId}`,
       runtime: Runtime.NODEJS_18_X,
       handler: 'index.handler',
       timeout: cdk.Duration.seconds(30),


### PR DESCRIPTION
## Summary
- TenantIAMStack デプロイ時に発生する `AWS::EarlyValidation::ResourceExistenceCheck` エラーを修正
- CDK の `IdentityPool.fromIdentityPoolId()` メソッドを使用せず、`identityPoolId` を文字列として直接渡すように変更
- 不要になった `IUserPool` と `IIdentityPool` のインポートを削除

## Test plan
- [ ] `npm run cdk:tenant:synth` でテンプレート生成を確認
- [ ] `npm run cdk:tenant:deploy` でテナントスタックのデプロイを確認
- [ ] IAM ロールの信頼ポリシーが正しく生成されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)