### PR TITLE
:sparkles: feat(summary): ユーザーサマリー機能の実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8961,6 +8961,578 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@aws-sdk/client-sfn": {
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sfn/-/client-sfn-3.965.0.tgz",
+      "integrity": "sha512-8ETr40WrvAfHuqW7mdf6bNSSosWSVyC2agTqUDa/y6td2FcwvTpaAZWk0kmNnuQVOpKpxfLo0VS4Vd+xXxNuYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/credential-provider-node": "3.965.0",
+        "@aws-sdk/middleware-host-header": "3.965.0",
+        "@aws-sdk/middleware-logger": "3.965.0",
+        "@aws-sdk/middleware-recursion-detection": "3.965.0",
+        "@aws-sdk/middleware-user-agent": "3.965.0",
+        "@aws-sdk/region-config-resolver": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
+        "@aws-sdk/util-endpoints": "3.965.0",
+        "@aws-sdk/util-user-agent-browser": "3.965.0",
+        "@aws-sdk/util-user-agent-node": "3.965.0",
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/core": "^3.20.0",
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/hash-node": "^4.2.7",
+        "@smithy/invalid-dependency": "^4.2.7",
+        "@smithy/middleware-content-length": "^4.2.7",
+        "@smithy/middleware-endpoint": "^4.4.1",
+        "@smithy/middleware-retry": "^4.4.17",
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/middleware-stack": "^4.2.7",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.16",
+        "@smithy/util-defaults-mode-node": "^4.2.19",
+        "@smithy/util-endpoints": "^3.2.7",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-retry": "^4.2.7",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@aws-sdk/client-sso": {
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.965.0.tgz",
+      "integrity": "sha512-iv2tr+n4aZ+nPUFFvG00hISPuEd4DU+1/Q8rPAYKXsM+vEPJ2nAnP5duUOa2fbOLIUCRxX3dcQaQaghVHDHzQw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/middleware-host-header": "3.965.0",
+        "@aws-sdk/middleware-logger": "3.965.0",
+        "@aws-sdk/middleware-recursion-detection": "3.965.0",
+        "@aws-sdk/middleware-user-agent": "3.965.0",
+        "@aws-sdk/region-config-resolver": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
+        "@aws-sdk/util-endpoints": "3.965.0",
+        "@aws-sdk/util-user-agent-browser": "3.965.0",
+        "@aws-sdk/util-user-agent-node": "3.965.0",
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/core": "^3.20.0",
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/hash-node": "^4.2.7",
+        "@smithy/invalid-dependency": "^4.2.7",
+        "@smithy/middleware-content-length": "^4.2.7",
+        "@smithy/middleware-endpoint": "^4.4.1",
+        "@smithy/middleware-retry": "^4.4.17",
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/middleware-stack": "^4.2.7",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.16",
+        "@smithy/util-defaults-mode-node": "^4.2.19",
+        "@smithy/util-endpoints": "^3.2.7",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-retry": "^4.2.7",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@aws-sdk/core": {
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.965.0.tgz",
+      "integrity": "sha512-aq9BhQxdHit8UUJ9C0im9TtuKeK0pT6NXmNJxMTCFeStI7GG7ImIsSislg3BZTIifVg1P6VLdzMyz9de85iutQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.965.0",
+        "@aws-sdk/xml-builder": "3.965.0",
+        "@smithy/core": "^3.20.0",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/signature-v4": "^5.3.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.965.0.tgz",
+      "integrity": "sha512-mdGnaIjMxTIjsb70dEj3VsWPWpoq1V5MWzBSfJq2H8zgMBXjn6d5/qHP8HMf53l9PrsgqzMpXGv3Av549A2x1g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.965.0.tgz",
+      "integrity": "sha512-YuGQel9EgA/z25oeLM+GYYQS750+8AESvr7ZEmVnRPL0sg+K3DmGqdv+9gFjFd0UkLjTlC/jtbP2cuY6UcPiHQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-stream": "^4.5.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.965.0.tgz",
+      "integrity": "sha512-xRo72Prer5s0xYVSCxCymVIRSqrVlevK5cmU0GWq9yJtaBNpnx02jwdJg80t/Ni7pgbkQyFWRMcq38c1tc6M/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/credential-provider-env": "3.965.0",
+        "@aws-sdk/credential-provider-http": "3.965.0",
+        "@aws-sdk/credential-provider-login": "3.965.0",
+        "@aws-sdk/credential-provider-process": "3.965.0",
+        "@aws-sdk/credential-provider-sso": "3.965.0",
+        "@aws-sdk/credential-provider-web-identity": "3.965.0",
+        "@aws-sdk/nested-clients": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
+        "@smithy/credential-provider-imds": "^4.2.7",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.965.0.tgz",
+      "integrity": "sha512-43/H8Qku8LHyugbhLo8kjD+eauhybCeVkmrnvWl8bXNHJP7xi1jCdtBQJKKJqiIHZws4MOEwkji8kFdAVRCe6g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/nested-clients": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.965.0.tgz",
+      "integrity": "sha512-cRxmMHF+Zh2lkkkEVduKl+8OQdtg/DhYA69+/7SPSQURlgyjFQGlRQ58B7q8abuNlrGT3sV+UzeOylZpJbV61Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.965.0",
+        "@aws-sdk/credential-provider-http": "3.965.0",
+        "@aws-sdk/credential-provider-ini": "3.965.0",
+        "@aws-sdk/credential-provider-process": "3.965.0",
+        "@aws-sdk/credential-provider-sso": "3.965.0",
+        "@aws-sdk/credential-provider-web-identity": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
+        "@smithy/credential-provider-imds": "^4.2.7",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.965.0.tgz",
+      "integrity": "sha512-gmkPmdiR0yxnTzLPDb7rwrDhGuCUjtgnj8qWP+m0gSz/W43rR4jRPVEf6DUX2iC+ImQhxo3NFhuB3V42Kzo3TQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.965.0.tgz",
+      "integrity": "sha512-N01AYvtCqG3Wo/s/LvYt19ity18/FqggiXT+elAs3X9Om/Wfx+hw9G+i7jaDmy+/xewmv8AdQ2SK5Q30dXw/Fw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.965.0",
+        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/token-providers": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.965.0.tgz",
+      "integrity": "sha512-T4gMZ2JzXnfxe1oTD+EDGLSxFfk1+WkLZdiHXEMZp8bFI1swP/3YyDFXI+Ib9Uq1JhnAmrCXtOnkicKEhDkdhQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/nested-clients": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.965.0.tgz",
+      "integrity": "sha512-SfpSYqoPOAmdb3DBsnNsZ0vix+1VAtkUkzXM79JL3R5IfacpyKE2zytOgVAQx/FjhhlpSTwuXd+LRhUEVb3MaA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.965.0",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.965.0.tgz",
+      "integrity": "sha512-gjUvJRZT1bUABKewnvkj51LAynFrfz2h5DYAg5/2F4Utx6UOGByTSr9Rq8JCLbURvvzAbCtcMkkIJRxw+8Zuzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.965.0",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.965.0.tgz",
+      "integrity": "sha512-6dvD+18Ni14KCRu+tfEoNxq1sIGVp9tvoZDZ7aMvpnA7mDXuRLrOjRQ/TAZqXwr9ENKVGyxcPl0cRK8jk1YWjA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.965.0",
+        "@aws/lambda-invoke-store": "^0.2.2",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.965.0.tgz",
+      "integrity": "sha512-RBEYVGgu/WeAt+H/qLrGc+t8LqAUkbyvh3wBfTiuAD+uBcWsKnvnB1iSBX75FearC0fmoxzXRUc0PMxMdqpjJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
+        "@aws-sdk/util-endpoints": "3.965.0",
+        "@smithy/core": "^3.20.0",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.965.0.tgz",
+      "integrity": "sha512-muNVUjUEU+/KLFrLzQ8PMXyw4+a/MP6t4GIvwLtyx/kH0rpSy5s0YmqacMXheuIe6F/5QT8uksXGNAQenitkGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/middleware-host-header": "3.965.0",
+        "@aws-sdk/middleware-logger": "3.965.0",
+        "@aws-sdk/middleware-recursion-detection": "3.965.0",
+        "@aws-sdk/middleware-user-agent": "3.965.0",
+        "@aws-sdk/region-config-resolver": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
+        "@aws-sdk/util-endpoints": "3.965.0",
+        "@aws-sdk/util-user-agent-browser": "3.965.0",
+        "@aws-sdk/util-user-agent-node": "3.965.0",
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/core": "^3.20.0",
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/hash-node": "^4.2.7",
+        "@smithy/invalid-dependency": "^4.2.7",
+        "@smithy/middleware-content-length": "^4.2.7",
+        "@smithy/middleware-endpoint": "^4.4.1",
+        "@smithy/middleware-retry": "^4.4.17",
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/middleware-stack": "^4.2.7",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/smithy-client": "^4.10.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.16",
+        "@smithy/util-defaults-mode-node": "^4.2.19",
+        "@smithy/util-endpoints": "^3.2.7",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-retry": "^4.2.7",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.965.0.tgz",
+      "integrity": "sha512-RoMhu9ly2B0coxn8ctXosPP2WmDD0MkQlZGLjoYHQUOCBmty5qmCxOqBmBDa6wbWbB8xKtMQ/4VXloQOgzjHXg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.965.0",
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@aws-sdk/token-providers": {
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.965.0.tgz",
+      "integrity": "sha512-aR0qxg0b8flkXJVE+CM1gzo7uJ57md50z2eyCwofC0QIz5Y0P7/7vvb9/dmUQt6eT9XRN5iRcUqq2IVxVDvJOw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.965.0",
+        "@aws-sdk/nested-clients": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@aws-sdk/types": {
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.965.0.tgz",
+      "integrity": "sha512-jvodoJdMavvg8faN7co58vVJRO5MVep4JFPRzUNCzpJ98BDqWDk/ad045aMJcmxkLzYLS2UAnUmqjJ/tUPNlzQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.965.0.tgz",
+      "integrity": "sha512-WqSCB0XIsGUwZWvrYkuoofi2vzoVHqyeJ2kN+WyoOsxPLTiQSBIoqm/01R/qJvoxwK/gOOF7su9i84Vw2NQQpQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.965.0",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-endpoints": "^3.2.7",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.965.0.tgz",
+      "integrity": "sha512-Xiza/zMntQGpkd2dETQeAK8So1pg5+STTzpcdGWxj5q0jGO5ayjqT/q1Q7BrsX5KIr6PvRkl9/V7lLCv04wGjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.965.0",
+        "@smithy/types": "^4.11.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.965.0.tgz",
+      "integrity": "sha512-kokIHUfNT3/P55E4fUJJrFHuuA9BbjFKUIxoLrd3UaRfdafT0ScRfg2eaZie6arf60EuhlUIZH0yALxttMEjxQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.965.0",
+        "@aws-sdk/types": "3.965.0",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@aws-sdk/xml-builder": {
+      "version": "3.965.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.965.0.tgz",
+      "integrity": "sha512-Tcod25/BTupraQwtb+Q+GX8bmEZfxIFjjJ/AvkhUZsZlkPeVluzq1uu3Oeqf145DCdMjzLIN6vab5MrykbDP+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.2.tgz",
+      "integrity": "sha512-C0NBLsIqzDIae8HFw9YIrIBsbc0xTiOtt7fAukGPnqQ/+zZNaq+4jhuccltK0QuWHBnNm/a6kLIRA6GFiM10eg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@smithy/protocol-http": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.7.tgz",
+      "integrity": "sha512-1r07pb994I20dD/c2seaZhoCuNYm0rWrvBxhCQ70brNh11M5Ml2ew6qJVo0lclB3jMIXirD4s2XRXRe7QEi0xA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.11.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@smithy/signature-v4": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.7.tgz",
+      "integrity": "sha512-9oNUlqBlFZFOSdxgImA6X5GFuzE7V2H7VG/7E70cdLhidFbdtvxxt81EHgykGK5vq5D3FafH//X+Oy31j3CKOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sfn/node_modules/@smithy/util-utf8": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
     "node_modules/@aws-sdk/client-sqs": {
       "version": "3.927.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.927.0.tgz",
@@ -21830,12 +22402,12 @@
       }
     },
     "node_modules/@smithy/abort-controller": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.5.tgz",
-      "integrity": "sha512-j7HwVkBw68YW8UmFRcjZOmssE77Rvk0GWAIN1oFBhsaovQmZWYCIcGa9/pwRB0ExI8Sk9MWNALTjftjHZea7VA==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.7.tgz",
+      "integrity": "sha512-rzMY6CaKx2qxrbYbqjXWS0plqEy7LOdKHS0bg4ixJ6aoGDPNUcLWk/FRNuCILh7GKLG9TFUXYYeQQldMBBwuyw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -21868,16 +22440,16 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.3.tgz",
-      "integrity": "sha512-ezHLe1tKLUxDJo2LHtDuEDyWXolw8WGOR92qb4bQdWq/zKenO5BvctZGrVJBK08zjezSk7bmbKFOXIVyChvDLw==",
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.5.tgz",
+      "integrity": "sha512-HAGoUAFYsUkoSckuKbCPayECeMim8pOu+yLy1zOxt1sifzEbrsRpYa+mKcMdiHKMeiqOibyPG0sFJnmaV/OGEg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/types": "^4.11.0",
         "@smithy/util-config-provider": "^4.2.0",
-        "@smithy/util-endpoints": "^3.2.5",
-        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-endpoints": "^3.2.7",
+        "@smithy/util-middleware": "^4.2.7",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -21885,18 +22457,18 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.18.7",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.18.7.tgz",
-      "integrity": "sha512-axG9MvKhMWOhFbvf5y2DuyTxQueO0dkedY9QC3mAfndLosRI/9LJv8WaL0mw7ubNhsO4IuXX9/9dYGPFvHrqlw==",
+      "version": "3.20.1",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.20.1.tgz",
+      "integrity": "sha512-wOboSEdQ85dbKAJ0zL+wQ6b0HTSBRhtGa0PYKysQXkRg+vK0tdCRRVruiFM2QMprkOQwSYOnwF4og96PAaEGag==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/middleware-serde": "^4.2.6",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-body-length-browser": "^4.2.0",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-stream": "^4.5.8",
         "@smithy/util-utf8": "^4.2.0",
         "@smithy/uuid": "^1.1.0",
         "tslib": "^2.6.2"
@@ -21906,12 +22478,12 @@
       }
     },
     "node_modules/@smithy/core/node_modules/@smithy/protocol-http": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.5.tgz",
-      "integrity": "sha512-RlaL+sA0LNMp03bf7XPbFmT5gN+w3besXSWMkA8rcmxLSVfiEXElQi4O2IWwPfxzcHkxqrwBFMbngB8yx/RvaQ==",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.7.tgz",
+      "integrity": "sha512-1r07pb994I20dD/c2seaZhoCuNYm0rWrvBxhCQ70brNh11M5Ml2ew6qJVo0lclB3jMIXirD4s2XRXRe7QEi0xA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -21932,15 +22504,15 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.5.tgz",
-      "integrity": "sha512-BZwotjoZWn9+36nimwm/OLIcVe+KYRwzMjfhd4QT7QxPm9WY0HiOV8t/Wlh+HVUif0SBVV7ksq8//hPaBC/okQ==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.7.tgz",
+      "integrity": "sha512-CmduWdCiILCRNbQWFR0OcZlUPVtyE49Sr8yYL0rZQ4D/wKxiNzBNS/YHemvnbkIWj623fplgkexUd/c9CAKdoA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22114,14 +22686,14 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.6.tgz",
-      "integrity": "sha512-3+RG3EA6BBJ/ofZUeTFJA7mHfSYrZtQIrDP9dI8Lf7X6Jbos2jptuLrAAteDiFVrmbEmLSuRG/bUKzfAXk7dhg==",
+      "version": "5.3.8",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.8.tgz",
+      "integrity": "sha512-h/Fi+o7mti4n8wx1SR6UHWLaakwHRx29sizvp8OOm7iqwKGFneT06GCSFhml6Bha5BT6ot5pj3CYZnCHhGC2Rg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/querystring-builder": "^4.2.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/querystring-builder": "^4.2.7",
+        "@smithy/types": "^4.11.0",
         "@smithy/util-base64": "^4.3.0",
         "tslib": "^2.6.2"
       },
@@ -22130,12 +22702,12 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler/node_modules/@smithy/protocol-http": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.5.tgz",
-      "integrity": "sha512-RlaL+sA0LNMp03bf7XPbFmT5gN+w3besXSWMkA8rcmxLSVfiEXElQi4O2IWwPfxzcHkxqrwBFMbngB8yx/RvaQ==",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.7.tgz",
+      "integrity": "sha512-1r07pb994I20dD/c2seaZhoCuNYm0rWrvBxhCQ70brNh11M5Ml2ew6qJVo0lclB3jMIXirD4s2XRXRe7QEi0xA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22158,12 +22730,12 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.5.tgz",
-      "integrity": "sha512-DpYX914YOfA3UDT9CN1BM787PcHfWRBB43fFGCYrZFUH0Jv+5t8yYl+Pd5PW4+QzoGEDvn5d5QIO4j2HyYZQSA==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.7.tgz",
+      "integrity": "sha512-PU/JWLTBCV1c8FtB8tEFnY4eV1tSfBc7bDBADHfn1K+uRbPgSJ9jnJp0hyjiFN2PMdPzxsf1Fdu0eo9fJ760Xw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.11.0",
         "@smithy/util-buffer-from": "^4.2.0",
         "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
@@ -22213,12 +22785,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.5.tgz",
-      "integrity": "sha512-2L2erASEro1WC5nV+plwIMxrTXpvpfzl4e+Nre6vBVRR2HKeGGcvpJyyL3/PpiSg+cJG2KpTmZmq934Olb6e5A==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.7.tgz",
+      "integrity": "sha512-ncvgCr9a15nPlkhIUx3CU4d7E7WEuVJOV7fS7nnK2hLtPK9tYRBkMHQbhXU1VvvKeBm/O0x26OEoBq+ngFpOEQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22265,13 +22837,13 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.5.tgz",
-      "integrity": "sha512-Y/RabVa5vbl5FuHYV2vUCwvh/dqzrEY/K2yWPSqvhFUwIY0atLqO4TienjBXakoy4zrKAMCZwg+YEqmH7jaN7A==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.7.tgz",
+      "integrity": "sha512-GszfBfCcvt7kIbJ41LuNa5f0wvQCHhnGx/aDaZJCCT05Ld6x6U2s0xsc/0mBFONBZjQJp2U/0uSJ178OXOwbhg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22279,12 +22851,12 @@
       }
     },
     "node_modules/@smithy/middleware-content-length/node_modules/@smithy/protocol-http": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.5.tgz",
-      "integrity": "sha512-RlaL+sA0LNMp03bf7XPbFmT5gN+w3besXSWMkA8rcmxLSVfiEXElQi4O2IWwPfxzcHkxqrwBFMbngB8yx/RvaQ==",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.7.tgz",
+      "integrity": "sha512-1r07pb994I20dD/c2seaZhoCuNYm0rWrvBxhCQ70brNh11M5Ml2ew6qJVo0lclB3jMIXirD4s2XRXRe7QEi0xA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22292,18 +22864,18 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.3.14",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.14.tgz",
-      "integrity": "sha512-v0q4uTKgBM8dsqGjqsabZQyH85nFaTnFcgpWU1uydKFsdyyMzfvOkNum9G7VK+dOP01vUnoZxIeRiJ6uD0kjIg==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.2.tgz",
+      "integrity": "sha512-mqpAdux0BNmZu/SqkFhQEnod4fX23xxTvU2LUpmKp0JpSI+kPYCiHJMmzREr8yxbNxKL2/DU1UZm9i++ayU+2g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.18.7",
-        "@smithy/middleware-serde": "^4.2.6",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
-        "@smithy/url-parser": "^4.2.5",
-        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/core": "^3.20.1",
+        "@smithy/middleware-serde": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
+        "@smithy/url-parser": "^4.2.7",
+        "@smithy/util-middleware": "^4.2.7",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22311,18 +22883,18 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.4.14",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.14.tgz",
-      "integrity": "sha512-Z2DG8Ej7FyWG1UA+7HceINtSLzswUgs2np3sZX0YBBxCt+CXG4QUxv88ZDS3+2/1ldW7LqtSY1UO/6VQ1pND8Q==",
+      "version": "4.4.18",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.18.tgz",
+      "integrity": "sha512-E5hulijA59nBk/zvcwVMaS7FG7Y4l6hWA9vrW018r+8kiZef4/ETQaPI4oY+3zsy9f6KqDv3c4VKtO4DwwgpCg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/service-error-classification": "^4.2.5",
-        "@smithy/smithy-client": "^4.9.10",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-middleware": "^4.2.5",
-        "@smithy/util-retry": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/service-error-classification": "^4.2.7",
+        "@smithy/smithy-client": "^4.10.3",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-middleware": "^4.2.7",
+        "@smithy/util-retry": "^4.2.7",
         "@smithy/uuid": "^1.1.0",
         "tslib": "^2.6.2"
       },
@@ -22331,12 +22903,12 @@
       }
     },
     "node_modules/@smithy/middleware-retry/node_modules/@smithy/protocol-http": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.5.tgz",
-      "integrity": "sha512-RlaL+sA0LNMp03bf7XPbFmT5gN+w3besXSWMkA8rcmxLSVfiEXElQi4O2IWwPfxzcHkxqrwBFMbngB8yx/RvaQ==",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.7.tgz",
+      "integrity": "sha512-1r07pb994I20dD/c2seaZhoCuNYm0rWrvBxhCQ70brNh11M5Ml2ew6qJVo0lclB3jMIXirD4s2XRXRe7QEi0xA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22344,13 +22916,13 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.6.tgz",
-      "integrity": "sha512-VkLoE/z7e2g8pirwisLz8XJWedUSY8my/qrp81VmAdyrhi94T+riBfwP+AOEEFR9rFTSonC/5D2eWNmFabHyGQ==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.8.tgz",
+      "integrity": "sha512-8rDGYen5m5+NV9eHv9ry0sqm2gI6W7mc1VSFMtn6Igo25S507/HaOX9LTHAS2/J32VXD0xSzrY0H5FJtOMS4/w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22358,12 +22930,12 @@
       }
     },
     "node_modules/@smithy/middleware-serde/node_modules/@smithy/protocol-http": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.5.tgz",
