### PR TITLE
:bug: fix(billing): プラン変更後のactivate-from-sessionでPLAN_NOT_FOUNDエラーを修正

### DIFF
--- a/packages/cdk/lambda/billing/user-api/subscriptions/changeSubscriptionPlan.ts
+++ b/packages/cdk/lambda/billing/user-api/subscriptions/changeSubscriptionPlan.ts
@@ -395,7 +395,7 @@ export const handler = async (
         type: 'plan_change',
         previousSubscriptionId: subscription.platform_subscription_id,
         previousPlanId: currentPlanId,
-        newPlanId: newPlanId,
+        planId: newPlanId,
         isUpgrade: isUpgrade.toString(),
         internalSubscriptionId: subscriptionId,
         userId,


### PR DESCRIPTION
## 問題の概要

プラン変更後に `activate-from-session` を呼び出す際に、PLAN_NOT_FOUND エラーが発生していました。

## 原因

`changeSubscriptionPlan.ts` でセッションメタデータに設定するキーが `newPlanId` となっていましたが、`activateFromSession.ts` では `session.metadata.planId` を期待していました。このキー名の不一致により、プラン情報が正しく取得できず、エラーが発生していました。

## 修正内容

- `packages/cdk/lambda/billing/user-api/subscriptions/changeSubscriptionPlan.ts` の 398 行目で、セッションメタデータのキーを `newPlanId` から `planId` に変更しました
- これにより、`activateFromSession.ts` で正しくプラン ID を取得できるようになります

## 影響範囲

- プラン変更機能のセッション管理に影響
- `activate-from-session` 呼び出し時のプラン情報取得処理
- サブスクリプション変更フロー全体の安定性向上