-      "integrity": "sha512-RlaL+sA0LNMp03bf7XPbFmT5gN+w3besXSWMkA8rcmxLSVfiEXElQi4O2IWwPfxzcHkxqrwBFMbngB8yx/RvaQ==",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.7.tgz",
+      "integrity": "sha512-1r07pb994I20dD/c2seaZhoCuNYm0rWrvBxhCQ70brNh11M5Ml2ew6qJVo0lclB3jMIXirD4s2XRXRe7QEi0xA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22371,12 +22943,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.5.tgz",
-      "integrity": "sha512-bYrutc+neOyWxtZdbB2USbQttZN0mXaOyYLIsaTbJhFsfpXyGWUxJpEuO1rJ8IIJm2qH4+xJT0mxUSsEDTYwdQ==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.7.tgz",
+      "integrity": "sha512-bsOT0rJ+HHlZd9crHoS37mt8qRRN/h9jRve1SXUhVbkRzu0QaNYZp1i1jha4n098tsvROjcwfLlfvcFuJSXEsw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22384,14 +22956,14 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.5.tgz",
-      "integrity": "sha512-UTurh1C4qkVCtqggI36DGbLB2Kv8UlcFdMXDcWMbqVY2uRg0XmT9Pb4Vj6oSQ34eizO1fvR0RnFV4Axw4IrrAg==",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.7.tgz",
+      "integrity": "sha512-7r58wq8sdOcrwWe+klL9y3bc4GW1gnlfnFOuL7CXa7UzfhzhxKuzNdtqgzmTV+53lEp9NXh5hY/S4UgjLOzPfw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/shared-ini-file-loader": "^4.4.0",
-        "@smithy/types": "^4.9.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/shared-ini-file-loader": "^4.4.2",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22399,15 +22971,15 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.4.5",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.5.tgz",
-      "integrity": "sha512-CMnzM9R2WqlqXQGtIlsHMEZfXKJVTIrqCNoSd/QpAyp+Dw0a1Vps13l6ma1fH8g7zSPNsA59B/kWgeylFuA/lw==",
+      "version": "4.4.7",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.7.tgz",
+      "integrity": "sha512-NELpdmBOO6EpZtWgQiHjoShs1kmweaiNuETUpuup+cmm/xJYjT4eUjfhrXRP4jCOaAsS3c3yPsP3B+K+/fyPCQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/abort-controller": "^4.2.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/querystring-builder": "^4.2.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/abort-controller": "^4.2.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/querystring-builder": "^4.2.7",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22415,12 +22987,12 @@
       }
     },
     "node_modules/@smithy/node-http-handler/node_modules/@smithy/protocol-http": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.5.tgz",
-      "integrity": "sha512-RlaL+sA0LNMp03bf7XPbFmT5gN+w3besXSWMkA8rcmxLSVfiEXElQi4O2IWwPfxzcHkxqrwBFMbngB8yx/RvaQ==",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.7.tgz",
+      "integrity": "sha512-1r07pb994I20dD/c2seaZhoCuNYm0rWrvBxhCQ70brNh11M5Ml2ew6qJVo0lclB3jMIXirD4s2XRXRe7QEi0xA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22428,12 +23000,12 @@
       }
     },
     "node_modules/@smithy/property-provider": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.5.tgz",
-      "integrity": "sha512-8iLN1XSE1rl4MuxvQ+5OSk/Zb5El7NJZ1td6Tn+8dQQHIjp59Lwl6bd0+nzw6SKm2wSSriH2v/I9LPzUic7EOg==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.7.tgz",
+      "integrity": "sha512-jmNYKe9MGGPoSl/D7JDDs1C8b3dC8f/w78LbaVfoTtWy4xAd5dfjaFG9c9PWPihY4ggMQNQSMtzU77CNgAJwmA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22466,12 +23038,12 @@
       }
     },
     "node_modules/@smithy/querystring-builder": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.5.tgz",
-      "integrity": "sha512-y98otMI1saoajeik2kLfGyRp11e5U/iJYH/wLCh3aTV/XutbGT9nziKGkgCaMD1ghK7p6htHMm6b6scl9JRUWg==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.7.tgz",
+      "integrity": "sha512-eKONSywHZxK4tBxe2lXEysh8wbBdvDWiA+RIuaxZSgCMmA0zMgoDpGLJhnyj+c0leOQprVnXOmcB4m+W9Rw7sg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.11.0",
         "@smithy/util-uri-escape": "^4.2.0",
         "tslib": "^2.6.2"
       },
@@ -22480,12 +23052,12 @@
       }
     },
     "node_modules/@smithy/querystring-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.5.tgz",
-      "integrity": "sha512-031WCTdPYgiQRYNPXznHXof2YM0GwL6SeaSyTH/P72M1Vz73TvCNH2Nq8Iu2IEPq9QP2yx0/nrw5YmSeAi/AjQ==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.7.tgz",
+      "integrity": "sha512-3X5ZvzUHmlSTHAXFlswrS6EGt8fMSIxX/c3Rm1Pni3+wYWB6cjGocmRIoqcQF9nU5OgGmL0u7l9m44tSUpfj9w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22493,24 +23065,24 @@
       }
     },
     "node_modules/@smithy/service-error-classification": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.5.tgz",
-      "integrity": "sha512-8fEvK+WPE3wUAcDvqDQG1Vk3ANLR8Px979te96m84CbKAjBVf25rPYSzb4xU4hlTyho7VhOGnh5i62D/JVF0JQ==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.7.tgz",
+      "integrity": "sha512-YB7oCbukqEb2Dlh3340/8g8vNGbs/QsNNRms+gv3N2AtZz9/1vSBx6/6tpwQpZMEJFs7Uq8h4mmOn48ZZ72MkA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0"
+        "@smithy/types": "^4.11.0"
       },
       "engines": {
         "node": ">=18.0.0"
       }
     },
     "node_modules/@smithy/shared-ini-file-loader": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.0.tgz",
-      "integrity": "sha512-5WmZ5+kJgJDjwXXIzr1vDTG+RhF9wzSODQBfkrQ2VVkYALKGvZX1lgVSxEkgicSAFnFhPj5rudJV0zoinqS0bA==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.2.tgz",
+      "integrity": "sha512-M7iUUff/KwfNunmrgtqBfvZSzh3bmFgv/j/t1Y1dQ+8dNo34br1cqVEqy6v0mYEgi0DkGO7Xig0AnuOaEGVlcg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22597,17 +23169,17 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.9.10",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.10.tgz",
-      "integrity": "sha512-Jaoz4Jw1QYHc1EFww/E6gVtNjhoDU+gwRKqXP6C3LKYqqH2UQhP8tMP3+t/ePrhaze7fhLE8vS2q6vVxBANFTQ==",
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.10.3.tgz",
+      "integrity": "sha512-EfECiO/0fAfb590LBnUe7rI5ux7XfquQ8LBzTe7gxw0j9QW/q8UT/EHWHlxV/+jhQ3+Ssga9uUYXCQgImGMbNg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.18.7",
-        "@smithy/middleware-endpoint": "^4.3.14",
-        "@smithy/middleware-stack": "^4.2.5",
-        "@smithy/protocol-http": "^5.3.5",
-        "@smithy/types": "^4.9.0",
-        "@smithy/util-stream": "^4.5.6",
+        "@smithy/core": "^3.20.1",
+        "@smithy/middleware-endpoint": "^4.4.2",
+        "@smithy/middleware-stack": "^4.2.7",
+        "@smithy/protocol-http": "^5.3.7",
+        "@smithy/types": "^4.11.0",
+        "@smithy/util-stream": "^4.5.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22615,12 +23187,12 @@
       }
     },
     "node_modules/@smithy/smithy-client/node_modules/@smithy/protocol-http": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.5.tgz",
-      "integrity": "sha512-RlaL+sA0LNMp03bf7XPbFmT5gN+w3besXSWMkA8rcmxLSVfiEXElQi4O2IWwPfxzcHkxqrwBFMbngB8yx/RvaQ==",
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.7.tgz",
+      "integrity": "sha512-1r07pb994I20dD/c2seaZhoCuNYm0rWrvBxhCQ70brNh11M5Ml2ew6qJVo0lclB3jMIXirD4s2XRXRe7QEi0xA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22628,9 +23200,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.9.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.9.0.tgz",
-      "integrity": "sha512-MvUbdnXDTwykR8cB1WZvNNwqoWVaTRA0RLlLmf/cIFNMM2cKWz01X4Ly6SMC4Kks30r8tT3Cty0jmeWfiuyHTA==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.11.0.tgz",
+      "integrity": "sha512-mlrmL0DRDVe3mNrjTcVcZEgkFmufITfUAPBEA+AHYiIeYyJebso/He1qLbP3PssRe22KUzLRpQSdBPbXdgZ2VA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -22640,13 +23212,13 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.5.tgz",
-      "integrity": "sha512-VaxMGsilqFnK1CeBX+LXnSuaMx4sTL/6znSZh2829txWieazdVxr54HmiyTsIbpOTLcf5nYpq9lpzmwRdxj6rQ==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.7.tgz",
+      "integrity": "sha512-/RLtVsRV4uY3qPWhBDsjwahAtt3x2IsMGnP5W1b2VZIe+qgCqkLxI1UOHDZp1Q1QSOrdOR32MF3Ph2JfWT1VHg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/querystring-parser": "^4.2.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/querystring-parser": "^4.2.7",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22730,14 +23302,14 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.3.13",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.13.tgz",
-      "integrity": "sha512-hlVLdAGrVfyNei+pKIgqDTxfu/ZI2NSyqj4IDxKd5bIsIqwR/dSlkxlPaYxFiIaDVrBy0he8orsFy+Cz119XvA==",
+      "version": "4.3.17",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.17.tgz",
+      "integrity": "sha512-dwN4GmivYF1QphnP3xJESXKtHvkkvKHSZI8GrSKMVoENVSKW2cFPRYC4ZgstYjUHdR3zwaDkIaTDIp26JuY7Cw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/smithy-client": "^4.9.10",
-        "@smithy/types": "^4.9.0",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/smithy-client": "^4.10.3",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22745,17 +23317,17 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.2.16",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.16.tgz",
-      "integrity": "sha512-F1t22IUiJLHrxW9W1CQ6B9PN+skZ9cqSuzB18Eh06HrJPbjsyZ7ZHecAKw80DQtyGTRcVfeukKaCRYebFwclbg==",
+      "version": "4.2.20",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.20.tgz",
+      "integrity": "sha512-VD/I4AEhF1lpB3B//pmOIMBNLMrtdMXwy9yCOfa2QkJGDr63vH3RqPbSAKzoGMov3iryCxTXCxSsyGmEB8PDpg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/config-resolver": "^4.4.3",
-        "@smithy/credential-provider-imds": "^4.2.5",
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/property-provider": "^4.2.5",
-        "@smithy/smithy-client": "^4.9.10",
-        "@smithy/types": "^4.9.0",
+        "@smithy/config-resolver": "^4.4.5",
+        "@smithy/credential-provider-imds": "^4.2.7",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/property-provider": "^4.2.7",
+        "@smithy/smithy-client": "^4.10.3",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22763,13 +23335,13 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.5.tgz",
-      "integrity": "sha512-3O63AAWu2cSNQZp+ayl9I3NapW1p1rR5mlVHcF6hAB1dPZUQFfRPYtplWX/3xrzWthPGj5FqB12taJJCfH6s8A==",
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.7.tgz",
+      "integrity": "sha512-s4ILhyAvVqhMDYREeTS68R43B1V5aenV5q/V1QpRQJkCXib5BPRo4s7uNdzGtIKxaPHCfU/8YkvPAEvTpxgspg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/node-config-provider": "^4.3.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/node-config-provider": "^4.3.7",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22789,12 +23361,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.5.tgz",
-      "integrity": "sha512-6Y3+rvBF7+PZOc40ybeZMcGln6xJGVeY60E7jy9Mv5iKpMJpHgRE6dKy9ScsVxvfAYuEX4Q9a65DQX90KaQ3bA==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.7.tgz",
+      "integrity": "sha512-i1IkpbOae6NvIKsEeLLM9/2q4X+M90KV3oCFgWQI4q0Qz+yUZvsr+gZPdAEAtFhWQhAHpTsJO8DRJPuwVyln+w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.9.0",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22802,13 +23374,13 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.2.5",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.5.tgz",
-      "integrity": "sha512-GBj3+EZBbN4NAqJ/7pAhsXdfzdlznOh8PydUijy6FpNIMnHPSMO2/rP4HKu+UFeikJxShERk528oy7GT79YiJg==",
+      "version": "4.2.7",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.7.tgz",
+      "integrity": "sha512-SvDdsQyF5CIASa4EYVT02LukPHVzAgUA4kMAuZ97QJc2BpAqZfA4PINB8/KOoCXEw9tsuv/jQjMeaHFvxdLNGg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/service-error-classification": "^4.2.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/service-error-classification": "^4.2.7",
+        "@smithy/types": "^4.11.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -22816,14 +23388,14 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.6.tgz",
-      "integrity": "sha512-qWw/UM59TiaFrPevefOZ8CNBKbYEP6wBAIlLqxn3VAIo9rgnTNc4ASbVrqDmhuwI87usnjhdQrxodzAGFFzbRQ==",
+      "version": "4.5.8",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.8.tgz",
+      "integrity": "sha512-ZnnBhTapjM0YPGUSmOs0Mcg/Gg87k503qG4zU2v/+Js2Gu+daKOJMeqcQns8ajepY8tgzzfYxl6kQyZKml6O2w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/fetch-http-handler": "^5.3.6",
-        "@smithy/node-http-handler": "^4.4.5",
-        "@smithy/types": "^4.9.0",
+        "@smithy/fetch-http-handler": "^5.3.8",
+        "@smithy/node-http-handler": "^4.4.7",
+        "@smithy/types": "^4.11.0",
         "@smithy/util-base64": "^4.3.0",
         "@smithy/util-buffer-from": "^4.2.0",
         "@smithy/util-hex-encoding": "^4.2.0",
@@ -44660,6 +45232,7 @@
         "@aws-sdk/client-s3": "^3.755.0",
         "@aws-sdk/client-sagemaker-runtime": "^3.755.0",
         "@aws-sdk/client-secrets-manager": "^3.755.0",
+        "@aws-sdk/client-sfn": "^3.755.0",
         "@aws-sdk/client-sqs": "^3.927.0",
         "@aws-sdk/client-ssm": "^3.755.0",
         "@aws-sdk/client-sts": "^3.755.0",

--- a/packages/cdk/.gitignore
+++ b/packages/cdk/.gitignore
@@ -15,3 +15,7 @@ cdk.tenant.json
 
 # E2E test environment variables (use .env.e2e.example as template)
 .env.e2e
+
+# Summary external context prompts (use *.example.md as templates)
+prompts/daily-summary-context.md
+prompts/user-summary-context.md

--- a/packages/cdk/bin/generative-ai-use-cases-tenant.ts
+++ b/packages/cdk/bin/generative-ai-use-cases-tenant.ts
@@ -43,6 +43,7 @@ interface TenantConfig {
     identityPoolId: string;
     userPoolClientId: string;
     controlPlaneLambdaRoleArn?: string;
+    controlPlaneLambdaRoleArns?: string[];
     openSearchIndexName?: string;
   };
   ipAccessControl?: {
@@ -50,6 +51,7 @@ interface TenantConfig {
     allowedIpV4AddressRanges: string[];
     allowedIpV6AddressRanges: string[];
   };
+  summaryJobEnabled?: boolean;
 }
 
 let tenantConfig: TenantConfig = {};
@@ -133,6 +135,15 @@ if (tenantConfig.controlPlane) {
     );
   }
   if (
+    controlPlane.controlPlaneLambdaRoleArns &&
+    !app.node.getAllContext()['controlPlaneLambdaRoleArns']
+  ) {
+    app.node.setContext(
+      'controlPlaneLambdaRoleArns',
+      controlPlane.controlPlaneLambdaRoleArns
+    );
+  }
+  if (
     controlPlane.account &&
     !app.node.getAllContext()['controlPlaneAccount']
   ) {
@@ -210,6 +221,8 @@ const params = {
   openSearchIndexName: context.openSearchIndexName || 'assistant-docs',
   openFgaConfig: context.openFgaConfig,
   controlPlaneLambdaRoleArn: context.controlPlane?.controlPlaneLambdaRoleArn,
+  controlPlaneLambdaRoleArns: context.controlPlane?.controlPlaneLambdaRoleArns,
+  summaryJobEnabled: context.summaryJobEnabled ?? false,
 };
 
 createTenantStacks(app, params);

--- a/packages/cdk/cdk.context.json
+++ b/packages/cdk/cdk.context.json
@@ -1,0 +1,10 @@
+{
+  "availability-zones:account=409661147439:region=us-east-1": [
+    "us-east-1a",
+    "us-east-1b",
+    "us-east-1c",
+    "us-east-1d",
+    "us-east-1e",
+    "us-east-1f"
+  ]
+}

--- a/packages/cdk/cdk.example.json
+++ b/packages/cdk/cdk.example.json
@@ -78,6 +78,21 @@
     "domainName": null,
     "hostedZoneId": null,
     "dashboard": false,
+    "summaryJobEnabled": false,
+    "summaryJobConfig": {
+      "dailySummarySchedule": {
+        "minute": "0",
+        "hour": "19",
+        "month": "*",
+        "weekDay": "*"
+      },
+      "dailySummaryMaxChars": 200,
+      "userSummaryMaxChars": 500,
+      "userSummaryDefaultTermUnit": "month",
+      "userSummaryDefaultTermValue": 1,
+      "summaryModelId": "vertex_ai/gemini-2.5-flash",
+      "maxConcurrentUsers": 10
+    },
     "anonymousUsageTracking": true,
     "guardrailEnabled": false,
     "crossAccountBedrockRoleArn": "",

--- a/packages/cdk/cdk.tenant.example.json
+++ b/packages/cdk/cdk.tenant.example.json
@@ -11,7 +11,11 @@
       "userPoolId": "us-east-1_EXAMPLE123",
       "identityPoolId": "us-east-1:12345678-1234-1234-1234-123456789012",
       "userPoolClientId": "1234567890abcdefghijklmnop",
-      "controlPlaneLambdaRoleArn": "arn:aws:iam::111111111111:role/YOUR_ENV-billing-background-job-role",
+      "controlPlaneLambdaRoleArns": [
+        "arn:aws:iam::111111111111:role/CONTROL-PLANE-STACK-CentralPptxApiPptxLambdaRole-XXXXX",
+        "arn:aws:iam::111111111111:role/CONTROL-PLANE-STACK-SummaryGeneratorDailySummaryRole-XXXXX",
+        "arn:aws:iam::111111111111:role/YOUR_ENV-billing-background-job-role"
+      ],
       "tenantsTableName": "Tenants-dev",
       "openSearchIndexName": "assistant-docs"
     },
@@ -71,6 +75,7 @@
         "loggingLevel": "INFO",
         "dataTraceEnabled": false
       }
-    }
+    },
+    "summaryJobEnabled": false
   }
 }

--- a/packages/cdk/jest.config.js
+++ b/packages/cdk/jest.config.js
@@ -1,0 +1,12 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = {
+    testEnvironment: 'node',
+    roots: ['<rootDir>/test'],
+    testMatch: ['**/*.test.ts'],
+    transform: {
+        '^.+\\.tsx?$': 'ts-jest',
+    },
+    snapshotSerializers: ['<rootDir>/test/snapshot-plugin.ts'],
+};
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiamVzdC5jb25maWcuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJqZXN0LmNvbmZpZy50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiOztBQUFBLGtCQUFlO0lBQ2IsZUFBZSxFQUFFLE1BQU07SUFDdkIsS0FBSyxFQUFFLENBQUMsZ0JBQWdCLENBQUM7SUFDekIsU0FBUyxFQUFFLENBQUMsY0FBYyxDQUFDO0lBQzNCLFNBQVMsRUFBRTtRQUNULGFBQWEsRUFBRSxTQUFTO0tBQ3pCO0lBQ0QsbUJBQW1CLEVBQUUsQ0FBQyxtQ0FBbUMsQ0FBQztDQUMzRCxDQUFDIiwic291cmNlc0NvbnRlbnQiOlsiZXhwb3J0IGRlZmF1bHQge1xuICB0ZXN0RW52aXJvbm1lbnQ6ICdub2RlJyxcbiAgcm9vdHM6IFsnPHJvb3REaXI+L3Rlc3QnXSxcbiAgdGVzdE1hdGNoOiBbJyoqLyoudGVzdC50cyddLFxuICB0cmFuc2Zvcm06IHtcbiAgICAnXi4rXFxcXC50c3g/JCc6ICd0cy1qZXN0JyxcbiAgfSxcbiAgc25hcHNob3RTZXJpYWxpemVyczogWyc8cm9vdERpcj4vdGVzdC9zbmFwc2hvdC1wbHVnaW4udHMnXSxcbn07XG4iXX0=

--- a/packages/cdk/lambda/assistantMessageHandler.ts
+++ b/packages/cdk/lambda/assistantMessageHandler.ts
@@ -380,9 +380,16 @@ async function handleCreateMessage(
     console.log('Using system prompt without RAG context');
   }
 
-  const systemMessage = ragContext
-    ? `${assistant.instruction}\n\nRelevant context from documents:\n${ragContext}`
-    : assistant.instruction;
+  // Build system message: instruction + RAG context
+  let systemMessage = `<instructions>\n${assistant.instruction}\n</instructions>`;
+
+  if (ragContext) {
+    systemMessage += `\n\nRelevant context from documents:\n${ragContext}`;
+  }
+
+  if (body.customInstructions?.trim()) {
+    systemMessage += `\n<user_custom_instructions>\n${body.customInstructions}\n</user_custom_instructions>`;
+  }
 
   // Determine model type:
   // - If modelId exists in modelMetadata → bedrock

--- a/packages/cdk/lambda/assistantMessageStreamHandler.ts
+++ b/packages/cdk/lambda/assistantMessageStreamHandler.ts
@@ -351,21 +351,16 @@ export const handler = awslambda.streamifyResponse(
         }
       }
 
-      // Build system message: assistant instruction + custom instructions + RAG context
-      const baseInstruction = customInstructions?.trim()
-        ? `<instructions>
-${assistant.instruction}
-</instructions>
-<user_custom_instructions>
-${customInstructions}
-</user_custom_instructions>`
-        : `<instructions>
-${assistant.instruction}
-</instructions>`;
+      // Build system message: instruction + RAG context + custom instructions
+      let systemMessage = `<instructions>\n${assistant.instruction}\n</instructions>`;
 
-      const systemMessage = ragContext
-        ? `${baseInstruction}\n\nRelevant context from documents:\n${ragContext}`
-        : baseInstruction;
+      if (ragContext) {
+        systemMessage += `\n\nRelevant context from documents:\n${ragContext}`;
+      }
+
+      if (customInstructions?.trim()) {
+        systemMessage += `\n<user_custom_instructions>\n${customInstructions}\n</user_custom_instructions>`;
+      }
 
       // Determine model type:
       // - If modelId exists in modelMetadata → bedrock

--- a/packages/cdk/lambda/getSummaries.ts
+++ b/packages/cdk/lambda/getSummaries.ts
@@ -1,0 +1,67 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { GetSummariesResponse } from 'generative-ai-use-cases';
+import {
+  getYesterdayDailySummary,
+  getUserSummary,
+  getUserSummaryConfig,
+} from './repository/userSummary';
+import {
+  ok200Response,
+  unauthorized401Response,
+  internalServerError500Response,
+} from './utils/apiResponse';
+
+/**
+ * GET /summaries
+ * Returns the user's daily summary (yesterday's) and user summary
+ */
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    const userId =
+      event.requestContext.authorizer?.claims?.['cognito:username'] ||
+      event.requestContext.authorizer?.claims?.sub;
+
+    if (!userId) {
+      return unauthorized401Response({ message: 'User ID not found' });
+    }
+
+    // Fetch all summary data in parallel
+    const [dailySummary, userSummary, config] = await Promise.all([
+      getYesterdayDailySummary(userId, event).catch((error) => {
+        console.warn('Failed to get daily summary:', error);
+        return null;
+      }),
+      getUserSummary(userId, event).catch((error) => {
+        console.warn('Failed to get user summary:', error);
+        return null;
+      }),
+      getUserSummaryConfig(userId, event).catch((error) => {
+        console.warn('Failed to get summary config:', error);
+        return null;
+      }),
+    ]);
+
+    const response: GetSummariesResponse = {};
+
+    if (dailySummary) {
+      response.dailySummary = dailySummary;
+    }
+
+    if (userSummary) {
+      response.userSummary = userSummary;
+    }
+
+    if (config) {
+      response.config = config;
+    }
+
+    return ok200Response(response);
+  } catch (error) {
+    console.error('Failed to get summaries:', error);
+    return internalServerError500Response({
+      message: 'Failed to retrieve summaries',
+    });
+  }
+};

--- a/packages/cdk/lambda/predict.ts
+++ b/packages/cdk/lambda/predict.ts
@@ -7,6 +7,8 @@ import {
   ok200Response,
 } from './utils/apiResponse';
 import { createOpenFgaClient, checkLlmAccess } from './utils/openFgaClient';
+import { buildSummaryContext } from './utils/summaryContext';
+import { UnrecordedMessage } from 'generative-ai-use-cases';
 
 export const handler = async (
   event: APIGatewayProxyEvent
@@ -42,11 +44,30 @@ export const handler = async (
       };
     }
 
-    const response = await api[model.type].invoke?.(
-      model,
-      req.messages,
-      req.id
-    );
+    // Inject summary context
+    let messages: UnrecordedMessage[] = req.messages;
+    try {
+      if (userId) {
+        const summaryContext = await buildSummaryContext(userId, event);
+
+        if (summaryContext) {
+          messages = req.messages.map((msg) => {
+            if (msg.role === 'system') {
+              return {
+                ...msg,
+                content: `${msg.content}\n\n${summaryContext}`,
+              };
+            }
+            return msg;
+          });
+        }
+      }
+    } catch (error) {
+      // Continue without summary context if injection fails
+      console.error('Failed to inject summary context:', error);
+    }
+
+    const response = await api[model.type].invoke?.(model, messages, req.id);
 
     return ok200Response(response);
   } catch (error) {

--- a/packages/cdk/lambda/predictStream.ts
+++ b/packages/cdk/lambda/predictStream.ts
@@ -1,4 +1,4 @@
-import { Handler, Context } from 'aws-lambda';
+import { Handler, Context, APIGatewayProxyEvent } from 'aws-lambda';
 import { PredictRequest, UnrecordedMessage } from 'generative-ai-use-cases';
 import api from './utils/api';
 import { defaultModel } from './utils/models';
@@ -8,6 +8,7 @@ import {
   getLatestUsage,
   AccessCheckResult,
 } from './utils/accessChecker';
+import { buildSummaryContext } from './utils/summaryContext';
 
 declare global {
   namespace awslambda {
@@ -125,10 +126,95 @@ export const handler = awslambda.streamifyResponse(
         }
       }
 
+      // Inject summary context if idToken is available
+      let messages = event.messages;
+      try {
+        // Extract userId and tenantId from idToken
+        const tokenPayload = JSON.parse(
+          Buffer.from(event.idToken.split('.')[1], 'base64').toString()
+        );
+        const userId = tokenPayload['cognito:username'];
+        const tenantId =
+          tokenPayload['custom:tenant_id'] ||
+          tokenPayload['custom:tenantId'] ||
+          '';
+
+        // Create request context for repository functions
+        const requestContext = {
+          body: null,
+          headers: {
+            Authorization: event.idToken,
+          },
+          multiValueHeaders: {},
+          httpMethod: 'POST',
+          isBase64Encoded: false,
+          path: '',
+          pathParameters: null,
+          queryStringParameters: null,
+          multiValueQueryStringParameters: null,
+          stageVariables: null,
+          resource: '',
+          requestContext: {
+            accountId: '',
+            apiId: '',
+            authorizer: {
+              claims: {
+                'cognito:username': userId,
+                'custom:tenant_id': tenantId,
+              },
+            },
+            protocol: 'HTTP/1.1',
+            httpMethod: 'POST',
+            identity: {
+              accessKey: null,
+              accountId: null,
+              apiKey: null,
+              apiKeyId: null,
+              caller: null,
+              clientCert: null,
+              cognitoAuthenticationProvider: null,
+              cognitoAuthenticationType: null,
+              cognitoIdentityId: null,
+              cognitoIdentityPoolId: null,
+              principalOrgId: null,
+              sourceIp: '',
+              user: null,
+              userAgent: null,
+              userArn: null,
+            },
+            path: '',
+            stage: '',
+            requestId: '',
+            requestTimeEpoch: 0,
+            resourceId: '',
+            resourcePath: '',
+          },
+        } satisfies APIGatewayProxyEvent;
+
+        // Build summary context
+        const summaryContext = await buildSummaryContext(userId, requestContext);
+
+        // Inject summary context into system message if available
+        if (summaryContext) {
+          messages = event.messages.map((msg) => {
+            if (msg.role === 'system') {
+              return {
+                ...msg,
+                content: `${msg.content}\n\n${summaryContext}`,
+              };
+            }
+            return msg;
+          });
+        }
+      } catch (error) {
+        // Continue without summary context if injection fails
+        console.error('Failed to inject summary context:', error);
+      }
+
       // If authorized, proceed with streaming
       for await (const token of api[model.type].invokeStream?.(
         model,
-        event.messages,
+        messages,
         event.id,
         event.idToken
       ) ?? []) {
@@ -177,17 +263,17 @@ export const handler = awslambda.streamifyResponse(
       ) {
         // チェック時と同じく、最後のメッセージのみを対象とする
         const lastMsg = event.messages[event.messages.length - 1];
-        const imageCount = lastMsg ? countImages([lastMsg]) : 0;
+        const imgCount = lastMsg ? countImages([lastMsg]) : 0;
         try {
           await incrementUsage(
             event.idToken,
             'prompt-media',
             'image',
             mediaCheckResult.limitType,
-            imageCount
+            imgCount
           );
           console.log(
-            `[PredictStream] Image usage incremented - count: ${imageCount}`
+            `[PredictStream] Image usage incremented - count: ${imgCount}`
           );
         } catch (error) {
           console.error('Failed to increment image usage count:', error);

--- a/packages/cdk/lambda/repository/chat.ts
+++ b/packages/cdk/lambda/repository/chat.ts
@@ -22,6 +22,8 @@ import {
   getTenantDynamoDBDocument,
   getTableName,
   executeDynamoDBOperation,
+  executeDynamoDBOperationForBatch,
+  getTableNameForBatch,
 } from './common';
 import { listMessages, deleteMessagesForChat } from './message';
 
@@ -430,4 +432,104 @@ export const deleteAllMessagesForAssistant = async (
     // chat.chatId already has the 'chat#' prefix from the database
     await deleteAssistantMessagesForChat(chat.chatId, event);
   }
+};
+
+/**
+ * List chats for batch processing (no JWT required)
+ * Uses STS AssumeRole for tenant access
+ */
+export const listChatsForBatch = async (
+  _userId: string,
+  tenantId: string,
+  _exclusiveStartKey?: string
+): Promise<ListChatsResponse> => {
+  return await executeDynamoDBOperationForBatch(
+    tenantId,
+    async (dynamoDbDocument, tableName) => {
+      const exclusiveStartKey = _exclusiveStartKey
+        ? JSON.parse(Buffer.from(_exclusiveStartKey, 'base64').toString())
+        : undefined;
+      const userId = `user#${_userId}`;
+
+      const res = await dynamoDbDocument.send(
+        new QueryCommand({
+          TableName: tableName,
+          KeyConditionExpression: '#id = :id',
+          ExpressionAttributeNames: {
+            '#id': 'id',
+          },
+          ExpressionAttributeValues: {
+            ':id': userId,
+          },
+          ScanIndexForward: false,
+          Limit: 100,
+          ExclusiveStartKey: exclusiveStartKey,
+        })
+      );
+
+      return {
+        data: res.Items as Chat[],
+        lastEvaluatedKey: res.LastEvaluatedKey
+          ? Buffer.from(JSON.stringify(res.LastEvaluatedKey)).toString('base64')
+          : undefined,
+      };
+    }
+  );
+};
+
+/**
+ * Discover users who had conversations on a specific date (batch mode - no JWT)
+ * Uses table scan with filter since there's no date-based GSI
+ * @param date Date in YYYY-MM-DD format
+ * @param tenantId Tenant ID
+ * @returns Array of unique user IDs (without 'user#' prefix)
+ */
+export const discoverUsersWithConversationsOnDate = async (
+  date: string,
+  tenantId: string
+): Promise<string[]> => {
+  // Calculate timestamp range for the date (JST timezone)
+  const startOfDay = new Date(`${date}T00:00:00+09:00`).getTime();
+  const endOfDay = new Date(`${date}T23:59:59.999+09:00`).getTime();
+
+  const userIds = new Set<string>();
+
+  return await executeDynamoDBOperationForBatch(
+    tenantId,
+    async (dynamoDbDocument, tableName) => {
+      let lastEvaluatedKey: Record<string, unknown> | undefined;
+
+      do {
+        const res: ScanCommandOutput = await dynamoDbDocument.send(
+          new ScanCommand({
+            TableName: tableName,
+            FilterExpression:
+              'begins_with(#id, :userPrefix) AND #updatedDate >= :start AND #updatedDate <= :end',
+            ExpressionAttributeNames: {
+              '#id': 'id',
+              '#updatedDate': 'updatedDate',
+            },
+            ExpressionAttributeValues: {
+              ':userPrefix': 'user#',
+              ':start': `${startOfDay}`,
+              ':end': `${endOfDay}`,
+            },
+            ProjectionExpression: 'id',
+            ExclusiveStartKey: lastEvaluatedKey,
+          })
+        );
+
+        if (res.Items) {
+          for (const item of res.Items) {
+            const userId = (item.id as string).replace('user#', '');
+            userIds.add(userId);
+          }
+        }
+
+        lastEvaluatedKey = res.LastEvaluatedKey;
+      } while (lastEvaluatedKey);
+
+      return Array.from(userIds);
+    }
+  );
 };

--- a/packages/cdk/lambda/repository/chat.ts
+++ b/packages/cdk/lambda/repository/chat.ts
@@ -479,7 +479,8 @@ export const listChatsForBatch = async (
 
 /**
  * Discover users who had conversations on a specific date (batch mode - no JWT)
- * Uses table scan with filter since there's no date-based GSI
+ * Scans message records (id starts with 'chat#') and extracts unique userIds
+ * Uses createdDate range since message records have createdDate in format 'timestamp#suffix'
  * @param date Date in YYYY-MM-DD format
  * @param tenantId Tenant ID
  * @returns Array of unique user IDs (without 'user#' prefix)
@@ -489,8 +490,11 @@ export const discoverUsersWithConversationsOnDate = async (
   tenantId: string
 ): Promise<string[]> => {
   // Calculate timestamp range for the date (JST timezone)
+  // Use exclusive end to handle createdDate format 'timestamp#suffix'
   const startOfDay = new Date(`${date}T00:00:00+09:00`).getTime();
-  const endOfDay = new Date(`${date}T23:59:59.999+09:00`).getTime();
+  const startOfNextDay = new Date(`${date}T00:00:00+09:00`);
+  startOfNextDay.setDate(startOfNextDay.getDate() + 1);
+  const endExclusive = startOfNextDay.getTime();
 
   const userIds = new Set<string>();
 
@@ -504,25 +508,31 @@ export const discoverUsersWithConversationsOnDate = async (
           new ScanCommand({
             TableName: tableName,
             FilterExpression:
-              'begins_with(#id, :userPrefix) AND #updatedDate >= :start AND #updatedDate <= :end',
+              'begins_with(#id, :chatPrefix) AND #createdDate >= :start AND #createdDate < :endExclusive',
             ExpressionAttributeNames: {
               '#id': 'id',
-              '#updatedDate': 'updatedDate',
+              '#createdDate': 'createdDate',
             },
             ExpressionAttributeValues: {
-              ':userPrefix': 'user#',
+              ':chatPrefix': 'chat#',
               ':start': `${startOfDay}`,
-              ':end': `${endOfDay}`,
+              ':endExclusive': `${endExclusive}`,
             },
-            ProjectionExpression: 'id',
+            ProjectionExpression: 'userId',
             ExclusiveStartKey: lastEvaluatedKey,
           })
         );
 
         if (res.Items) {
           for (const item of res.Items) {
-            const userId = (item.id as string).replace('user#', '');
-            userIds.add(userId);
+            if (item.userId) {
+              // Handle both 'user#xxx' and 'xxx' formats
+              const rawUserId = item.userId as string;
+              const userId = rawUserId.replace(/^user#/, '');
+              if (userId) {
+                userIds.add(userId);
+              }
+            }
           }
         }
 

--- a/packages/cdk/lambda/repository/common.ts
+++ b/packages/cdk/lambda/repository/common.ts
@@ -2,7 +2,12 @@ import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
 import { APIGatewayProxyEvent } from 'aws-lambda';
 import { getTenantId } from '../utils/tenantUtils';
-import { createTenantDynamoDBClient } from '../utils/tenantDynamoDBClient';
+import {
+  createTenantDynamoDBClient,
+  createTenantDynamoDBClientForBackgroundJob,
+} from '../utils/tenantDynamoDBClient';
+// Re-export for use by other repository modules
+export { createTenantDynamoDBClientForBackgroundJob };
 import {
   TooManyRequestsError,
   ServiceUnavailableError,
@@ -18,6 +23,10 @@ const ASSISTANT_TABLE_PREFIX: string =
   process.env.ASSISTANT_TABLE_NAME || 'Assistant';
 const DEFAULT_ASSISTANT_TABLE_NAME: string =
   process.env.DEFAULT_ASSISTANT_TABLE_NAME || '';
+const USER_SUMMARY_TABLE_PREFIX: string =
+  process.env.USER_SUMMARY_TABLE_NAME || 'UserSummary';
+const DEFAULT_USER_SUMMARY_TABLE_NAME: string =
+  process.env.DEFAULT_USER_SUMMARY_TABLE_NAME || '';
 
 /**
  * Get or create a tenant-specific DynamoDB document client
@@ -104,6 +113,19 @@ export function getAssistantTableName(event: APIGatewayProxyEvent): string {
 }
 
 /**
+ * Get tenant-specific user summary table name
+ */
+export function getUserSummaryTableName(event: APIGatewayProxyEvent): string {
+  const tenantId = getTenantId(event);
+
+  if (!tenantId || tenantId === 'default') {
+    return DEFAULT_USER_SUMMARY_TABLE_NAME;
+  }
+
+  return `${USER_SUMMARY_TABLE_PREFIX}-${ENVIRONMENT}-tenant-${tenantId}`;
+}
+
+/**
  * Execute DynamoDB operation with proper tenant table selection
  */
 export async function executeDynamoDBOperation<T>(
@@ -114,4 +136,39 @@ export async function executeDynamoDBOperation<T>(
   const tableName = getTableName(event);
 
   return await operation(dynamoDbDocument, tableName);
+}
+
+/**
+ * Execute DynamoDB operation for batch/background jobs (no JWT required)
+ * Uses STS AssumeRole for tenant access instead of AssumeRoleWithWebIdentity
+ */
+export async function executeDynamoDBOperationForBatch<T>(
+  tenantId: string,
+  operation: (client: DynamoDBDocumentClient, tableName: string) => Promise<T>
+): Promise<T> {
+  const dynamoDb = await createTenantDynamoDBClientForBackgroundJob(tenantId);
+  const dynamoDbDocument = DynamoDBDocumentClient.from(dynamoDb);
+  const tableName = getTableNameForBatch(tenantId);
+
+  return await operation(dynamoDbDocument, tableName);
+}
+
+/**
+ * Get table name for batch operations (without APIGatewayProxyEvent)
+ */
+export function getTableNameForBatch(tenantId: string): string {
+  if (!tenantId || tenantId === 'default') {
+    return DEFAULT_TABLE_NAME;
+  }
+  return `${TABLE_PREFIX}-${ENVIRONMENT}-tenant-${tenantId}`;
+}
+
+/**
+ * Get user summary table name for batch operations
+ */
+export function getUserSummaryTableNameForBatch(tenantId: string): string {
+  if (!tenantId || tenantId === 'default') {
+    return DEFAULT_USER_SUMMARY_TABLE_NAME;
+  }
+  return `${USER_SUMMARY_TABLE_PREFIX}-${ENVIRONMENT}-tenant-${tenantId}`;
 }

--- a/packages/cdk/lambda/repository/message.ts
+++ b/packages/cdk/lambda/repository/message.ts
@@ -15,6 +15,7 @@ import {
   getTenantDynamoDBDocument,
   getTableName,
   getStatsTableName,
+  executeDynamoDBOperationForBatch,
 } from './common';
 
 // Update token usage helper function
@@ -324,4 +325,47 @@ export const deleteMessagesForChat = async (
 
     await Promise.all(batchPromises);
   }
+};
+
+/**
+ * List messages for batch processing (no JWT required)
+ * Uses STS AssumeRole for tenant access
+ */
+export const listMessagesForBatch = async (
+  _chatId: string,
+  tenantId: string
+): Promise<RecordedMessage[]> => {
+  return await executeDynamoDBOperationForBatch(
+    tenantId,
+    async (dynamoDbDocument, tableName) => {
+      const chatId = `chat#${_chatId}`;
+
+      let allItems: RecordedMessage[] = [];
+      let exclusiveStartKey: Record<string, string> | undefined = undefined;
+
+      do {
+        const res: QueryCommandOutput = await dynamoDbDocument.send(
+          new QueryCommand({
+            TableName: tableName,
+            KeyConditionExpression: '#id = :id',
+            ExpressionAttributeNames: {
+              '#id': 'id',
+            },
+            ExpressionAttributeValues: {
+              ':id': chatId,
+            },
+            ExclusiveStartKey: exclusiveStartKey,
+          })
+        );
+
+        if (res.Items && res.Items.length > 0) {
+          allItems = allItems.concat(res.Items as RecordedMessage[]);
+        }
+
+        exclusiveStartKey = res.LastEvaluatedKey;
+      } while (exclusiveStartKey);
+
+      return allItems as RecordedMessage[];
+    }
+  );
 };

--- a/packages/cdk/lambda/repository/userSummary.ts
+++ b/packages/cdk/lambda/repository/userSummary.ts
@@ -1,0 +1,672 @@
+import {
+  DailySummary,
+  UserSummary,
+  UserSummaryConfig,
+} from 'generative-ai-use-cases';
+import {
+  PutCommand,
+  QueryCommand,
+  GetCommand,
+  UpdateCommand,
+  QueryCommandInput,
+  DynamoDBDocumentClient,
+} from '@aws-sdk/lib-dynamodb';
+import { APIGatewayProxyEvent } from 'aws-lambda';
+import {
+  getTenantDynamoDBDocument,
+  getUserSummaryTableName,
+  getUserSummaryTableNameForBatch,
+  createTenantDynamoDBClientForBackgroundJob,
+} from './common';
+import { getTenantId } from '../utils/tenantUtils';
+
+// Sort key prefixes for different summary types
+const DAILY_PREFIX = 'DAILY#';
+const USER_SUMMARY_SK = 'USER_SUMMARY';
+const CONFIG_SK = 'CONFIG';
+
+/**
+ * Get yesterday's date in YYYY-MM-DD format (JST timezone)
+ */
+export function getYesterdayDate(): string {
+  const now = new Date();
+  // Convert to JST (UTC+9)
+  const jstOffset = 9 * 60 * 60 * 1000;
+  const jstNow = new Date(now.getTime() + jstOffset);
+  // Subtract one day
+  jstNow.setDate(jstNow.getDate() - 1);
+  return jstNow.toISOString().split('T')[0];
+}
+
+/**
+ * Get today's date in YYYY-MM-DD format (JST timezone)
+ */
+export function getTodayDate(): string {
+  const now = new Date();
+  const jstOffset = 9 * 60 * 60 * 1000;
+  const jstNow = new Date(now.getTime() + jstOffset);
+  return jstNow.toISOString().split('T')[0];
+}
+
+/**
+ * Calculate term start date based on unit and value
+ */
+export function calculateTermStart(
+  termUnit: 'month' | 'year',
+  termValue: number,
+  endDate: string
+): string {
+  const end = new Date(endDate);
+  if (termUnit === 'month') {
+    end.setMonth(end.getMonth() - termValue);
+  } else {
+    end.setFullYear(end.getFullYear() - termValue);
+  }
+  return end.toISOString().split('T')[0];
+}
+
+/**
+ * Get daily summary for a specific user and date
+ */
+export const getDailySummary = async (
+  _userId: string,
+  date: string,
+  event: APIGatewayProxyEvent
+): Promise<DailySummary | null> => {
+  const userId = _userId.startsWith('user#') ? _userId : `user#${_userId}`;
+  const sortKey = `${DAILY_PREFIX}${date}`;
+
+  const dynamoDbDocument = await getTenantDynamoDBDocument(event);
+  const tableName = getUserSummaryTableName(event);
+
+  const res = await dynamoDbDocument.send(
+    new GetCommand({
+      TableName: tableName,
+      Key: {
+        id: userId,
+        createdDate: sortKey,
+      },
+    })
+  );
+
+  return res.Item ? (res.Item as DailySummary) : null;
+};
+
+/**
+ * Get yesterday's daily summary for a user
+ */
+export const getYesterdayDailySummary = async (
+  userId: string,
+  event: APIGatewayProxyEvent
+): Promise<DailySummary | null> => {
+  const yesterday = getYesterdayDate();
+  return getDailySummary(userId, yesterday, event);
+};
+
+/**
+ * Get the latest daily summary for a user
+ * Queries with descending order and returns the most recent one
+ */
+export const getLatestDailySummary = async (
+  _userId: string,
+  event: APIGatewayProxyEvent
+): Promise<DailySummary | null> => {
+  const userId = _userId.startsWith('user#') ? _userId : `user#${_userId}`;
+
+  const dynamoDbDocument = await getTenantDynamoDBDocument(event);
+  const tableName = getUserSummaryTableName(event);
+
+  const res = await dynamoDbDocument.send(
+    new QueryCommand({
+      TableName: tableName,
+      KeyConditionExpression: '#id = :id AND begins_with(#createdDate, :prefix)',
+      ExpressionAttributeNames: {
+        '#id': 'id',
+        '#createdDate': 'createdDate',
+      },
+      ExpressionAttributeValues: {
+        ':id': userId,
+        ':prefix': DAILY_PREFIX,
+      },
+      ScanIndexForward: false, // Descending order (newest first)
+      Limit: 1,
+    })
+  );
+
+  return res.Items && res.Items.length > 0
+    ? (res.Items[0] as DailySummary)
+    : null;
+};
+
+/**
+ * Get user summary (aggregated profile)
+ */
+export const getUserSummary = async (
+  _userId: string,
+  event: APIGatewayProxyEvent
+): Promise<UserSummary | null> => {
+  const userId = _userId.startsWith('user#') ? _userId : `user#${_userId}`;
+
+  const dynamoDbDocument = await getTenantDynamoDBDocument(event);
+  const tableName = getUserSummaryTableName(event);
+
+  const res = await dynamoDbDocument.send(
+    new GetCommand({
+      TableName: tableName,
+      Key: {
+        id: userId,
+        createdDate: USER_SUMMARY_SK,
+      },
+    })
+  );
+
+  return res.Item ? (res.Item as UserSummary) : null;
+};
+
+/**
+ * Get user summary configuration
+ */
+export const getUserSummaryConfig = async (
+  _userId: string,
+  event: APIGatewayProxyEvent
+): Promise<UserSummaryConfig | null> => {
+  const userId = _userId.startsWith('user#') ? _userId : `user#${_userId}`;
+
+  const dynamoDbDocument = await getTenantDynamoDBDocument(event);
+  const tableName = getUserSummaryTableName(event);
+
+  const res = await dynamoDbDocument.send(
+    new GetCommand({
+      TableName: tableName,
+      Key: {
+        id: userId,
+        createdDate: CONFIG_SK,
+      },
+    })
+  );
+
+  return res.Item ? (res.Item as UserSummaryConfig) : null;
+};
+
+/**
+ * Save daily summary
+ */
+export const saveDailySummary = async (
+  summary: Omit<DailySummary, 'id' | 'createdDate'> & { userId: string },
+  event: APIGatewayProxyEvent
+): Promise<DailySummary> => {
+  const userId = summary.userId.startsWith('user#')
+    ? summary.userId
+    : `user#${summary.userId}`;
+  const sortKey = `${DAILY_PREFIX}${summary.date}`;
+
+  const item: DailySummary = {
+    id: userId,
+    createdDate: sortKey,
+    userId: summary.userId,
+    tenantId: summary.tenantId,
+    date: summary.date,
+    summary: summary.summary,
+    chatIds: summary.chatIds,
+    messageCount: summary.messageCount,
+    externalContext: summary.externalContext,
+    generatedAt: summary.generatedAt,
+    tokenUsage: summary.tokenUsage,
+  };
+
+  const dynamoDbDocument = await getTenantDynamoDBDocument(event);
+  const tableName = getUserSummaryTableName(event);
+
+  await dynamoDbDocument.send(
+    new PutCommand({
+      TableName: tableName,
+      Item: item,
+    })
+  );
+
+  return item;
+};
+
+/**
+ * Save user summary
+ */
+export const saveUserSummary = async (
+  summary: Omit<UserSummary, 'id' | 'createdDate'> & { userId: string },
+  event: APIGatewayProxyEvent
+): Promise<UserSummary> => {
+  const userId = summary.userId.startsWith('user#')
+    ? summary.userId
+    : `user#${summary.userId}`;
+
+  const item: UserSummary = {
+    id: userId,
+    createdDate: USER_SUMMARY_SK,
+    userId: summary.userId,
+    tenantId: summary.tenantId,
+    summary: summary.summary,
+    termUnit: summary.termUnit,
+    termValue: summary.termValue,
+    termStart: summary.termStart,
+    termEnd: summary.termEnd,
+    dailySummaryDates: summary.dailySummaryDates,
+    generatedAt: summary.generatedAt,
+    tokenUsage: summary.tokenUsage,
+  };
+
+  const dynamoDbDocument = await getTenantDynamoDBDocument(event);
+  const tableName = getUserSummaryTableName(event);
+
+  await dynamoDbDocument.send(
+    new PutCommand({
+      TableName: tableName,
+      Item: item,
+    })
+  );
+
+  return item;
+};
+
+/**
+ * Save or update user summary configuration
+ */
+export const saveUserSummaryConfig = async (
+  config: Omit<UserSummaryConfig, 'id' | 'createdDate'> & { userId: string },
+  event: APIGatewayProxyEvent
+): Promise<UserSummaryConfig> => {
+  const userId = config.userId.startsWith('user#')
+    ? config.userId
+    : `user#${config.userId}`;
+  const tenantId = getTenantId(event) || 'default';
+
+  const item: UserSummaryConfig = {
+    id: userId,
+    createdDate: CONFIG_SK,
+    userId: config.userId,
+    tenantId: tenantId,
+    termUnit: config.termUnit,
+    termValue: config.termValue,
+    externalContextPrompt: config.externalContextPrompt,
+    enabled: config.enabled,
+  };
+
+  const dynamoDbDocument = await getTenantDynamoDBDocument(event);
+  const tableName = getUserSummaryTableName(event);
+
+  await dynamoDbDocument.send(
+    new PutCommand({
+      TableName: tableName,
+      Item: item,
+    })
+  );
+
+  return item;
+};
+
+/**
+ * Get daily summaries within a date range for a user
+ */
+export const getDailySummariesInRange = async (
+  _userId: string,
+  startDate: string,
+  endDate: string,
+  event: APIGatewayProxyEvent
+): Promise<DailySummary[]> => {
+  const userId = _userId.startsWith('user#') ? _userId : `user#${_userId}`;
+  const startKey = `${DAILY_PREFIX}${startDate}`;
+  const endKey = `${DAILY_PREFIX}${endDate}`;
+
+  const dynamoDbDocument = await getTenantDynamoDBDocument(event);
+  const tableName = getUserSummaryTableName(event);
+
+  const queryParams: QueryCommandInput = {
+    TableName: tableName,
+    KeyConditionExpression:
+      '#id = :id AND #createdDate BETWEEN :start AND :end',
+    ExpressionAttributeNames: {
+      '#id': 'id',
+      '#createdDate': 'createdDate',
+    },
+    ExpressionAttributeValues: {
+      ':id': userId,
+      ':start': startKey,
+      ':end': endKey,
+    },
+    ScanIndexForward: true, // Oldest first
+  };
+
+  const summaries: DailySummary[] = [];
+  let lastEvaluatedKey: Record<string, unknown> | undefined;
+
+  do {
+    if (lastEvaluatedKey) {
+      queryParams.ExclusiveStartKey = lastEvaluatedKey;
+    }
+
+    const res = await dynamoDbDocument.send(new QueryCommand(queryParams));
+
+    if (res.Items) {
+      summaries.push(...(res.Items as DailySummary[]));
+    }
+
+    lastEvaluatedKey = res.LastEvaluatedKey;
+  } while (lastEvaluatedKey);
+
+  return summaries;
+};
+
+/**
+ * Get all users who have daily summaries on a specific date
+ * Uses the DateIndex GSI
+ */
+export const getUsersWithSummaryOnDate = async (
+  date: string,
+  event: APIGatewayProxyEvent
+): Promise<string[]> => {
+  const dynamoDbDocument = await getTenantDynamoDBDocument(event);
+  const tableName = getUserSummaryTableName(event);
+
+  const queryParams: QueryCommandInput = {
+    TableName: tableName,
+    IndexName: 'DateIndex',
+    KeyConditionExpression: '#date = :date',
+    ExpressionAttributeNames: {
+      '#date': 'date',
+    },
+    ExpressionAttributeValues: {
+      ':date': date,
+    },
+    ProjectionExpression: 'userId',
+  };
+
+  const userIds: string[] = [];
+  let lastEvaluatedKey: Record<string, unknown> | undefined;
+
+  do {
+    if (lastEvaluatedKey) {
+      queryParams.ExclusiveStartKey = lastEvaluatedKey;
+    }
+
+    const res = await dynamoDbDocument.send(new QueryCommand(queryParams));
+
+    if (res.Items) {
+      userIds.push(...res.Items.map((item) => item.userId as string));
+    }
+
+    lastEvaluatedKey = res.LastEvaluatedKey;
+  } while (lastEvaluatedKey);
+
+  return [...new Set(userIds)]; // Deduplicate
+};
+
+/**
+ * Update user summary configuration
+ */
+export const updateUserSummaryConfig = async (
+  _userId: string,
+  updates: Partial<Omit<UserSummaryConfig, 'id' | 'createdDate' | 'userId'>>,
+  event: APIGatewayProxyEvent
+): Promise<UserSummaryConfig | null> => {
+  const userId = _userId.startsWith('user#') ? _userId : `user#${_userId}`;
+
+  const dynamoDbDocument = await getTenantDynamoDBDocument(event);
+  const tableName = getUserSummaryTableName(event);
+
+  const updateExpressions: string[] = [];
+  const expressionAttributeNames: Record<string, string> = {};
+  const expressionAttributeValues: Record<string, unknown> = {};
+
+  if (updates.termUnit !== undefined) {
+    updateExpressions.push('#termUnit = :termUnit');
+    expressionAttributeNames['#termUnit'] = 'termUnit';
+    expressionAttributeValues[':termUnit'] = updates.termUnit;
+  }
+
+  if (updates.termValue !== undefined) {
+    updateExpressions.push('#termValue = :termValue');
+    expressionAttributeNames['#termValue'] = 'termValue';
+    expressionAttributeValues[':termValue'] = updates.termValue;
+  }
+
+  if (updates.externalContextPrompt !== undefined) {
+    updateExpressions.push('#externalContextPrompt = :externalContextPrompt');
+    expressionAttributeNames['#externalContextPrompt'] = 'externalContextPrompt';
+    expressionAttributeValues[':externalContextPrompt'] =
+      updates.externalContextPrompt;
+  }
+
+  if (updates.enabled !== undefined) {
+    updateExpressions.push('#enabled = :enabled');
+    expressionAttributeNames['#enabled'] = 'enabled';
+    expressionAttributeValues[':enabled'] = updates.enabled;
+  }
+
+  if (updateExpressions.length === 0) {
+    return getUserSummaryConfig(_userId, event);
+  }
+
+  const res = await dynamoDbDocument.send(
+    new UpdateCommand({
+      TableName: tableName,
+      Key: {
+        id: userId,
+        createdDate: CONFIG_SK,
+      },
+      UpdateExpression: `SET ${updateExpressions.join(', ')}`,
+      ExpressionAttributeNames: expressionAttributeNames,
+      ExpressionAttributeValues: expressionAttributeValues,
+      ReturnValues: 'ALL_NEW',
+    })
+  );
+
+  return res.Attributes ? (res.Attributes as UserSummaryConfig) : null;
+};
+
+// ============================================
+// Batch/Background Job Functions (no JWT required)
+// ============================================
+
+/**
+ * Execute UserSummary table operation for batch/background jobs (no JWT required)
+ * Uses STS AssumeRole for tenant access instead of AssumeRoleWithWebIdentity
+ */
+async function executeUserSummaryOperationForBatch<T>(
+  tenantId: string,
+  operation: (client: DynamoDBDocumentClient, tableName: string) => Promise<T>
+): Promise<T> {
+  const dynamoDb = await createTenantDynamoDBClientForBackgroundJob(tenantId);
+  const dynamoDbDocument = DynamoDBDocumentClient.from(dynamoDb);
+  const tableName = getUserSummaryTableNameForBatch(tenantId);
+
+  return await operation(dynamoDbDocument, tableName);
+}
+
+/**
+ * Get user summary config for batch processing (no JWT required)
+ */
+export const getUserSummaryConfigForBatch = async (
+  _userId: string,
+  tenantId: string
+): Promise<UserSummaryConfig | null> => {
+  const userId = _userId.startsWith('user#') ? _userId : `user#${_userId}`;
+
+  return executeUserSummaryOperationForBatch(tenantId, async (client, tableName) => {
+    const res = await client.send(
+      new GetCommand({
+        TableName: tableName,
+        Key: {
+          id: userId,
+          createdDate: CONFIG_SK,
+        },
+      })
+    );
+    return res.Item ? (res.Item as UserSummaryConfig) : null;
+  });
+};
+
+/**
+ * Get daily summaries in range for batch processing (no JWT required)
+ */
+export const getDailySummariesInRangeForBatch = async (
+  _userId: string,
+  startDate: string,
+  endDate: string,
+  tenantId: string
+): Promise<DailySummary[]> => {
+  const userId = _userId.startsWith('user#') ? _userId : `user#${_userId}`;
+  const startKey = `${DAILY_PREFIX}${startDate}`;
+  const endKey = `${DAILY_PREFIX}${endDate}`;
+
+  return executeUserSummaryOperationForBatch(tenantId, async (client, tableName) => {
+    const queryParams: QueryCommandInput = {
+      TableName: tableName,
+      KeyConditionExpression:
+        '#id = :id AND #createdDate BETWEEN :start AND :end',
+      ExpressionAttributeNames: {
+        '#id': 'id',
+        '#createdDate': 'createdDate',
+      },
+      ExpressionAttributeValues: {
+        ':id': userId,
+        ':start': startKey,
+        ':end': endKey,
+      },
+      ScanIndexForward: true, // Oldest first
+    };
+
+    const summaries: DailySummary[] = [];
+    let lastEvaluatedKey: Record<string, unknown> | undefined;
+
+    do {
+      if (lastEvaluatedKey) {
+        queryParams.ExclusiveStartKey = lastEvaluatedKey;
+      }
+
+      const res = await client.send(new QueryCommand(queryParams));
+
+      if (res.Items) {
+        summaries.push(...(res.Items as DailySummary[]));
+      }
+
+      lastEvaluatedKey = res.LastEvaluatedKey;
+    } while (lastEvaluatedKey);
+
+    return summaries;
+  });
+};
+
+/**
+ * Save daily summary for batch processing (no JWT required)
+ */
+export const saveDailySummaryForBatch = async (
+  summary: Omit<DailySummary, 'id' | 'createdDate'> & { userId: string }
+): Promise<DailySummary> => {
+  const userId = summary.userId.startsWith('user#')
+    ? summary.userId
+    : `user#${summary.userId}`;
+  const sortKey = `${DAILY_PREFIX}${summary.date}`;
+
+  const item: DailySummary = {
+    id: userId,
+    createdDate: sortKey,
+    userId: summary.userId,
+    tenantId: summary.tenantId,
+    date: summary.date,
+    summary: summary.summary,
+    chatIds: summary.chatIds,
+    messageCount: summary.messageCount,
+    externalContext: summary.externalContext,
+    generatedAt: summary.generatedAt,
+    tokenUsage: summary.tokenUsage,
+  };
+
+  await executeUserSummaryOperationForBatch(summary.tenantId, async (client, tableName) => {
+    await client.send(
+      new PutCommand({
+        TableName: tableName,
+        Item: item,
+      })
+    );
+  });
+
+  return item;
+};
+
+/**
+ * Save user summary for batch processing (no JWT required)
+ */
+export const saveUserSummaryForBatch = async (
+  summary: Omit<UserSummary, 'id' | 'createdDate'> & { userId: string }
+): Promise<UserSummary> => {
+  const userId = summary.userId.startsWith('user#')
+    ? summary.userId
+    : `user#${summary.userId}`;
+
+  const item: UserSummary = {
+    id: userId,
+    createdDate: USER_SUMMARY_SK,
+    userId: summary.userId,
+    tenantId: summary.tenantId,
+    summary: summary.summary,
+    termUnit: summary.termUnit,
+    termValue: summary.termValue,
+    termStart: summary.termStart,
+    termEnd: summary.termEnd,
+    dailySummaryDates: summary.dailySummaryDates,
+    generatedAt: summary.generatedAt,
+    tokenUsage: summary.tokenUsage,
+  };
+
+  await executeUserSummaryOperationForBatch(summary.tenantId, async (client, tableName) => {
+    await client.send(
+      new PutCommand({
+        TableName: tableName,
+        Item: item,
+      })
+    );
+  });
+
+  return item;
+};
+
+/**
+ * Get all users who have daily summaries on a specific date (batch mode - no JWT)
+ * Uses the DateIndex GSI
+ */
+export const getUsersWithSummaryOnDateForBatch = async (
+  date: string,
+  tenantId: string
+): Promise<string[]> => {
+  return executeUserSummaryOperationForBatch(tenantId, async (client, tableName) => {
+    const queryParams: QueryCommandInput = {
+      TableName: tableName,
+      IndexName: 'DateIndex',
+      KeyConditionExpression: '#date = :date',
+      ExpressionAttributeNames: {
+        '#date': 'date',
+      },
+      ExpressionAttributeValues: {
+        ':date': date,
+      },
+      ProjectionExpression: 'userId',
+    };
+
+    const userIds: string[] = [];
+    let lastEvaluatedKey: Record<string, unknown> | undefined;
+
+    do {
+      if (lastEvaluatedKey) {
+        queryParams.ExclusiveStartKey = lastEvaluatedKey;
+      }
+
+      const res = await client.send(new QueryCommand(queryParams));
+
+      if (res.Items) {
+        userIds.push(...res.Items.map((item) => item.userId as string));
+      }
+
+      lastEvaluatedKey = res.LastEvaluatedKey;
+    } while (lastEvaluatedKey);
+
+    return [...new Set(userIds)]; // Deduplicate
+  });
+};

--- a/packages/cdk/lambda/summary/generateDailySummary.ts
+++ b/packages/cdk/lambda/summary/generateDailySummary.ts
@@ -76,23 +76,17 @@ export async function generateDailySummaryForUser(
     const chatsResponse = await listChatsForBatch(userId, tenantId);
     const chats = chatsResponse.data || [];
 
-    // Filter chats that were updated on the target date
-    const relevantChats = chats.filter((chat: Chat) => {
-      const updatedDate = parseInt(chat.updatedDate);
-      return updatedDate >= start && updatedDate <= end;
-    });
-
-    if (relevantChats.length === 0) {
+    if (chats.length === 0) {
       return { success: true, summary: undefined };
     }
 
-    // Collect messages from relevant chats
+    // Collect messages from all chats, filtering by message timestamp
+    // Don't filter chats by updatedDate as it may be empty for some chat types
     const allMessages: Array<{ role: string; content: string }> = [];
     const chatIds: string[] = [];
 
-    for (const chat of relevantChats) {
+    for (const chat of chats) {
       const chatId = chat.chatId.replace('chat#', '');
-      chatIds.push(chatId);
 
       // Use batch mode - no JWT required
       const messages = await listMessagesForBatch(chatId, tenantId);
@@ -103,12 +97,16 @@ export async function generateDailySummaryForUser(
         return msgTimestamp >= start && msgTimestamp <= end;
       });
 
-      allMessages.push(
-        ...dayMessages.map((msg) => ({
-          role: msg.role,
-          content: msg.content,
-        }))
-      );
+      // Only include chat if it has messages on the target date
+      if (dayMessages.length > 0) {
+        chatIds.push(chatId);
+        allMessages.push(
+          ...dayMessages.map((msg) => ({
+            role: msg.role,
+            content: msg.content,
+          }))
+        );
+      }
     }
 
     if (allMessages.length === 0) {

--- a/packages/cdk/lambda/summary/generateDailySummary.ts
+++ b/packages/cdk/lambda/summary/generateDailySummary.ts
@@ -1,0 +1,301 @@
+import { ScheduledEvent } from 'aws-lambda';
+import { ConverseCommand } from '@aws-sdk/client-bedrock-runtime';
+import { initBedrockRuntimeClient } from '../utils/bedrockClient';
+import {
+  buildDailySummarySystemPrompt,
+  buildDailySummaryUserPrompt,
+  formatMessagesForSummary,
+  truncateSummary,
+} from '../utils/summaryPrompts';
+import { saveDailySummaryForBatch } from '../repository/userSummary';
+import { listMessagesForBatch } from '../repository/message';
+import {
+  listChatsForBatch,
+  discoverUsersWithConversationsOnDate,
+} from '../repository/chat';
+import { Chat } from 'generative-ai-use-cases';
+import liteLlmApi from '../utils/liteLlmApi';
+
+// Configuration from environment
+const SUMMARY_MODEL_ID =
+  process.env.SUMMARY_MODEL_ID || 'us.anthropic.claude-3-5-haiku-20241022-v1:0';
+const MODEL_REGION = process.env.MODEL_REGION || 'us-east-1';
+const LITELLM_ENDPOINT = process.env.LITELLM_ENDPOINT || '';
+const DAILY_SUMMARY_MAX_CHARS = parseInt(
+  process.env.DAILY_SUMMARY_MAX_CHARS || '200'
+);
+
+interface DailySummaryEvent {
+  tenantId: string;
+  userId: string;
+  date: string; // YYYY-MM-DD
+}
+
+interface BatchEvent {
+  tenantId?: string;
+  date?: string;
+  users?: Array<{ userId: string }>;
+}
+
+/**
+ * Get yesterday's date in YYYY-MM-DD format (JST timezone)
+ */
+function getYesterdayDate(): string {
+  const now = new Date();
+  const jstOffset = 9 * 60 * 60 * 1000;
+  const jstNow = new Date(now.getTime() + jstOffset);
+  jstNow.setDate(jstNow.getDate() - 1);
+  return jstNow.toISOString().split('T')[0];
+}
+
+/**
+ * Get start and end timestamps for a given date (in milliseconds)
+ */
+function getDateTimestampRange(date: string): { start: number; end: number } {
+  const startOfDay = new Date(`${date}T00:00:00+09:00`); // JST
+  const endOfDay = new Date(`${date}T23:59:59.999+09:00`); // JST
+  return {
+    start: startOfDay.getTime(),
+    end: endOfDay.getTime(),
+  };
+}
+
+/**
+ * Generate daily summary for a single user
+ * Uses batch mode functions (STS AssumeRole) - no JWT required
+ */
+export async function generateDailySummaryForUser(
+  userId: string,
+  tenantId: string,
+  date: string
+): Promise<{ success: boolean; summary?: string; error?: string }> {
+  try {
+    const { start, end } = getDateTimestampRange(date);
+
+    // Get user's chats (using batch mode - no JWT required)
+    const chatsResponse = await listChatsForBatch(userId, tenantId);
+    const chats = chatsResponse.data || [];
+
+    // Filter chats that were updated on the target date
+    const relevantChats = chats.filter((chat: Chat) => {
+      const updatedDate = parseInt(chat.updatedDate);
+      return updatedDate >= start && updatedDate <= end;
+    });
+
+    if (relevantChats.length === 0) {
+      return { success: true, summary: undefined };
+    }
+
+    // Collect messages from relevant chats
+    const allMessages: Array<{ role: string; content: string }> = [];
+    const chatIds: string[] = [];
+
+    for (const chat of relevantChats) {
+      const chatId = chat.chatId.replace('chat#', '');
+      chatIds.push(chatId);
+
+      // Use batch mode - no JWT required
+      const messages = await listMessagesForBatch(chatId, tenantId);
+
+      // Filter messages from the target date
+      const dayMessages = messages.filter((msg) => {
+        const msgTimestamp = parseInt(msg.createdDate.split('#')[0]);
+        return msgTimestamp >= start && msgTimestamp <= end;
+      });
+
+      allMessages.push(
+        ...dayMessages.map((msg) => ({
+          role: msg.role,
+          content: msg.content,
+        }))
+      );
+    }
+
+    if (allMessages.length === 0) {
+      return { success: true, summary: undefined };
+    }
+
+    // Format messages for summarization
+    const formattedMessages = formatMessagesForSummary(allMessages);
+
+    const systemPrompt = buildDailySummarySystemPrompt(DAILY_SUMMARY_MAX_CHARS);
+    const userPrompt = buildDailySummaryUserPrompt(formattedMessages, date);
+
+    let rawSummary: string;
+    let inputTokens = 0;
+    let outputTokens = 0;
+
+    // Use LiteLLM if configured, otherwise use Bedrock directly
+    if (LITELLM_ENDPOINT) {
+      // Use LiteLLM proxy
+      const result = await liteLlmApi.invoke(
+        { modelId: SUMMARY_MODEL_ID, type: 'liteLlm' },
+        [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: userPrompt },
+        ],
+        ''
+      );
+      rawSummary = result;
+      // Note: LiteLLM doesn't return token usage in invoke response
+    } else {
+      // Use Bedrock directly
+      const client = await initBedrockRuntimeClient({ region: MODEL_REGION });
+      const response = await client.send(
+        new ConverseCommand({
+          modelId: SUMMARY_MODEL_ID,
+          messages: [
+            {
+              role: 'user',
+              content: [{ text: userPrompt }],
+            },
+          ],
+          system: [{ text: systemPrompt }],
+          inferenceConfig: {
+            maxTokens: 256,
+            temperature: 0.3,
+          },
+        })
+      );
+      rawSummary = response.output?.message?.content?.[0]?.text || '';
+      inputTokens = response.usage?.inputTokens || 0;
+      outputTokens = response.usage?.outputTokens || 0;
+    }
+
+    const summary = truncateSummary(rawSummary.trim(), DAILY_SUMMARY_MAX_CHARS);
+
+    // Save the summary - uses batch mode
+    await saveDailySummaryForBatch({
+      userId,
+      tenantId,
+      date,
+      summary,
+      chatIds,
+      messageCount: allMessages.length,
+      generatedAt: new Date().toISOString(),
+      tokenUsage: {
+        inputTokens,
+        outputTokens,
+      },
+    });
+
+    return { success: true, summary };
+  } catch (error) {
+    console.error(`Failed to generate daily summary for user ${userId}:`, error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}
+
+/**
+ * Lambda handler for generating daily summaries
+ * Can be invoked by:
+ * 1. EventBridge scheduled rule (batch processing)
+ * 2. Step Functions with specific user/tenant
+ */
+export const handler = async (
+  event: ScheduledEvent | DailySummaryEvent | BatchEvent
+): Promise<{
+  statusCode: number;
+  body: string;
+}> => {
+  console.log('Daily summary generation triggered:', JSON.stringify(event));
+
+  try {
+    // Check if this is a single user request
+    if ('userId' in event && 'tenantId' in event) {
+      const { userId, tenantId, date } = event as DailySummaryEvent;
+      const targetDate = date || getYesterdayDate();
+
+      const result = await generateDailySummaryForUser(
+        userId,
+        tenantId,
+        targetDate
+      );
+
+      return {
+        statusCode: result.success ? 200 : 500,
+        body: JSON.stringify(result),
+      };
+    }
+
+    // Batch processing for multiple users (from Step Functions or EventBridge)
+    if ('users' in event || 'tenantId' in event) {
+      const batchEvent = event as BatchEvent;
+      const tenantId = batchEvent.tenantId || 'default';
+      // Normalize date: EventBridge passes ISO 8601 (YYYY-MM-DDTHH:mm:ssZ), extract YYYY-MM-DD
+      const targetDate = (batchEvent.date ?? getYesterdayDate()).slice(0, 10);
+
+      // Discover users with conversations on the target date if not provided
+      let users = batchEvent.users || [];
+      if (users.length === 0) {
+        console.log(
+          `No users provided, discovering users with conversations on ${targetDate}`
+        );
+        const discoveredUserIds = await discoverUsersWithConversationsOnDate(
+          targetDate,
+          tenantId
+        );
+        users = discoveredUserIds.map((userId) => ({ userId }));
+        console.log(`Discovered ${users.length} users with conversations`);
+      }
+
+      // Return early if no users found
+      if (users.length === 0) {
+        return {
+          statusCode: 200,
+          body: JSON.stringify({
+            message: 'No users with conversations on target date',
+            date: targetDate,
+            total: 0,
+            successful: 0,
+            failed: 0,
+          }),
+        };
+      }
+
+      const results = await Promise.allSettled(
+        users.map((user) =>
+          generateDailySummaryForUser(user.userId, tenantId, targetDate)
+        )
+      );
+
+      const summary = {
+        total: results.length,
+        successful: results.filter(
+          (r) => r.status === 'fulfilled' && r.value.success
+        ).length,
+        failed: results.filter(
+          (r) =>
+            r.status === 'rejected' ||
+            (r.status === 'fulfilled' && !r.value.success)
+        ).length,
+      };
+
+      return {
+        statusCode: 200,
+        body: JSON.stringify(summary),
+      };
+    }
+
+    // Default: scheduled invocation - should be handled by Step Functions
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        message:
+          'Scheduled invocation - should be orchestrated by Step Functions',
+        date: getYesterdayDate(),
+      }),
+    };
+  } catch (error) {
+    console.error('Daily summary generation failed:', error);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }),
+    };
+  }
+};

--- a/packages/cdk/lambda/summary/generateUserSummary.ts
+++ b/packages/cdk/lambda/summary/generateUserSummary.ts
@@ -1,0 +1,260 @@
+import { ConverseCommand } from '@aws-sdk/client-bedrock-runtime';
+import { initBedrockRuntimeClient } from '../utils/bedrockClient';
+import {
+  buildUserSummarySystemPrompt,
+  buildUserSummaryUserPrompt,
+  truncateSummary,
+} from '../utils/summaryPrompts';
+import {
+  saveUserSummaryForBatch,
+  getUserSummaryConfigForBatch,
+  getDailySummariesInRangeForBatch,
+  calculateTermStart,
+  getYesterdayDate,
+  getUsersWithSummaryOnDateForBatch,
+} from '../repository/userSummary';
+import { DailySummary } from 'generative-ai-use-cases';
+import liteLlmApi from '../utils/liteLlmApi';
+
+// Configuration from environment
+const SUMMARY_MODEL_ID =
+  process.env.SUMMARY_MODEL_ID || 'us.anthropic.claude-3-5-haiku-20241022-v1:0';
+const MODEL_REGION = process.env.MODEL_REGION || 'us-east-1';
+const LITELLM_ENDPOINT = process.env.LITELLM_ENDPOINT || '';
+const USER_SUMMARY_MAX_CHARS = parseInt(
+  process.env.USER_SUMMARY_MAX_CHARS || '500'
+);
+const DEFAULT_TERM_UNIT = (process.env.DEFAULT_TERM_UNIT || 'month') as
+  | 'month'
+  | 'year';
+const DEFAULT_TERM_VALUE = parseInt(process.env.DEFAULT_TERM_VALUE || '1');
+
+interface UserSummaryEvent {
+  tenantId: string;
+  userId: string;
+  termEnd?: string; // YYYY-MM-DD, defaults to yesterday
+}
+
+interface BatchEvent {
+  tenantId?: string;
+  termEnd?: string;
+  users?: Array<{ userId: string }>;
+}
+
+/**
+ * Generate user summary for a single user
+ * Uses batch mode functions (STS AssumeRole) - no JWT required
+ */
+export async function generateUserSummaryForUser(
+  userId: string,
+  tenantId: string,
+  termEnd?: string
+): Promise<{ success: boolean; summary?: string; error?: string }> {
+  try {
+    // Determine term end date (default: yesterday)
+    const endDate = termEnd || getYesterdayDate();
+
+    // Get user's term configuration (or use defaults) - uses batch mode
+    const config = await getUserSummaryConfigForBatch(userId, tenantId);
+    const termUnit = config?.termUnit || DEFAULT_TERM_UNIT;
+    const termValue = config?.termValue || DEFAULT_TERM_VALUE;
+
+    // Calculate term start date
+    const startDate = calculateTermStart(termUnit, termValue, endDate);
+
+    // Get daily summaries within the term - uses batch mode
+    const dailySummaries = await getDailySummariesInRangeForBatch(
+      userId,
+      startDate,
+      endDate,
+      tenantId
+    );
+
+    if (dailySummaries.length === 0) {
+      console.log(`No daily summaries found for user ${userId} in term ${startDate} to ${endDate}`);
+      return { success: true, summary: undefined };
+    }
+
+    // Format daily summaries for the prompt
+    const formattedSummaries = dailySummaries.map((s: DailySummary) => ({
+      date: s.date,
+      summary: s.summary,
+    }));
+
+    const systemPrompt = buildUserSummarySystemPrompt(USER_SUMMARY_MAX_CHARS);
+    const userPrompt = buildUserSummaryUserPrompt(
+      formattedSummaries,
+      startDate,
+      endDate
+    );
+
+    let rawSummary: string;
+    let inputTokens = 0;
+    let outputTokens = 0;
+
+    // Use LiteLLM if configured, otherwise use Bedrock directly
+    if (LITELLM_ENDPOINT) {
+      // Use LiteLLM proxy
+      const result = await liteLlmApi.invoke(
+        { modelId: SUMMARY_MODEL_ID, type: 'liteLlm' },
+        [
+          { role: 'system', content: systemPrompt },
+          { role: 'user', content: userPrompt },
+        ],
+        ''
+      );
+      rawSummary = result;
+      // Note: LiteLLM doesn't return token usage in invoke response
+    } else {
+      // Use Bedrock directly
+      const client = await initBedrockRuntimeClient({ region: MODEL_REGION });
+      const response = await client.send(
+        new ConverseCommand({
+          modelId: SUMMARY_MODEL_ID,
+          messages: [
+            {
+              role: 'user',
+              content: [{ text: userPrompt }],
+            },
+          ],
+          system: [{ text: systemPrompt }],
+          inferenceConfig: {
+            maxTokens: 512,
+            temperature: 0.3,
+          },
+        })
+      );
+      rawSummary = response.output?.message?.content?.[0]?.text || '';
+      inputTokens = response.usage?.inputTokens || 0;
+      outputTokens = response.usage?.outputTokens || 0;
+    }
+
+    const summary = truncateSummary(rawSummary.trim(), USER_SUMMARY_MAX_CHARS);
+
+    // Save the user summary - uses batch mode
+    await saveUserSummaryForBatch({
+      userId,
+      tenantId,
+      summary,
+      termUnit,
+      termValue,
+      termStart: startDate,
+      termEnd: endDate,
+      dailySummaryDates: dailySummaries.map((s: DailySummary) => s.date),
+      generatedAt: new Date().toISOString(),
+      tokenUsage: {
+        inputTokens,
+        outputTokens,
+      },
+    });
+
+    return { success: true, summary };
+  } catch (error) {
+    console.error(`Failed to generate user summary for user ${userId}:`, error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}
+
+/**
+ * Lambda handler for generating user summaries
+ * Typically invoked by Step Functions after daily summary generation completes
+ */
+export const handler = async (
+  event: UserSummaryEvent | BatchEvent
+): Promise<{
+  statusCode: number;
+  body: string;
+}> => {
+  console.log('User summary generation triggered:', JSON.stringify(event));
+
+  try {
+    // Check if this is a single user request
+    if ('userId' in event && 'tenantId' in event) {
+      const { userId, tenantId, termEnd } = event as UserSummaryEvent;
+
+      const result = await generateUserSummaryForUser(userId, tenantId, termEnd);
+
+      return {
+        statusCode: result.success ? 200 : 500,
+        body: JSON.stringify(result),
+      };
+    }
+
+    // Batch processing for multiple users (from Step Functions or EventBridge)
+    if ('users' in event || 'tenantId' in event) {
+      const batchEvent = event as BatchEvent;
+      const tenantId = batchEvent.tenantId || 'default';
+      // Normalize date: EventBridge passes ISO 8601 (YYYY-MM-DDTHH:mm:ssZ), extract YYYY-MM-DD
+      const termEnd = (batchEvent.termEnd ?? getYesterdayDate()).slice(0, 10);
+
+      // Discover users with daily summaries on the target date if not provided
+      let users = batchEvent.users || [];
+      if (users.length === 0) {
+        console.log(
+          `No users provided, discovering users with daily summaries on ${termEnd}`
+        );
+        const discoveredUserIds = await getUsersWithSummaryOnDateForBatch(
+          termEnd,
+          tenantId
+        );
+        users = discoveredUserIds.map((userId) => ({ userId }));
+        console.log(`Discovered ${users.length} users with daily summaries`);
+      }
+
+      // Return early if no users found
+      if (users.length === 0) {
+        return {
+          statusCode: 200,
+          body: JSON.stringify({
+            message: 'No users with daily summaries on target date',
+            date: termEnd,
+            total: 0,
+            successful: 0,
+            failed: 0,
+          }),
+        };
+      }
+
+      const results = await Promise.allSettled(
+        users.map((user) =>
+          generateUserSummaryForUser(user.userId, tenantId, termEnd)
+        )
+      );
+
+      const summary = {
+        total: results.length,
+        successful: results.filter(
+          (r) => r.status === 'fulfilled' && r.value.success
+        ).length,
+        failed: results.filter(
+          (r) =>
+            r.status === 'rejected' ||
+            (r.status === 'fulfilled' && !r.value.success)
+        ).length,
+      };
+
+      return {
+        statusCode: 200,
+        body: JSON.stringify(summary),
+      };
+    }
+
+    return {
+      statusCode: 400,
+      body: JSON.stringify({
+        error: 'Invalid event format. Expected userId/tenantId or users array.',
+      }),
+    };
+  } catch (error) {
+    console.error('User summary generation failed:', error);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }),
+    };
+  }
+};

--- a/packages/cdk/lambda/summary/summaryTenantDiscovery.ts
+++ b/packages/cdk/lambda/summary/summaryTenantDiscovery.ts
@@ -1,0 +1,191 @@
+import { ScheduledEvent } from 'aws-lambda';
+import {
+  SFNClient,
+  StartExecutionCommand,
+} from '@aws-sdk/client-sfn';
+import {
+  DynamoDBClient,
+  ScanCommand,
+} from '@aws-sdk/client-dynamodb';
+import { unmarshall } from '@aws-sdk/util-dynamodb';
+
+const STATE_MACHINE_ARN = process.env.STATE_MACHINE_ARN!;
+const TENANTS_TABLE_NAME = process.env.TENANTS_TABLE_NAME;
+const DEFAULT_TENANT_ID = process.env.DEFAULT_TENANT_ID || 'default';
+
+const sfnClient = new SFNClient({});
+const dynamoClient = new DynamoDBClient({});
+
+interface Tenant {
+  tenantId: string;
+  status: string;
+}
+
+/**
+ * Get yesterday's date in YYYY-MM-DD format (JST timezone)
+ */
+function getYesterdayDate(): string {
+  const now = new Date();
+  const jstOffset = 9 * 60 * 60 * 1000;
+  const jstNow = new Date(now.getTime() + jstOffset);
+  jstNow.setDate(jstNow.getDate() - 1);
+  return jstNow.toISOString().split('T')[0];
+}
+
+/**
+ * List all active tenants from the Tenants table
+ */
+async function listActiveTenants(): Promise<string[]> {
+  if (!TENANTS_TABLE_NAME) {
+    console.log('No TENANTS_TABLE_NAME configured, using default tenant only');
+    return [DEFAULT_TENANT_ID];
+  }
+
+  try {
+    const tenantIds: string[] = [];
+    let lastEvaluatedKey: Record<string, any> | undefined;
+
+    do {
+      const response = await dynamoClient.send(
+        new ScanCommand({
+          TableName: TENANTS_TABLE_NAME,
+          FilterExpression: '#status = :activeStatus',
+          ExpressionAttributeNames: {
+            '#status': 'status',
+          },
+          ExpressionAttributeValues: {
+            ':activeStatus': { S: 'active' },
+          },
+          ExclusiveStartKey: lastEvaluatedKey,
+        })
+      );
+
+      if (response.Items) {
+        for (const item of response.Items) {
+          const tenant = unmarshall(item) as Tenant;
+          tenantIds.push(tenant.tenantId);
+        }
+      }
+
+      lastEvaluatedKey = response.LastEvaluatedKey;
+    } while (lastEvaluatedKey);
+
+    // Always include default tenant if not already in the list
+    if (!tenantIds.includes(DEFAULT_TENANT_ID)) {
+      tenantIds.unshift(DEFAULT_TENANT_ID);
+    }
+
+    return tenantIds;
+  } catch (error) {
+    console.error('Failed to list tenants:', error);
+    // Fallback to default tenant on error
+    return [DEFAULT_TENANT_ID];
+  }
+}
+
+/**
+ * Start Step Functions execution for a single tenant
+ */
+async function startExecutionForTenant(
+  tenantId: string,
+  date: string
+): Promise<{ tenantId: string; success: boolean; executionArn?: string; error?: string }> {
+  try {
+    const executionName = `summary-${tenantId}-${date}-${Date.now()}`;
+
+    const response = await sfnClient.send(
+      new StartExecutionCommand({
+        stateMachineArn: STATE_MACHINE_ARN,
+        name: executionName,
+        input: JSON.stringify({
+          tenantId,
+          date,
+          users: [], // Will be discovered by the Lambda
+        }),
+      })
+    );
+
+    console.log(`Started execution for tenant ${tenantId}: ${response.executionArn}`);
+    return {
+      tenantId,
+      success: true,
+      executionArn: response.executionArn,
+    };
+  } catch (error) {
+    console.error(`Failed to start execution for tenant ${tenantId}:`, error);
+    return {
+      tenantId,
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}
+
+/**
+ * Lambda handler for tenant discovery and Step Functions fan-out
+ * Triggered by EventBridge on schedule
+ */
+export const handler = async (
+  event: ScheduledEvent
+): Promise<{
+  statusCode: number;
+  body: string;
+}> => {
+  console.log('Summary tenant discovery triggered:', JSON.stringify(event));
+
+  try {
+    const targetDate = getYesterdayDate();
+    console.log(`Target date for summary generation: ${targetDate}`);
+
+    // Discover all active tenants
+    const tenantIds = await listActiveTenants();
+    console.log(`Discovered ${tenantIds.length} tenants: ${tenantIds.join(', ')}`);
+
+    if (tenantIds.length === 0) {
+      return {
+        statusCode: 200,
+        body: JSON.stringify({
+          message: 'No tenants found',
+          date: targetDate,
+          total: 0,
+        }),
+      };
+    }
+
+    // Start executions for all tenants in parallel
+    const results = await Promise.allSettled(
+      tenantIds.map((tenantId) => startExecutionForTenant(tenantId, targetDate))
+    );
+
+    const summary = {
+      date: targetDate,
+      total: results.length,
+      successful: results.filter(
+        (r) => r.status === 'fulfilled' && r.value.success
+      ).length,
+      failed: results.filter(
+        (r) =>
+          r.status === 'rejected' ||
+          (r.status === 'fulfilled' && !r.value.success)
+      ).length,
+      executions: results
+        .filter((r) => r.status === 'fulfilled')
+        .map((r) => (r as PromiseFulfilledResult<any>).value),
+    };
+
+    console.log('Tenant discovery complete:', JSON.stringify(summary));
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify(summary),
+    };
+  } catch (error) {
+    console.error('Tenant discovery failed:', error);
+    return {
+      statusCode: 500,
+      body: JSON.stringify({
+        error: error instanceof Error ? error.message : 'Unknown error',
+      }),
+    };
+  }
+};

--- a/packages/cdk/lambda/tenantRegistrationHandler.ts
+++ b/packages/cdk/lambda/tenantRegistrationHandler.ts
@@ -27,7 +27,14 @@ interface TenantRegistrationRequest {
   region: string;
   environment: string;
   roleArn?: string;
+  /**
+   * @deprecated Use controlPlaneLambdaRoleArns instead
+   */
   controlPlaneLambdaRoleArn?: string;
+  /**
+   * Array of control plane Lambda role ARNs for cross-account access
+   */
+  controlPlaneLambdaRoleArns?: string[];
   openSearchDomainArn?: string;
   openSearchEndpoint?: string;
   openSearchIndexName?: string;
@@ -57,6 +64,7 @@ export const handler = async (
       environment,
       roleArn,
       controlPlaneLambdaRoleArn,
+      controlPlaneLambdaRoleArns,
       openSearchDomainArn,
       openSearchEndpoint,
       openSearchIndexName,
@@ -137,7 +145,9 @@ export const handler = async (
       region,
       environment,
       roleArn,
-      controlPlaneLambdaRoleArn,
+      // Store both for backwards compatibility, prefer array
+      ...(controlPlaneLambdaRoleArn && { controlPlaneLambdaRoleArn }),
+      ...(controlPlaneLambdaRoleArns && { controlPlaneLambdaRoleArns }),
       createdAt: now,
       updatedAt: now,
       metadata: {

--- a/packages/cdk/lambda/updateSummaryConfig.ts
+++ b/packages/cdk/lambda/updateSummaryConfig.ts
@@ -1,0 +1,95 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import {
+  UpdateSummaryConfigRequest,
+  UserSummaryConfig,
+} from 'generative-ai-use-cases';
+import {
+  getUserSummaryConfig,
+  saveUserSummaryConfig,
+  updateUserSummaryConfig,
+} from './repository/userSummary';
+import { getTenantId } from './utils/tenantUtils';
+import {
+  ok200Response,
+  badRequest400Response,
+  unauthorized401Response,
+  internalServerError500Response,
+} from './utils/apiResponse';
+
+/**
+ * PUT /summaries/config
+ * Updates the user's summary configuration
+ */
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    const userId =
+      event.requestContext.authorizer?.claims?.['cognito:username'] ||
+      event.requestContext.authorizer?.claims?.sub;
+
+    if (!userId) {
+      return unauthorized401Response({ message: 'User ID not found' });
+    }
+
+    if (!event.body) {
+      return badRequest400Response({ message: 'Request body is required' });
+    }
+
+    const requestBody: UpdateSummaryConfigRequest = JSON.parse(event.body);
+
+    // Validate term unit if provided
+    if (
+      requestBody.termUnit &&
+      !['month', 'year'].includes(requestBody.termUnit)
+    ) {
+      return badRequest400Response({
+        message: 'Invalid termUnit. Must be "month" or "year"',
+      });
+    }
+
+    // Validate term value if provided
+    if (
+      requestBody.termValue !== undefined &&
+      (requestBody.termValue < 1 || requestBody.termValue > 12)
+    ) {
+      return badRequest400Response({
+        message: 'Invalid termValue. Must be between 1 and 12',
+      });
+    }
+
+    // Check if config exists
+    const existingConfig = await getUserSummaryConfig(userId, event);
+    const tenantId = getTenantId(event) || 'default';
+
+    let updatedConfig: UserSummaryConfig | null;
+
+    if (existingConfig) {
+      // Update existing config
+      updatedConfig = await updateUserSummaryConfig(userId, requestBody, event);
+    } else {
+      // Create new config with defaults for missing fields
+      updatedConfig = await saveUserSummaryConfig(
+        {
+          userId,
+          tenantId,
+          termUnit: requestBody.termUnit || 'month',
+          termValue: requestBody.termValue || 1,
+          externalContextPrompt: requestBody.externalContextPrompt,
+          enabled: requestBody.enabled ?? true,
+        },
+        event
+      );
+    }
+
+    return ok200Response({
+      message: 'Configuration updated successfully',
+      config: updatedConfig,
+    });
+  } catch (error) {
+    console.error('Failed to update summary config:', error);
+    return internalServerError500Response({
+      message: 'Failed to update configuration',
+    });
+  }
+};

--- a/packages/cdk/lambda/utils/documentLoader.ts
+++ b/packages/cdk/lambda/utils/documentLoader.ts
@@ -592,14 +592,14 @@ export async function loadDocuments(
 ): Promise<Document[]> {
   const loadPromises = sources.map(async (source) => {
     try {
-      if (source.type === 'file' && source.storageKey) {
+      if (source.type === 'file' && source.storageKey && source.id) {
         return await loadDocumentFromFile(
           source.storageKey,
           source.id,
           userId,
           event
         );
-      } else if (source.type === 'web' && source.sourceUrl) {
+      } else if (source.type === 'web' && source.sourceUrl && source.id) {
         return await loadDocumentFromWeb(source.sourceUrl, source.id);
       } else {
         throw new Error(

--- a/packages/cdk/lambda/utils/summaryContext.ts
+++ b/packages/cdk/lambda/utils/summaryContext.ts
@@ -1,0 +1,143 @@
+import { APIGatewayProxyEvent } from 'aws-lambda';
+import { DailySummary, UserSummary } from 'generative-ai-use-cases';
+import {
+  getLatestDailySummary,
+  getUserSummary,
+} from '../repository/userSummary';
+
+// Check if summary feature is enabled (set at deployment time)
+const SUMMARY_JOB_ENABLED = process.env.SUMMARY_JOB_ENABLED === 'true';
+
+/**
+ * Build summary context XML to inject into system prompts
+ * Returns empty string if summary feature is disabled for this environment
+ * @param userId User ID (without 'user#' prefix)
+ * @param event API Gateway event for tenant context
+ * @returns XML-formatted summary context string, or empty string if no summaries or feature disabled
+ */
+export async function buildSummaryContext(
+  userId: string,
+  event: APIGatewayProxyEvent
+): Promise<string> {
+  // Skip if summary feature is not enabled for this environment
+  if (!SUMMARY_JOB_ENABLED) {
+    console.log('Summary feature is disabled (SUMMARY_JOB_ENABLED != true)');
+    return '';
+  }
+
+  console.log(`Building summary context for user: ${userId}`);
+
+  try {
+    // Fetch both summaries in parallel
+    const [dailySummary, userSummary] = await Promise.all([
+      getLatestDailySummary(userId, event).catch((err) => {
+        console.error('Failed to get latest daily summary:', err);
+        return null;
+      }),
+      getUserSummary(userId, event).catch((err) => {
+        console.error('Failed to get user summary:', err);
+        return null;
+      }),
+    ]);
+
+    console.log(
+      `Summary fetch results - daily: ${!!dailySummary}, user: ${!!userSummary}`
+    );
+
+    if (!dailySummary && !userSummary) {
+      console.log('No summaries found for user');
+      return '';
+    }
+
+    const context = formatSummaryContext(dailySummary, userSummary);
+    console.log(`Summary context built, length: ${context.length}`);
+    return context;
+  } catch (error) {
+    console.error('Failed to build summary context:', error);
+    return '';
+  }
+}
+
+/**
+ * Format summary context as XML for system prompt injection
+ * @param dailySummary Latest daily summary (optional)
+ * @param userSummary User's aggregated summary (optional)
+ * @returns Formatted XML context string
+ */
+export function formatSummaryContext(
+  dailySummary: DailySummary | null,
+  userSummary: UserSummary | null
+): string {
+  if (!dailySummary && !userSummary) {
+    return '';
+  }
+
+  let context = '<context_summaries>\n';
+
+  if (dailySummary) {
+    context += `<daily_summary date="${dailySummary.date}">\n`;
+    context += dailySummary.summary;
+    context += '\n</daily_summary>\n';
+  }
+
+  if (userSummary) {
+    context += `<user_profile term="${userSummary.termValue} ${userSummary.termUnit}(s)">\n`;
+    context += '<user_summary>\n';
+    context += userSummary.summary;
+    context += '\n</user_summary>\n';
+    context += '</user_profile>\n';
+  }
+
+  context += '</context_summaries>';
+
+  return context;
+}
+
+/**
+ * Build complete system message with summary context injected
+ * @param baseInstruction The base assistant/system instruction
+ * @param summaryContext Summary context XML (from buildSummaryContext)
+ * @param ragContext RAG context (optional)
+ * @param customInstructions User's custom instructions (optional)
+ * @returns Complete system message with all context
+ */
+export function buildSystemMessageWithSummary(
+  baseInstruction: string,
+  summaryContext: string,
+  ragContext?: string | null,
+  customInstructions?: string | null
+): string {
+  let message = `<instructions>\n${baseInstruction}\n</instructions>`;
+
+  if (summaryContext) {
+    message += `\n\n${summaryContext}`;
+  }
+
+  if (ragContext) {
+    message += `\n\nRelevant context from documents:\n${ragContext}`;
+  }
+
+  if (customInstructions?.trim()) {
+    message += `\n<user_custom_instructions>\n${customInstructions}\n</user_custom_instructions>`;
+  }
+
+  return message;
+}
+
+/**
+ * Extract user ID from different formats
+ * @param userId User ID potentially with 'user#' prefix
+ * @returns Clean user ID without prefix
+ */
+export function extractUserId(userId: string): string {
+  return userId.startsWith('user#') ? userId.substring(5) : userId;
+}
+
+/**
+ * Build user ID with prefix
+ * @param userId Clean user ID
+ * @returns User ID with 'user#' prefix
+ */
+export function buildUserIdWithPrefix(userId: string): string {
+  return userId.startsWith('user#') ? userId : `user#${userId}`;
+}

--- a/packages/cdk/lambda/utils/summaryPrompts.ts
+++ b/packages/cdk/lambda/utils/summaryPrompts.ts
@@ -1,0 +1,156 @@
+/**
+ * Prompt templates for daily and user summary generation
+ */
+
+/**
+ * Build the system prompt for daily summary generation
+ * @param maxChars Maximum characters for the summary (default: 200)
+ */
+export function buildDailySummarySystemPrompt(maxChars: number = 200): string {
+  return `You are a coaching journal assistant. Your task is to summarize a day's conversations to track the user's learning journey and growth.
+
+EXTRACTION FOCUS:
+1. Problem genres - What types of problems/issues did the user face today?
+2. Confusion points - What caused the user difficulty or confusion?
+3. AI coaching - How did the AI assist, guide, or coach the user?
+4. User growth - What did the user learn, improve, or change today?
+
+CRITICAL REQUIREMENTS:
+1. Output MUST be under ${maxChars} characters (this is a hard limit)
+2. Prioritize insights about user's learning and growth over topic listing
+3. Note specific struggles and breakthroughs
+4. Output in the same language as the conversations
+
+Output format: A single paragraph focusing on the user's learning journey. No bullet points.`;
+}
+
+/**
+ * Build the user prompt for daily summary generation
+ * @param messages Formatted conversation messages from the day
+ * @param date The date being summarized (YYYY-MM-DD)
+ */
+export function buildDailySummaryUserPrompt(
+  messages: string,
+  date: string
+): string {
+  return `Date: ${date}
+
+CONVERSATION HISTORY:
+${messages}
+
+Analyze the conversations and extract: what problems the user faced, where they struggled, how AI helped them, and what growth or learning occurred.`;
+}
+
+/**
+ * Build the system prompt for user summary generation
+ * @param maxChars Maximum characters for the summary (default: 500)
+ */
+export function buildUserSummarySystemPrompt(maxChars: number = 500): string {
+  return `You are a growth tracking assistant. Your task is to analyze daily coaching summaries and create a comprehensive view of the user's growth trajectory.
+
+EXTRACTION FOCUS:
+1. Growth trajectory - How has the user grown over this period?
+2. Breakthroughs - What problems can the user now solve that they couldn't before?
+3. Persistent challenges - What areas still cause difficulty?
+4. Growth potential - Where are the opportunities for further development?
+5. Learning patterns - How does the user learn best? What approaches worked?
+
+CRITICAL REQUIREMENTS:
+1. Output MUST be under ${maxChars} characters (this is a hard limit)
+2. Focus on concrete examples of growth (e.g., "user now handles X independently")
+3. Note both achievements and areas needing support
+4. Output in the same language as the daily summaries
+
+Output format: A narrative focusing on user's growth journey and potential. No bullet points.`;
+}
+
+/**
+ * Build the user prompt for user summary generation
+ * @param dailySummaries Array of daily summary texts
+ * @param termStart Start date of the term (YYYY-MM-DD)
+ * @param termEnd End date of the term (YYYY-MM-DD)
+ */
+export function buildUserSummaryUserPrompt(
+  dailySummaries: Array<{ date: string; summary: string }>,
+  termStart: string,
+  termEnd: string
+): string {
+  const formattedSummaries = dailySummaries
+    .map((s) => `[${s.date}] ${s.summary}`)
+    .join('\n');
+
+  return `PERIOD: ${termStart} to ${termEnd}
+
+DAILY COACHING SUMMARIES:
+${formattedSummaries}
+
+Analyze the user's growth trajectory: What breakthroughs occurred? What can they do now that they couldn't before? What challenges persist? Where is their growth potential?`;
+}
+
+/**
+ * Format conversation messages for summarization
+ * @param messages Array of message objects with role and content
+ * @param maxTotalLength Maximum total length of formatted messages
+ */
+export function formatMessagesForSummary(
+  messages: Array<{ role: string; content: string }>,
+  maxTotalLength: number = 32000
+): string {
+  const formatted: string[] = [];
+  let totalLength = 0;
+
+  for (const msg of messages) {
+    // Skip system messages
+    if (msg.role === 'system') continue;
+
+    // Truncate long messages
+    const truncatedContent =
+      msg.content.length > 1000
+        ? msg.content.substring(0, 1000) + '...'
+        : msg.content;
+
+    const line = `[${msg.role}]: ${truncatedContent}`;
+
+    if (totalLength + line.length > maxTotalLength) {
+      formatted.push('[...conversation truncated due to length...]');
+      break;
+    }
+
+    formatted.push(line);
+    totalLength += line.length;
+  }
+
+  return formatted.join('\n');
+}
+
+/**
+ * Truncate summary to ensure it meets character limit
+ * @param text The generated summary text
+ * @param maxChars Maximum allowed characters
+ */
+export function truncateSummary(text: string, maxChars: number): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+
+  // Find the last sentence boundary before the limit
+  const truncated = text.substring(0, maxChars);
+  const lastPeriod = truncated.lastIndexOf('.');
+  const lastQuestion = truncated.lastIndexOf('?');
+  const lastExclamation = truncated.lastIndexOf('!');
+
+  const lastSentenceEnd = Math.max(lastPeriod, lastQuestion, lastExclamation);
+
+  if (lastSentenceEnd > maxChars * 0.5) {
+    // If we found a sentence end in the latter half, use it
+    return truncated.substring(0, lastSentenceEnd + 1);
+  }
+
+  // Otherwise, truncate at word boundary
+  const lastSpace = truncated.lastIndexOf(' ');
+  if (lastSpace > maxChars * 0.8) {
+    return truncated.substring(0, lastSpace) + '...';
+  }
+
+  return truncated + '...';
+}

--- a/packages/cdk/lambda/utils/tenantCredentials.ts
+++ b/packages/cdk/lambda/utils/tenantCredentials.ts
@@ -454,3 +454,80 @@ export async function getTenantCredentialsForInternalCall(
     );
   }
 }
+
+/**
+ * Get tenant credentials for batch processing (without JWT token)
+ * Uses direct STS AssumeRole instead of AssumeRoleWithWebIdentity
+ *
+ * This is designed for background jobs like summary generation where
+ * there is no user JWT token available.
+ */
+export async function getTenantCredentialsForBatch(
+  tenantId: string
+): Promise<TenantCredentialsWithInfo> {
+  const { region } = validateEnvironment();
+
+  // Check cache first (using a batch-specific key)
+  const cacheKey = `batch:${tenantId}`;
+  const cached = getFromCache(cacheKey);
+  if (cached) {
+    console.log(`Using cached batch credentials for tenant: ${tenantId}`);
+    return {
+      credentials: cached.credentials,
+      tenant: cached.tenant,
+      region: cached.tenant.region || region,
+    };
+  }
+
+  console.log(`Getting batch credentials for tenant: ${tenantId} using AssumeRole`);
+
+  try {
+    // Get tenant metadata
+    const tenant = await getTenant(tenantId);
+    if (!tenant) {
+      throw new Error(`Tenant ${tenantId} not found in tenants table`);
+    }
+
+    if (!tenant.roleArn) {
+      throw new Error(`Tenant ${tenantId} is missing roleArn configuration`);
+    }
+
+    console.log(`Assuming role for batch tenant ${tenantId}: ${tenant.roleArn}`);
+
+    // Use direct STS AssumeRole (not AssumeRoleWithWebIdentity)
+    const stsClient = new STSClient({ region });
+
+    const assumeRoleResponse = await stsClient.send(
+      new AssumeRoleCommand({
+        RoleArn: tenant.roleArn,
+        RoleSessionName: `batch-summary-${tenantId}-${Date.now()}`,
+        DurationSeconds: 3600, // 1 hour
+      })
+    );
+
+    if (!assumeRoleResponse.Credentials) {
+      throw new Error('No credentials returned from AssumeRole');
+    }
+
+    const credentials: Credentials = {
+      AccessKeyId: assumeRoleResponse.Credentials.AccessKeyId,
+      SecretAccessKey: assumeRoleResponse.Credentials.SecretAccessKey,
+      SessionToken: assumeRoleResponse.Credentials.SessionToken,
+      Expiration: assumeRoleResponse.Credentials.Expiration,
+    };
+
+    // Save to cache
+    saveToCache(cacheKey, credentials, tenant);
+
+    console.log(`Successfully obtained batch credentials for tenant: ${tenantId}`);
+
+    return {
+      credentials,
+      tenant,
+      region: tenant.region || region,
+    };
+  } catch (error) {
+    console.error(`Failed to get batch credentials for tenant: ${tenantId}:`, error);
+    throw new Error(`Failed to get batch credentials: ${(error as Error).message}`);
+  }
+}

--- a/packages/cdk/lib/construct/api/assistant.ts
+++ b/packages/cdk/lib/construct/api/assistant.ts
@@ -4,7 +4,7 @@ import { Construct } from 'constructs';
 import { LAMBDA_RUNTIME_NODEJS } from '../../../consts';
 import { Duration } from 'aws-cdk-lib';
 import { getBaseEnvironment } from './util';
-import { ASSISTANT_TABLE_PREFIX } from './const';
+import { ASSISTANT_TABLE_PREFIX, USER_SUMMARY_TABLE_PREFIX } from './const';
 import { GenericApiProps } from './props';
 import { Bucket } from 'aws-cdk-lib/aws-s3';
 import * as iam from 'aws-cdk-lib/aws-iam';
@@ -106,6 +106,14 @@ class AssistantApi extends Construct {
           OPENSEARCH_INDEX: 'assistant-docs',
           TENANTS_TABLE_NAME: tenantManager?.tenantsTable.tableName || '',
           LITELLM_ENDPOINT: props.litellmEndpoint ?? '',
+          // User Summary table for summary context injection (only when enabled)
+          ...(props.summaryJobEnabled && props.userSummaryTable
+            ? {
+                USER_SUMMARY_TABLE_NAME: USER_SUMMARY_TABLE_PREFIX,
+                DEFAULT_USER_SUMMARY_TABLE_NAME: props.userSummaryTable.tableName,
+                SUMMARY_JOB_ENABLED: 'true',
+              }
+            : {}),
           ...(props.openai?.apiKey
             ? { OPENAI_API_KEY: props.openai.apiKey }
             : {}),
@@ -116,6 +124,9 @@ class AssistantApi extends Construct {
     // Grant permissions for message operations
     assistantTable.grantReadData(assistantMessageHandler);
     table.grantReadWriteData(assistantMessageHandler);
+    if (props.userSummaryTable) {
+      props.userSummaryTable.grantReadData(assistantMessageHandler);
+    }
 
     // Grant Bedrock permissions for LLM calls
     if (props.bedrockPolicy) {
@@ -156,6 +167,14 @@ class AssistantApi extends Construct {
           USER_POOL_CLIENT_ID: userPoolClient.userPoolClientId,
           TENANTS_TABLE_NAME: tenantManager?.tenantsTable.tableName || '',
           LITELLM_ENDPOINT: props.litellmEndpoint ?? '',
+          // User Summary table for summary context injection (only when enabled)
+          ...(props.summaryJobEnabled && props.userSummaryTable
+            ? {
+                USER_SUMMARY_TABLE_NAME: USER_SUMMARY_TABLE_PREFIX,
+                DEFAULT_USER_SUMMARY_TABLE_NAME: props.userSummaryTable.tableName,
+                SUMMARY_JOB_ENABLED: 'true',
+              }
+            : {}),
         }),
       }
     );
@@ -163,6 +182,9 @@ class AssistantApi extends Construct {
     // Grant permissions for streaming handler
     assistantTable.grantReadData(assistantMessageStreamFunction);
     table.grantReadWriteData(assistantMessageStreamFunction);
+    if (props.userSummaryTable) {
+      props.userSummaryTable.grantReadData(assistantMessageStreamFunction);
+    }
 
     // Grant Bedrock permissions for LLM streaming calls
     if (props.bedrockPolicy) {

--- a/packages/cdk/lib/construct/api/const.ts
+++ b/packages/cdk/lib/construct/api/const.ts
@@ -2,3 +2,4 @@
 export const TABLE_PREFIX = 'ChatHistory';
 export const STATS_TABLE_PREFIX = 'TokenUsageStats';
 export const ASSISTANT_TABLE_PREFIX = 'Assistant';
+export const USER_SUMMARY_TABLE_PREFIX = 'UserSummary';

--- a/packages/cdk/lib/construct/api/index.ts
+++ b/packages/cdk/lib/construct/api/index.ts
@@ -51,6 +51,7 @@ import FileBucket from '../file-bucket';
 import ShareApi from './share';
 import AdminApi from './admin';
 import UserApi from './user';
+import SummaryApi from './summary';
 import { CentralPptxApi } from './central-pptx';
 
 export interface BackendApiProps {
@@ -80,6 +81,7 @@ export interface BackendApiProps {
   readonly userPoolClient: UserPoolClient;
   readonly table: Table;
   readonly statsTable: Table;
+  readonly userSummaryTable?: Table;
   readonly assistantTable: Table;
   readonly knowledgeBaseId?: string;
   readonly agents?: Agent[];
@@ -93,6 +95,9 @@ export interface BackendApiProps {
   readonly openai?: {
     readonly apiKey: string; // OPENAI_API_KEY
   };
+
+  // Summary feature (environment-specific)
+  readonly summaryJobEnabled?: boolean;
 }
 
 export class Api extends Construct {
@@ -404,6 +409,14 @@ export class Api extends Construct {
     new WebTextApi(this, 'WebTextAPI', apiProps);
     new AdminApi(this, 'AdminAPI', apiProps);
     new UserApi(this, 'UserAPI', apiProps);
+
+    // Summary API (only when feature enabled)
+    if (props.summaryJobEnabled && props.userSummaryTable) {
+      new SummaryApi(this, 'SummaryAPI', {
+        ...apiProps,
+        userSummaryTable: props.userSummaryTable,
+      });
+    }
 
     // Central PPTX API for multi-tenant architecture
     // Lambda functions dynamically access tenant-specific resources based on Cognito claims

--- a/packages/cdk/lib/construct/api/predict.ts
+++ b/packages/cdk/lib/construct/api/predict.ts
@@ -6,6 +6,11 @@ import { LAMBDA_RUNTIME_NODEJS } from '../../../consts';
 import { Duration, Stack } from 'aws-cdk-lib';
 import { getBaseEnvironment } from './util';
 import * as iam from 'aws-cdk-lib/aws-iam';
+import {
+  TABLE_PREFIX,
+  STATS_TABLE_PREFIX,
+  USER_SUMMARY_TABLE_PREFIX,
+} from './const';
 
 export type PredictApiProps = GenericApiProps;
 
@@ -43,6 +48,8 @@ class PredictApi extends Construct {
       assumeRolePolicy,
       litellmProxy,
       environment,
+      summaryJobEnabled,
+      userSummaryTable,
     } = props;
 
     const predictFunction = new NodejsFunction(this, 'Predict', {
@@ -62,6 +69,15 @@ class PredictApi extends Construct {
 
         // LangChain Credentials
         OPENAI_API_KEY: openai?.apiKey ?? '',
+
+        // User Summary table for summary context injection (only when enabled)
+        ...(summaryJobEnabled && userSummaryTable
+          ? {
+              USER_SUMMARY_TABLE_NAME: USER_SUMMARY_TABLE_PREFIX,
+              DEFAULT_USER_SUMMARY_TABLE_NAME: userSummaryTable.tableName,
+              SUMMARY_JOB_ENABLED: 'true',
+            }
+          : {}),
 
         // Tenant Management Environment Variables
         ...(tenantManager
@@ -112,6 +128,15 @@ class PredictApi extends Construct {
         // Environment
         ENVIRONMENT: environment,
 
+        // User Summary table for summary context injection (only when enabled)
+        ...(summaryJobEnabled && userSummaryTable
+          ? {
+              USER_SUMMARY_TABLE_NAME: USER_SUMMARY_TABLE_PREFIX,
+              DEFAULT_USER_SUMMARY_TABLE_NAME: userSummaryTable.tableName,
+              SUMMARY_JOB_ENABLED: 'true',
+            }
+          : {}),
+
         // Tenant Management Environment Variables
         ...(tenantManager
           ? {
@@ -133,6 +158,10 @@ class PredictApi extends Construct {
       },
     });
     fileBucket.grantReadWrite(predictStreamFunction);
+    if (userSummaryTable) {
+      userSummaryTable.grantReadData(predictStreamFunction);
+      userSummaryTable.grantReadData(predictFunction);
+    }
     predictStreamFunction.grantInvoke(idPool.authenticatedRole);
 
     const predictTitleFunction = new NodejsFunction(this, 'PredictTitle', {

--- a/packages/cdk/lib/construct/api/props.ts
+++ b/packages/cdk/lib/construct/api/props.ts
@@ -44,6 +44,7 @@ export type GenericApiProps = {
   readonly userPoolClient: UserPoolClient;
   readonly table: Table;
   readonly statsTable: Table;
+  readonly userSummaryTable?: Table;
   readonly assistantTable: Table;
   readonly knowledgeBaseId?: string;
   readonly agents?: Agent[];
@@ -75,4 +76,7 @@ export type GenericApiProps = {
   assumeRolePolicy?: PolicyStatement;
 
   selfSignUpTenantMap?: SelfSignUpTenantMapEntry[] | null;
+
+  // Summary feature (environment-specific)
+  summaryJobEnabled?: boolean;
 };

--- a/packages/cdk/lib/construct/api/summary.ts
+++ b/packages/cdk/lib/construct/api/summary.ts
@@ -1,0 +1,84 @@
+import { LambdaIntegration } from 'aws-cdk-lib/aws-apigateway';
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { Construct } from 'constructs';
+import { LAMBDA_RUNTIME_NODEJS } from '../../../consts';
+import { Duration } from 'aws-cdk-lib';
+import { getBaseEnvironment } from './util';
+import { GenericApiProps } from './props';
+import { Table } from 'aws-cdk-lib/aws-dynamodb';
+import { USER_SUMMARY_TABLE_PREFIX } from './const';
+
+export interface SummaryApiProps extends GenericApiProps {
+  readonly userSummaryTable: Table;
+}
+
+/**
+ * Summary API construct for user summary endpoints
+ * - GET /summaries - Returns user's daily and user summaries
+ * - PUT /summaries/config - Updates user's summary configuration
+ */
+class SummaryApi extends Construct {
+  constructor(scope: Construct, id: string, props: SummaryApiProps) {
+    super(scope, id);
+
+    const { api, commonAuthorizerProps, userSummaryTable, tenantManager } =
+      props;
+
+    const summariesResource = api.root.addResource('summaries');
+
+    // GET /summaries - Get user summaries
+    const getSummariesFunction = new NodejsFunction(this, 'GetSummaries', {
+      runtime: LAMBDA_RUNTIME_NODEJS,
+      entry: './lambda/getSummaries.ts',
+      timeout: Duration.seconds(30),
+      environment: getBaseEnvironment(this, props, {
+        USER_SUMMARY_TABLE_NAME: USER_SUMMARY_TABLE_PREFIX,
+        DEFAULT_USER_SUMMARY_TABLE_NAME: userSummaryTable.tableName,
+        TENANTS_TABLE_NAME: tenantManager?.tenantsTable.tableName || '',
+      }),
+    });
+
+    // Grant read permissions
+    userSummaryTable.grantReadData(getSummariesFunction);
+    if (tenantManager) {
+      tenantManager.tenantsTable.grantReadData(getSummariesFunction);
+    }
+
+    summariesResource.addMethod(
+      'GET',
+      new LambdaIntegration(getSummariesFunction),
+      commonAuthorizerProps
+    );
+
+    // PUT /summaries/config - Update summary configuration
+    const updateSummaryConfigFunction = new NodejsFunction(
+      this,
+      'UpdateSummaryConfig',
+      {
+        runtime: LAMBDA_RUNTIME_NODEJS,
+        entry: './lambda/updateSummaryConfig.ts',
+        timeout: Duration.seconds(30),
+        environment: getBaseEnvironment(this, props, {
+          USER_SUMMARY_TABLE_NAME: USER_SUMMARY_TABLE_PREFIX,
+          DEFAULT_USER_SUMMARY_TABLE_NAME: userSummaryTable.tableName,
+          TENANTS_TABLE_NAME: tenantManager?.tenantsTable.tableName || '',
+        }),
+      }
+    );
+
+    // Grant read/write permissions for config updates
+    userSummaryTable.grantReadWriteData(updateSummaryConfigFunction);
+    if (tenantManager) {
+      tenantManager.tenantsTable.grantReadData(updateSummaryConfigFunction);
+    }
+
+    const configResource = summariesResource.addResource('config');
+    configResource.addMethod(
+      'PUT',
+      new LambdaIntegration(updateSummaryConfigFunction),
+      commonAuthorizerProps
+    );
+  }
+}
+
+export default SummaryApi;

--- a/packages/cdk/lib/construct/database.ts
+++ b/packages/cdk/lib/construct/database.ts
@@ -1,16 +1,23 @@
 import { Construct } from 'constructs';
 import * as ddb from 'aws-cdk-lib/aws-dynamodb';
 
+export interface DatabaseProps {
+  readonly summaryJobEnabled?: boolean;
+}
+
 export class Database extends Construct {
   public readonly table: ddb.Table;
   public readonly statsTable: ddb.Table;
+  public readonly userSummaryTable?: ddb.Table;
   public readonly feedbackIndexName: string;
   public readonly assistantTable: ddb.Table;
   public readonly assistantIdIndexName: string;
   public readonly tenantVisibilityIndexName: string;
 
-  constructor(scope: Construct, id: string) {
+  constructor(scope: Construct, id: string, props?: DatabaseProps) {
     super(scope, id);
+
+    const { summaryJobEnabled = false } = props || {};
 
     const feedbackIndexName = 'FeedbackIndex';
     const table = new ddb.Table(this, 'Table', {
@@ -47,6 +54,36 @@ export class Database extends Construct {
       billingMode: ddb.BillingMode.PAY_PER_REQUEST,
       encryption: ddb.TableEncryption.AWS_MANAGED,
     });
+
+    // User Summary table for storing daily and user summaries (only when feature enabled)
+    let userSummaryTable: ddb.Table | undefined;
+    if (summaryJobEnabled) {
+      userSummaryTable = new ddb.Table(this, 'UserSummaryTable', {
+        partitionKey: {
+          name: 'id',
+          type: ddb.AttributeType.STRING,
+        },
+        sortKey: {
+          name: 'createdDate',
+          type: ddb.AttributeType.STRING,
+        },
+        billingMode: ddb.BillingMode.PAY_PER_REQUEST,
+        encryption: ddb.TableEncryption.AWS_MANAGED,
+      });
+
+      userSummaryTable.addGlobalSecondaryIndex({
+        indexName: 'DateIndex',
+        partitionKey: {
+          name: 'date',
+          type: ddb.AttributeType.STRING,
+        },
+        sortKey: {
+          name: 'userId',
+          type: ddb.AttributeType.STRING,
+        },
+        projectionType: ddb.ProjectionType.ALL,
+      });
+    }
 
     // Assistant table for storing assistant configurations
     const assistantIdIndexName = 'AssistantIdIndex';
@@ -89,6 +126,7 @@ export class Database extends Construct {
 
     this.table = table;
     this.statsTable = statsTable;
+    this.userSummaryTable = userSummaryTable;
     this.feedbackIndexName = feedbackIndexName;
     this.assistantTable = assistantTable;
     this.assistantIdIndexName = assistantIdIndexName;

--- a/packages/cdk/lib/construct/index.ts
+++ b/packages/cdk/lib/construct/index.ts
@@ -19,3 +19,4 @@ export * from './maintenance-mode';
 export * from './authorization-database';
 export * from './authorization-functions';
 export * from './orchestration-database';
+export * from './summary-generator';

--- a/packages/cdk/lib/construct/summary-generator.ts
+++ b/packages/cdk/lib/construct/summary-generator.ts
@@ -1,0 +1,245 @@
+import * as cdk from 'aws-cdk-lib';
+import { Construct } from 'constructs';
+import { Duration } from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as events from 'aws-cdk-lib/aws-events';
+import * as targets from 'aws-cdk-lib/aws-events-targets';
+import * as stepfunctions from 'aws-cdk-lib/aws-stepfunctions';
+import * as stepfunctionsTasks from 'aws-cdk-lib/aws-stepfunctions-tasks';
+import * as iam from 'aws-cdk-lib/aws-iam';
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { Table } from 'aws-cdk-lib/aws-dynamodb';
+import { LAMBDA_RUNTIME_NODEJS, DEFAULT_TENANT_ID } from '../../consts';
+import { TenantManager } from './tenant-manager';
+
+export interface SummaryGeneratorProps {
+  readonly environment: string;
+  readonly modelRegion: string;
+
+  // Tables
+  readonly chatHistoryTable: Table;
+  readonly userSummaryTable: Table;
+  readonly statsTable: Table;
+
+  // Tenant management
+  readonly tenantManager?: TenantManager;
+
+  // LiteLLM proxy endpoint (optional)
+  readonly litellmEndpoint?: string | null;
+
+  // Schedule configuration
+  readonly summaryJobConfig: {
+    dailySummarySchedule: {
+      minute: string;
+      hour: string;
+      month: string;
+      weekDay: string;
+    };
+    dailySummaryMaxChars: number;
+    userSummaryMaxChars: number;
+    userSummaryDefaultTermUnit: 'month' | 'year';
+    userSummaryDefaultTermValue: number;
+    summaryModelId: string;
+    maxConcurrentUsers: number;
+    enableExternalContext: boolean;
+  };
+}
+
+export class SummaryGenerator extends Construct {
+  public readonly dailySummaryFunction: NodejsFunction;
+  public readonly userSummaryFunction: NodejsFunction;
+  public readonly stateMachine: stepfunctions.StateMachine;
+
+  constructor(scope: Construct, id: string, props: SummaryGeneratorProps) {
+    super(scope, id);
+
+    const {
+      environment,
+      modelRegion,
+      chatHistoryTable,
+      userSummaryTable,
+      statsTable,
+      tenantManager,
+      litellmEndpoint,
+      summaryJobConfig,
+    } = props;
+
+    // Common environment variables for Lambda functions
+    const commonEnv = {
+      ENVIRONMENT: environment,
+      MODEL_REGION: modelRegion,
+      AWS_ACCOUNT_ID: cdk.Stack.of(this).account,
+      SUMMARY_MODEL_ID: summaryJobConfig.summaryModelId,
+      DAILY_SUMMARY_MAX_CHARS: summaryJobConfig.dailySummaryMaxChars.toString(),
+      USER_SUMMARY_MAX_CHARS: summaryJobConfig.userSummaryMaxChars.toString(),
+      DEFAULT_TERM_UNIT: summaryJobConfig.userSummaryDefaultTermUnit,
+      DEFAULT_TERM_VALUE: summaryJobConfig.userSummaryDefaultTermValue.toString(),
+      TABLE_NAME: 'ChatHistory',
+      DEFAULT_TABLE_NAME: chatHistoryTable.tableName,
+      STATS_TABLE_NAME: 'TokenUsageStats',
+      DEFAULT_STATS_TABLE_NAME: statsTable.tableName,
+      USER_SUMMARY_TABLE_NAME: 'UserSummary',
+      DEFAULT_USER_SUMMARY_TABLE_NAME: userSummaryTable.tableName,
+      DEFAULT_TENANT_ID: DEFAULT_TENANT_ID,
+      // LiteLLM endpoint for using proxy instead of direct Bedrock
+      ...(litellmEndpoint ? { LITELLM_ENDPOINT: litellmEndpoint } : {}),
+      ...(tenantManager
+        ? { TENANTS_TABLE_NAME: tenantManager.tenantsTable.tableName }
+        : {}),
+    };
+
+    // Daily Summary Lambda
+    this.dailySummaryFunction = new NodejsFunction(this, 'DailySummary', {
+      runtime: LAMBDA_RUNTIME_NODEJS,
+      entry: './lambda/summary/generateDailySummary.ts',
+      handler: 'handler',
+      timeout: Duration.minutes(15),
+      memorySize: 1024,
+      environment: commonEnv,
+    });
+
+    // User Summary Lambda
+    this.userSummaryFunction = new NodejsFunction(this, 'UserSummary', {
+      runtime: LAMBDA_RUNTIME_NODEJS,
+      entry: './lambda/summary/generateUserSummary.ts',
+      handler: 'handler',
+      timeout: Duration.minutes(15),
+      memorySize: 1024,
+      environment: commonEnv,
+    });
+
+    // Grant table permissions
+    chatHistoryTable.grantReadData(this.dailySummaryFunction);
+    userSummaryTable.grantReadWriteData(this.dailySummaryFunction);
+    userSummaryTable.grantReadWriteData(this.userSummaryFunction);
+    statsTable.grantReadData(this.dailySummaryFunction);
+
+    if (tenantManager) {
+      tenantManager.tenantsTable.grantReadData(this.dailySummaryFunction);
+      tenantManager.tenantsTable.grantReadData(this.userSummaryFunction);
+    }
+
+    // Grant Bedrock access
+    const bedrockPolicy = new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: ['bedrock:InvokeModel', 'bedrock:Converse'],
+      resources: ['*'],
+    });
+
+    this.dailySummaryFunction.addToRolePolicy(bedrockPolicy);
+    this.userSummaryFunction.addToRolePolicy(bedrockPolicy);
+
+    // Grant STS AssumeRole for tenant cross-account access (batch mode)
+    const stsAssumeRolePolicy = new iam.PolicyStatement({
+      effect: iam.Effect.ALLOW,
+      actions: ['sts:AssumeRole'],
+      resources: ['*'], // Tenant roles are dynamically created
+    });
+
+    this.dailySummaryFunction.addToRolePolicy(stsAssumeRolePolicy);
+    this.userSummaryFunction.addToRolePolicy(stsAssumeRolePolicy);
+
+    // Grant Lambda Function URL invocation for LiteLLM proxy (if configured)
+    if (litellmEndpoint) {
+      const lambdaInvokeUrlPolicy = new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: ['lambda:InvokeFunctionUrl'],
+        resources: ['*'], // LiteLLM Function URL ARN is derived from endpoint
+      });
+
+      this.dailySummaryFunction.addToRolePolicy(lambdaInvokeUrlPolicy);
+      this.userSummaryFunction.addToRolePolicy(lambdaInvokeUrlPolicy);
+    }
+
+    // Step Functions definition
+    // Task 1: Generate Daily Summaries
+    // Use resultPath to preserve original input (tenantId, date, users) for the next task
+    const dailySummaryTask = new stepfunctionsTasks.LambdaInvoke(
+      this,
+      'GenerateDailySummaries',
+      {
+        lambdaFunction: this.dailySummaryFunction,
+        resultPath: '$.dailySummaryResult',
+        payload: stepfunctions.TaskInput.fromObject({
+          'tenantId.$': '$.tenantId',
+          'date.$': '$.date',
+          'users.$': '$.users',
+        }),
+      }
+    );
+
+    // Task 2: Generate User Summaries (runs after daily summaries complete)
+    const userSummaryTask = new stepfunctionsTasks.LambdaInvoke(
+      this,
+      'GenerateUserSummaries',
+      {
+        lambdaFunction: this.userSummaryFunction,
+        resultPath: '$.userSummaryResult',
+        payload: stepfunctions.TaskInput.fromObject({
+          'tenantId.$': '$.tenantId',
+          'termEnd.$': '$.date',
+          'users.$': '$.users',
+        }),
+      }
+    );
+
+    // Chain the tasks
+    const definition = dailySummaryTask.next(userSummaryTask);
+
+    // Create State Machine
+    this.stateMachine = new stepfunctions.StateMachine(
+      this,
+      'SummaryStateMachine',
+      {
+        definitionBody: stepfunctions.DefinitionBody.fromChainable(definition),
+        timeout: Duration.hours(2),
+        stateMachineName: `SummaryGenerator-${environment}`,
+      }
+    );
+
+    // EventBridge Rule for scheduled execution
+    const { dailySummarySchedule } = summaryJobConfig;
+
+    new events.Rule(this, 'SummaryScheduleRule', {
+      schedule: events.Schedule.cron({
+        minute: dailySummarySchedule.minute,
+        hour: dailySummarySchedule.hour,
+        month: dailySummarySchedule.month,
+        weekDay: dailySummarySchedule.weekDay,
+      }),
+      targets: [
+        new targets.SfnStateMachine(this.stateMachine, {
+          input: events.RuleTargetInput.fromObject({
+            tenantId: 'default', // Will be overridden per tenant
+            date: events.EventField.time, // Current time for date calculation
+            users: [], // Will be populated by the Lambda
+          }),
+        }),
+      ],
+    });
+
+    // Outputs
+    new cdk.CfnOutput(this, 'SummaryStateMachineArn', {
+      value: this.stateMachine.stateMachineArn,
+      description: 'ARN of the summary generation state machine',
+    });
+
+    new cdk.CfnOutput(this, 'DailySummaryFunctionArn', {
+      value: this.dailySummaryFunction.functionArn,
+      description: 'ARN of the daily summary Lambda function',
+    });
+
+    new cdk.CfnOutput(this, 'UserSummaryFunctionArn', {
+      value: this.userSummaryFunction.functionArn,
+      description: 'ARN of the user summary Lambda function',
+    });
+
+    // Export Lambda role ARN for cross-account tenant trust
+    new cdk.CfnOutput(this, 'DailySummaryLambdaRoleArn', {
+      value: this.dailySummaryFunction.role!.roleArn,
+      description:
+        'ARN of the daily summary Lambda role - add to tenant role trust policy for cross-account access',
+      exportName: `${cdk.Stack.of(this).stackName}-DailySummaryLambdaRoleArn`,
+    });
+  }
+}

--- a/packages/cdk/lib/construct/summary-generator.ts
+++ b/packages/cdk/lib/construct/summary-generator.ts
@@ -48,6 +48,7 @@ export interface SummaryGeneratorProps {
 export class SummaryGenerator extends Construct {
   public readonly dailySummaryFunction: NodejsFunction;
   public readonly userSummaryFunction: NodejsFunction;
+  public readonly tenantDiscoveryFunction: NodejsFunction;
   public readonly stateMachine: stepfunctions.StateMachine;
 
   constructor(scope: Construct, id: string, props: SummaryGeneratorProps) {
@@ -119,6 +120,27 @@ export class SummaryGenerator extends Construct {
       tenantManager.tenantsTable.grantReadData(this.userSummaryFunction);
     }
 
+    // Tenant Discovery Lambda (for multi-tenant fan-out)
+    this.tenantDiscoveryFunction = new NodejsFunction(
+      this,
+      'TenantDiscovery',
+      {
+        runtime: LAMBDA_RUNTIME_NODEJS,
+        entry: './lambda/summary/summaryTenantDiscovery.ts',
+        handler: 'handler',
+        timeout: Duration.minutes(5),
+        memorySize: 256,
+        environment: {
+          ENVIRONMENT: environment,
+          DEFAULT_TENANT_ID: DEFAULT_TENANT_ID,
+          ...(tenantManager
+            ? { TENANTS_TABLE_NAME: tenantManager.tenantsTable.tableName }
+            : {}),
+          // STATE_MACHINE_ARN will be set after state machine is created
+        },
+      }
+    );
+
     // Grant Bedrock access
     const bedrockPolicy = new iam.PolicyStatement({
       effect: iam.Effect.ALLOW,
@@ -128,6 +150,11 @@ export class SummaryGenerator extends Construct {
 
     this.dailySummaryFunction.addToRolePolicy(bedrockPolicy);
     this.userSummaryFunction.addToRolePolicy(bedrockPolicy);
+
+    // Grant tenant discovery Lambda access to tenants table
+    if (tenantManager) {
+      tenantManager.tenantsTable.grantReadData(this.tenantDiscoveryFunction);
+    }
 
     // Grant STS AssumeRole for tenant cross-account access (batch mode)
     const stsAssumeRolePolicy = new iam.PolicyStatement({
@@ -197,7 +224,17 @@ export class SummaryGenerator extends Construct {
       }
     );
 
+    // Add state machine ARN to tenant discovery Lambda environment
+    this.tenantDiscoveryFunction.addEnvironment(
+      'STATE_MACHINE_ARN',
+      this.stateMachine.stateMachineArn
+    );
+
+    // Grant tenant discovery Lambda permission to start Step Functions executions
+    this.stateMachine.grantStartExecution(this.tenantDiscoveryFunction);
+
     // EventBridge Rule for scheduled execution
+    // Triggers tenant discovery Lambda which fans out to all tenants
     const { dailySummarySchedule } = summaryJobConfig;
 
     new events.Rule(this, 'SummaryScheduleRule', {
@@ -207,15 +244,7 @@ export class SummaryGenerator extends Construct {
         month: dailySummarySchedule.month,
         weekDay: dailySummarySchedule.weekDay,
       }),
-      targets: [
-        new targets.SfnStateMachine(this.stateMachine, {
-          input: events.RuleTargetInput.fromObject({
-            tenantId: 'default', // Will be overridden per tenant
-            date: events.EventField.time, // Current time for date calculation
-            users: [], // Will be populated by the Lambda
-          }),
-        }),
-      ],
+      targets: [new targets.LambdaFunction(this.tenantDiscoveryFunction)],
     });
 
     // Outputs
@@ -232,6 +261,11 @@ export class SummaryGenerator extends Construct {
     new cdk.CfnOutput(this, 'UserSummaryFunctionArn', {
       value: this.userSummaryFunction.functionArn,
       description: 'ARN of the user summary Lambda function',
+    });
+
+    new cdk.CfnOutput(this, 'TenantDiscoveryFunctionArn', {
+      value: this.tenantDiscoveryFunction.functionArn,
+      description: 'ARN of the tenant discovery Lambda function',
     });
 
     // Export Lambda role ARN for cross-account tenant trust

--- a/packages/cdk/lib/construct/tenant-dynamodb.ts
+++ b/packages/cdk/lib/construct/tenant-dynamodb.ts
@@ -48,6 +48,13 @@ export interface TenantDynamoDBProps {
    * @default RemovalPolicy.RETAIN
    */
   readonly removalPolicy?: cdk.RemovalPolicy;
+
+  /**
+   * Whether summary job feature is enabled
+   * When false, UserSummary table is not created
+   * @default false
+   */
+  readonly summaryJobEnabled?: boolean;
 }
 
 export class TenantDynamoDB extends Construct {
@@ -75,6 +82,12 @@ export class TenantDynamoDB extends Construct {
    * The user-stripe mapping table for the tenant
    */
   public readonly userStripeMappingTable: dynamodb.Table;
+
+  /**
+   * The user summary table for the tenant
+   * Only created when summaryJobEnabled is true
+   */
+  public readonly userSummaryTable?: dynamodb.Table;
 
   /**
    * The tenant ID
@@ -106,6 +119,12 @@ export class TenantDynamoDB extends Construct {
    */
   public readonly userStripeMappingTableName: string;
 
+  /**
+   * User summary table name
+   * Only set when summaryJobEnabled is true
+   */
+  public readonly userSummaryTableName?: string;
+
   constructor(scope: Construct, id: string, props: TenantDynamoDBProps) {
     super(scope, id);
 
@@ -136,6 +155,9 @@ export class TenantDynamoDB extends Construct {
     this.useCaseBuilderTableName = `${useCaseBuilderBaseName}-${environment}-tenant-${sanitizedTenantId}`;
     this.assistantTableName = `Assistant-${environment}-tenant-${sanitizedTenantId}`;
     this.userStripeMappingTableName = `${userStripeMappingBaseName}-${environment}-tenant-${sanitizedTenantId}`;
+    if (props.summaryJobEnabled) {
+      this.userSummaryTableName = `UserSummary-${environment}-tenant-${sanitizedTenantId}`;
+    }
 
     // Determine removal policy based on environment
     const removalPolicy =
@@ -308,6 +330,44 @@ export class TenantDynamoDB extends Construct {
     cdk.Tags.of(this.userStripeMappingTable).add('TenantId', this.tenantId);
     cdk.Tags.of(this.userStripeMappingTable).add('Environment', environment);
 
+    // User Summary Table (only when summary feature is enabled)
+    // PK: user#{userId}, SK: DAILY#{YYYY-MM-DD} or USER_SUMMARY or CONFIG
+    if (props.summaryJobEnabled && this.userSummaryTableName) {
+      this.userSummaryTable = new dynamodb.Table(this, 'UserSummaryTable', {
+        tableName: this.userSummaryTableName,
+        partitionKey: {
+          name: 'id',
+          type: dynamodb.AttributeType.STRING,
+        },
+        sortKey: {
+          name: 'createdDate',
+          type: dynamodb.AttributeType.STRING,
+        },
+        billingMode: props.billingMode || dynamodb.BillingMode.PAY_PER_REQUEST,
+        encryption: dynamodb.TableEncryption.AWS_MANAGED,
+        removalPolicy: removalPolicy,
+      });
+
+      // Add tags to User Summary table
+      cdk.Tags.of(this.userSummaryTable).add('TenantId', this.tenantId);
+      cdk.Tags.of(this.userSummaryTable).add('Environment', environment);
+
+      // Add DateIndex for querying all users who have summaries for a specific date
+      // Used by batch job to find users with activity on a date
+      this.userSummaryTable.addGlobalSecondaryIndex({
+        indexName: 'DateIndex',
+        partitionKey: {
+          name: 'date',
+          type: dynamodb.AttributeType.STRING,
+        },
+        sortKey: {
+          name: 'userId',
+          type: dynamodb.AttributeType.STRING,
+        },
+        projectionType: dynamodb.ProjectionType.ALL,
+      });
+    }
+
     // Output table ARNs
     new cdk.CfnOutput(this, 'ChatHistoryTableArn', {
       value: this.chatHistoryTable.tableArn,
@@ -362,6 +422,19 @@ export class TenantDynamoDB extends Construct {
       value: this.userStripeMappingTable.tableName,
       description: `Name of the user-stripe mapping table for tenant ${this.tenantId}`,
     });
+
+    // Output user summary table ARNs and names (only when feature enabled)
+    if (this.userSummaryTable) {
+      new cdk.CfnOutput(this, 'UserSummaryTableArn', {
+        value: this.userSummaryTable.tableArn,
+        description: `ARN of the user summary table for tenant ${this.tenantId}`,
+      });
+
+      new cdk.CfnOutput(this, 'UserSummaryTableName', {
+        value: this.userSummaryTable.tableName,
+        description: `Name of the user summary table for tenant ${this.tenantId}`,
+      });
+    }
   }
 
   /**

--- a/packages/cdk/lib/construct/tenant-role.ts
+++ b/packages/cdk/lib/construct/tenant-role.ts
@@ -22,8 +22,9 @@ export interface TenantRoleProps {
   readonly account: string;
   readonly env: string;
   /**
-   * Optional: ARN of the control plane Lambda execution role
+   * Optional: ARN of the control plane Lambda execution role (single)
    * Required for cross-account background job access
+   * @deprecated Use controlPlaneLambdaRoleArns instead for multiple roles
    */
   readonly controlPlaneLambdaRoleArn?: string;
   /**
@@ -34,6 +35,11 @@ export interface TenantRoleProps {
    * functions (billing, orchestration, etc.) need to access tenant resources.
    */
   readonly controlPlaneAccountId?: string;
+  /**
+   * Optional: ARNs of control plane Lambda execution roles (array)
+   * Required for cross-account background job access (e.g., PPTX, Summary generation)
+   */
+  readonly controlPlaneLambdaRoleArns?: string[];
 }
 
 /**
@@ -68,11 +74,18 @@ export class TenantRole extends Construct {
     // Build cross-account trust principals
     const crossAccountPrincipals: (ArnPrincipal | AccountPrincipal)[] = [];
 
-    // Add specific Lambda role ARN if provided
+    // Add specific Lambda role ARN if provided (single, deprecated)
     if (props.controlPlaneLambdaRoleArn) {
       crossAccountPrincipals.push(
         new ArnPrincipal(props.controlPlaneLambdaRoleArn)
       );
+    }
+
+    // Add all Lambda role ARNs from the array if provided
+    if (props.controlPlaneLambdaRoleArns) {
+      for (const arn of props.controlPlaneLambdaRoleArns) {
+        crossAccountPrincipals.push(new ArnPrincipal(arn));
+      }
     }
 
     // Add control plane account trust if provided

--- a/packages/cdk/lib/create-tenant-stacks.ts
+++ b/packages/cdk/lib/create-tenant-stacks.ts
@@ -102,6 +102,13 @@ export interface TenantStackInput {
   openSearchIndexName?: string;
   openFgaConfig: OpenFgaConfig;
   controlPlaneLambdaRoleArn?: string;
+  controlPlaneLambdaRoleArns?: string[];
+  /**
+   * Whether summary job feature is enabled for this tenant
+   * When false, UserSummary table is not created
+   * @default false
+   */
+  summaryJobEnabled?: boolean;
 }
 
 export const createTenantStacks = (app: cdk.App, params: TenantStackInput) => {
@@ -132,6 +139,7 @@ export const createTenantStacks = (app: cdk.App, params: TenantStackInput) => {
       },
       tenantId: params.tenantId,
       environment: params.environment,
+      summaryJobEnabled: params.summaryJobEnabled,
     }
   );
 

--- a/packages/cdk/lib/stack-input.ts
+++ b/packages/cdk/lib/stack-input.ts
@@ -178,6 +178,30 @@ const baseStackInputSchema = z.object({
   // Dashboard
   dashboard: z.boolean().default(false),
 
+  // Summary Job
+  summaryJobEnabled: z.boolean().default(false),
+  summaryJobConfig: z
+    .object({
+      dailySummarySchedule: z
+        .object({
+          minute: z.string().default('0'),
+          hour: z.string().default('19'), // 19:00 UTC = 4:00 AM JST
+          month: z.string().default('*'),
+          weekDay: z.string().default('*'),
+        })
+        .default({}),
+      dailySummaryMaxChars: z.number().default(200),
+      userSummaryMaxChars: z.number().default(500),
+      userSummaryDefaultTermUnit: z.enum(['month', 'year']).default('month'),
+      userSummaryDefaultTermValue: z.number().default(1),
+      summaryModelId: z
+        .string()
+        .default('us.anthropic.claude-3-5-haiku-20241022-v1:0'),
+      maxConcurrentUsers: z.number().default(10),
+      enableExternalContext: z.boolean().default(false),
+    })
+    .default({}),
+
   // Email Service (SendGrid)
   emailServiceName: z.string().default('GenU'),
   sendgridApiKey: z.string(),

--- a/packages/cdk/lib/stacks/common/assistant-api-stack.ts
+++ b/packages/cdk/lib/stacks/common/assistant-api-stack.ts
@@ -19,6 +19,7 @@ interface AssistantApiStackProps extends StackProps {
   auth: Auth;
   assistantTable: Table;
   chatHistoryTable: Table;
+  userSummaryTable?: Table;
   fileBucket: Bucket;
   tenantManager?: TenantManager;
   videoBucketRegionMap?: Record<string, string>;
@@ -40,6 +41,7 @@ class AssistantApiStack extends NestedStack {
       auth,
       assistantTable,
       chatHistoryTable,
+      userSummaryTable,
       fileBucket,
       tenantManager,
       videoBucketRegionMap,
@@ -92,6 +94,7 @@ class AssistantApiStack extends NestedStack {
       userPoolClient: auth.client,
       table: chatHistoryTable,
       statsTable: assistantTable, // Reuse for stats
+      userSummaryTable,
       assistantTable,
       knowledgeBaseId: params.ragKnowledgeBaseId || undefined,
       agents: params.agents,
@@ -113,6 +116,9 @@ class AssistantApiStack extends NestedStack {
 
       // OpenAI
       openai: params.openai,
+
+      // Summary feature (environment-specific)
+      summaryJobEnabled: params.summaryJobEnabled,
     });
 
     this.assistantApi = assistantApi;

--- a/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
@@ -11,6 +11,7 @@ import {
   CommonWebAcl,
   LitellmProxyServer,
   TenantManager,
+  SummaryGenerator,
 } from '../../construct';
 import { PptxDb } from '../../construct/pptx-db';
 import * as s3 from 'aws-cdk-lib/aws-s3';
@@ -71,7 +72,9 @@ export class GenerativeAiUseCasesStack extends Stack {
     const params = props.params;
 
     // Database
-    const database = new Database(this, 'Database');
+    const database = new Database(this, 'Database', {
+      summaryJobEnabled: params.summaryJobEnabled,
+    });
 
     // Tenant Management（Auth より先に作成：postConfirmHandler がテナント情報を参照するため）
     const tenantManager = new TenantManager(this, 'TenantManager', {
@@ -202,6 +205,7 @@ export class GenerativeAiUseCasesStack extends Stack {
       userPoolClient: auth.client,
       table: database.table,
       statsTable: database.statsTable,
+      userSummaryTable: database.userSummaryTable,
       assistantTable: database.assistantTable,
       knowledgeBaseId: params.ragKnowledgeBaseId || props.knowledgeBaseId,
       agents: props.agents,
@@ -213,6 +217,9 @@ export class GenerativeAiUseCasesStack extends Stack {
 
       // LangChain Credentials
       openai: params.openai,
+
+      // Summary feature (environment-specific)
+      summaryJobEnabled: params.summaryJobEnabled,
     });
 
     // WAF
@@ -385,6 +392,20 @@ export class GenerativeAiUseCasesStack extends Stack {
       description: 'ARN of the shared background job IAM role. Set this as controlPlaneLambdaRoleArn in cdk.tenant.json for cross-tenant access.',
       exportName: `${this.stackName}-BackgroundJobRoleArn`,
     });
+
+    // Summary Generator (Step Functions for batch summary generation)
+    if (params.summaryJobEnabled && database.userSummaryTable) {
+      new SummaryGenerator(this, 'SummaryGenerator', {
+        environment: params.env,
+        modelRegion: params.modelRegion,
+        chatHistoryTable: database.table,
+        userSummaryTable: database.userSummaryTable,
+        statsTable: database.statsTable,
+        tenantManager: tenantManager,
+        litellmEndpoint: litellmEndpoint,
+        summaryJobConfig: params.summaryJobConfig,
+      });
+    }
 
     // Web Frontend (must be after BillingManagementStack to use billingApi.url)
     // Only deploy if useWebUi is true

--- a/packages/cdk/lib/stacks/tenant/tenant-dynamodb-stack.ts
+++ b/packages/cdk/lib/stacks/tenant/tenant-dynamodb-stack.ts
@@ -49,6 +49,13 @@ export interface TenantDynamoDBStackProps extends cdk.StackProps {
    * @default RemovalPolicy.RETAIN
    */
   readonly removalPolicy?: cdk.RemovalPolicy;
+
+  /**
+   * Whether summary job feature is enabled
+   * When false, UserSummary table is not created
+   * @default false
+   */
+  readonly summaryJobEnabled?: boolean;
 }
 
 /**
@@ -86,6 +93,7 @@ export class TenantDynamoDBStack extends cdk.Stack {
       useCaseBuilderTableBaseName: props?.useCaseBuilderTableBaseName,
       billingMode: props?.billingMode,
       removalPolicy: props?.removalPolicy,
+      summaryJobEnabled: props?.summaryJobEnabled,
     });
 
     // Add stack-level outputs with export names

--- a/packages/cdk/lib/stacks/tenant/tenant-iam-stack.ts
+++ b/packages/cdk/lib/stacks/tenant/tenant-iam-stack.ts
@@ -77,6 +77,9 @@ export class TenantIAMStack extends cdk.Stack {
     const controlPlaneAccountId = this.node.tryGetContext(
       'controlPlaneAccount'
     );
+    const controlPlaneLambdaRoleArns = this.node.tryGetContext(
+      'controlPlaneLambdaRoleArns'
+    ) as string[] | undefined;
 
     if (!userPoolId) {
       throw new Error(
@@ -135,6 +138,7 @@ export class TenantIAMStack extends cdk.Stack {
       env: environment,
       controlPlaneLambdaRoleArn: controlPlaneLambdaRoleArn,
       controlPlaneAccountId: controlPlaneAccountId,
+      controlPlaneLambdaRoleArns: controlPlaneLambdaRoleArns,
     });
 
     // Create a Lambda to call the registration API

--- a/packages/cdk/lib/stacks/tenant/tenant-openfga-stack.ts
+++ b/packages/cdk/lib/stacks/tenant/tenant-openfga-stack.ts
@@ -46,8 +46,15 @@ export interface TenantOpenFgaStackProps extends cdk.StackProps {
 
   /**
    * Control plane Lambda role ARN for cross-account access
+   * @deprecated Use controlPlaneLambdaRoleArns instead for multiple roles
    */
   readonly controlPlaneLambdaRoleArn?: string;
+
+  /**
+   * Control plane Lambda role ARNs for cross-account access (array)
+   * Required for cross-account background job access (e.g., PPTX, Summary generation)
+   */
+  readonly controlPlaneLambdaRoleArns?: string[];
 
   /**
    * Tenant role ARN for authorization checks
@@ -681,11 +688,17 @@ export class TenantOpenFgaStack extends cdk.Stack {
       new iam.ArnPrincipal(props.tenantRoleArn),
     ];
 
-    // Add control plane Lambda role if provided (for cross-account scenarios)
+    // Add control plane Lambda roles for cross-account scenarios
+    // Support both deprecated single ARN and new array pattern
     if (props.controlPlaneLambdaRoleArn) {
       allowedPrincipals.push(
         new iam.ArnPrincipal(props.controlPlaneLambdaRoleArn)
       );
+    }
+    if (props.controlPlaneLambdaRoleArns) {
+      for (const arn of props.controlPlaneLambdaRoleArns) {
+        allowedPrincipals.push(new iam.ArnPrincipal(arn));
+      }
     }
 
     api.addToResourcePolicy(

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -48,6 +48,7 @@
     "@aws-sdk/client-s3": "^3.755.0",
     "@aws-sdk/client-sagemaker-runtime": "^3.755.0",
     "@aws-sdk/client-secrets-manager": "^3.755.0",
+    "@aws-sdk/client-sfn": "^3.755.0",
     "@aws-sdk/client-sqs": "^3.927.0",
     "@aws-sdk/client-ssm": "^3.755.0",
     "@aws-sdk/client-sts": "^3.755.0",

--- a/packages/cdk/prompts/daily-summary-context.example.md
+++ b/packages/cdk/prompts/daily-summary-context.example.md
@@ -1,0 +1,37 @@
+# Daily Summary External Context
+
+This file provides the complete system prompt for generating daily summaries.
+Copy this file to `daily-summary-context.md` and customize it for your needs.
+
+When this file exists, its content replaces the default system prompt entirely.
+
+## Default Behavior (without this file)
+
+The default prompt instructs the AI to:
+- Summarize conversations under 200 characters
+- Focus on key topics, decisions, and insights
+- Use clear, direct language
+- Output in the same language as conversations
+
+## Customization
+
+Replace this content with your complete system prompt. Example structure:
+
+```
+# Role
+You are a summarizer...
+
+# Requirements
+- Output length constraints
+- Formatting rules
+- Content focus areas
+
+# Summary Perspectives
+- Topics discussed
+- User concerns
+- Actions taken
+- Outcomes achieved
+- Next steps identified
+```
+
+The conversation log will be provided separately in the user prompt.

--- a/packages/cdk/prompts/user-summary-context.example.md
+++ b/packages/cdk/prompts/user-summary-context.example.md
@@ -1,0 +1,38 @@
+# User Summary External Context
+
+This file provides the complete system prompt for generating user profile summaries.
+Copy this file to `user-summary-context.md` and customize it for your needs.
+
+When this file exists, its content replaces the default system prompt entirely.
+
+## Default Behavior (without this file)
+
+The default prompt instructs the AI to:
+- Aggregate daily summaries under 500 characters
+- Identify patterns and recurring themes
+- Highlight decisions and accomplishments
+- Provide a holistic view of user activities
+- Output in the same language as daily summaries
+
+## Customization
+
+Replace this content with your complete system prompt. Example structure:
+
+```
+# Role
+You are a profile creator...
+
+# Requirements
+- Output length constraints
+- Formatting rules
+- Content focus areas
+
+# Profile Perspectives
+- Primary interest areas
+- Recurring themes
+- Progress and achievements
+- Behavior patterns
+- Ongoing tasks
+```
+
+The daily summaries will be provided separately in the user prompt.

--- a/packages/cdk/test/tenant-dynamodb.test.ts
+++ b/packages/cdk/test/tenant-dynamodb.test.ts
@@ -44,12 +44,71 @@ describe('TenantDynamoDB Tests', () => {
         BillingMode: 'PAY_PER_REQUEST',
       });
 
-      // Check that all three tables are created
+      // Check that all four tables are created (ChatHistory, TokenUsageStats, UseCaseBuilder, Assistant)
+      // UserSummary table is not created when summaryJobEnabled is false (default)
       const resources = template.toJSON().Resources;
       const tables = Object.values(resources).filter(
         (r: any) => r.Type === 'AWS::DynamoDB::Table'
       );
-      expect(tables.length).toBe(3);
+      expect(tables.length).toBe(4);
+    });
+
+    test('Should create UserSummary table when summaryJobEnabled is true', () => {
+      // Arrange
+      const tenantId = 'test-tenant-summary';
+
+      // Act
+      new TenantDynamoDB(stack, 'TestTenantDynamoDB', {
+        tenantId,
+        environment: 'dev',
+        summaryJobEnabled: true,
+      });
+
+      // Assert
+      const template = Template.fromStack(stack);
+
+      // Check UserSummary table is created
+      template.hasResourceProperties('AWS::DynamoDB::Table', {
+        TableName: 'UserSummary-dev-tenant-test-tenant-summary',
+        BillingMode: 'PAY_PER_REQUEST',
+      });
+
+      // Check that all five tables are created
+      const resources = template.toJSON().Resources;
+      const tables = Object.values(resources).filter(
+        (r: any) => r.Type === 'AWS::DynamoDB::Table'
+      );
+      expect(tables.length).toBe(5);
+    });
+
+    test('Should NOT create UserSummary table when summaryJobEnabled is false', () => {
+      // Arrange
+      const tenantId = 'test-tenant-no-summary';
+
+      // Act
+      new TenantDynamoDB(stack, 'TestTenantDynamoDB', {
+        tenantId,
+        environment: 'dev',
+        summaryJobEnabled: false,
+      });
+
+      // Assert
+      const template = Template.fromStack(stack);
+      const resources = template.toJSON().Resources;
+
+      // Check UserSummary table is NOT created
+      const userSummaryTable = Object.values(resources).find(
+        (r: any) =>
+          r.Type === 'AWS::DynamoDB::Table' &&
+          r.Properties.TableName?.includes('UserSummary')
+      );
+      expect(userSummaryTable).toBeUndefined();
+
+      // Check that only four tables are created
+      const tables = Object.values(resources).filter(
+        (r: any) => r.Type === 'AWS::DynamoDB::Table'
+      );
+      expect(tables.length).toBe(4);
     });
 
     test('Should sanitize tenant ID for resource names', () => {

--- a/packages/types/src/assistant.d.ts
+++ b/packages/types/src/assistant.d.ts
@@ -102,6 +102,7 @@ export type UpdateAssistantRequest = {
 
 export type CreateAssistantMessageRequest = {
   content: string;
+  customInstructions?: string;
 };
 
 export type ListAssistantsQueryParams = {

--- a/packages/types/src/index.d.ts
+++ b/packages/types/src/index.d.ts
@@ -19,3 +19,4 @@ export * from './speech-to-speech';
 export * from './stat';
 export * from './mcp';
 export * from './tenant';
+export * from './summary';

--- a/packages/types/src/summary.d.ts
+++ b/packages/types/src/summary.d.ts
@@ -1,0 +1,74 @@
+/**
+ * Daily summary for a user's conversations on a specific date
+ */
+export interface DailySummary {
+  id?: string; // DynamoDB partition key (user#userId)
+  createdDate?: string; // DynamoDB sort key (DAILY#date)
+  userId: string;
+  tenantId: string;
+  date: string; // YYYY-MM-DD
+  summary: string;
+  chatIds: string[];
+  messageCount: number;
+  externalContext?: string; // External context used for summary generation
+  generatedAt: string; // ISO timestamp
+  tokenUsage?: {
+    inputTokens: number;
+    outputTokens: number;
+  };
+}
+
+/**
+ * Aggregated user summary over a term period
+ */
+export interface UserSummary {
+  id?: string; // DynamoDB partition key (user#userId)
+  createdDate?: string; // DynamoDB sort key (USER_SUMMARY)
+  userId: string;
+  tenantId: string;
+  summary: string;
+  termUnit: 'month' | 'year';
+  termValue: number;
+  termStart: string; // YYYY-MM-DD
+  termEnd: string; // YYYY-MM-DD
+  dailySummaryDates: string[];
+  generatedAt: string; // ISO timestamp
+  tokenUsage?: {
+    inputTokens: number;
+    outputTokens: number;
+  };
+}
+
+/**
+ * User-specific summary configuration
+ */
+export interface UserSummaryConfig {
+  id?: string; // DynamoDB partition key (user#userId)
+  createdDate?: string; // DynamoDB sort key (CONFIG)
+  userId: string;
+  tenantId: string;
+  termUnit?: 'month' | 'year';
+  termValue?: number;
+  externalContextPrompt?: string; // Custom prompt for external context
+  enabled?: boolean; // Whether summary generation is enabled
+  updatedAt?: string;
+}
+
+/**
+ * Request to update summary configuration
+ */
+export interface UpdateSummaryConfigRequest {
+  termUnit?: 'month' | 'year';
+  termValue?: number;
+  externalContextPrompt?: string;
+  enabled?: boolean;
+}
+
+/**
+ * Response from GET /summaries endpoint
+ */
+export interface GetSummariesResponse {
+  dailySummary?: DailySummary;
+  userSummary?: UserSummary;
+  config?: UserSummaryConfig;
+}


### PR DESCRIPTION
## 概要

毎日4:00 JST (19:00 UTC) に自動実行されるバッチジョブで、ユーザーの会話履歴からサマリーを生成する機能を追加しました。

### 主な機能

- **デイリーサマリー**: 前日の会話から200文字以内のサマリーを生成
- **ユーザーサマリー**: デイリーサマリーを集約して500文字以内のプロファイルを生成
- **システムプロンプト注入**: 全チャット（通常チャット・アシスタント）にサマリーをコンテキストとして注入

### 技術的変更

- `packages/types/src/summary.d.ts`: サマリー型定義
- `packages/cdk/lib/construct/database.ts`: UserSummaryテーブル追加
- `packages/cdk/lambda/repository/userSummary.ts`: サマリーリポジトリ
- `packages/cdk/lambda/utils/summaryContext.ts`: コンテキスト構築ユーティリティ
- `packages/cdk/lambda/predict.ts`, `predictStream.ts`: サマリー注入
- `packages/cdk/lib/construct/api/summary.ts`: サマリーAPI

### 設定例

```json
{
  "summaryJobEnabled": true,
  "summaryJobConfig": {
    "dailySummaryMaxChars": 200,
    "userSummaryMaxChars": 500,
    "userSummaryDefaultTermUnit": "month",
    "userSummaryDefaultTermValue": 1
  }
}
```

## テスト計画

- [ ] UserSummaryテーブルが正しく作成されること
- [ ] GET /summaries エンドポイントが動作すること  
- [ ] サマリーコンテキストがシステムプロンプトに注入されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)