### PR TITLE
✨ feat(chat): チャット機能にAgentic Web検索を統合

### DIFF
--- a/packages/cdk/cdk.example.json
+++ b/packages/cdk/cdk.example.json
@@ -63,6 +63,7 @@
     "endpointNames": [],
     "agentEnabled": false,
     "searchAgentEnabled": false,
+    "webSearchInChatEnabled": false,
     "searchEngine": "Brave",
     "searchApiKey": "",
     "agents": [],

--- a/packages/cdk/jest.config.js
+++ b/packages/cdk/jest.config.js
@@ -1,0 +1,12 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.default = {
+    testEnvironment: 'node',
+    roots: ['<rootDir>/test'],
+    testMatch: ['**/*.test.ts'],
+    transform: {
+        '^.+\\.tsx?$': 'ts-jest',
+    },
+    snapshotSerializers: ['<rootDir>/test/snapshot-plugin.ts'],
+};
+//# sourceMappingURL=data:application/json;base64,eyJ2ZXJzaW9uIjozLCJmaWxlIjoiamVzdC5jb25maWcuanMiLCJzb3VyY2VSb290IjoiIiwic291cmNlcyI6WyJqZXN0LmNvbmZpZy50cyJdLCJuYW1lcyI6W10sIm1hcHBpbmdzIjoiOztBQUFBLGtCQUFlO0lBQ2IsZUFBZSxFQUFFLE1BQU07SUFDdkIsS0FBSyxFQUFFLENBQUMsZ0JBQWdCLENBQUM7SUFDekIsU0FBUyxFQUFFLENBQUMsY0FBYyxDQUFDO0lBQzNCLFNBQVMsRUFBRTtRQUNULGFBQWEsRUFBRSxTQUFTO0tBQ3pCO0lBQ0QsbUJBQW1CLEVBQUUsQ0FBQyxtQ0FBbUMsQ0FBQztDQUMzRCxDQUFDIiwic291cmNlc0NvbnRlbnQiOlsiZXhwb3J0IGRlZmF1bHQge1xuICB0ZXN0RW52aXJvbm1lbnQ6ICdub2RlJyxcbiAgcm9vdHM6IFsnPHJvb3REaXI+L3Rlc3QnXSxcbiAgdGVzdE1hdGNoOiBbJyoqLyoudGVzdC50cyddLFxuICB0cmFuc2Zvcm06IHtcbiAgICAnXi4rXFxcXC50c3g/JCc6ICd0cy1qZXN0JyxcbiAgfSxcbiAgc25hcHNob3RTZXJpYWxpemVyczogWyc8cm9vdERpcj4vdGVzdC9zbmFwc2hvdC1wbHVnaW4udHMnXSxcbn07XG4iXX0=

--- a/packages/cdk/lambda/predictStream.ts
+++ b/packages/cdk/lambda/predictStream.ts
@@ -2,6 +2,7 @@ import { Handler, Context } from 'aws-lambda';
 import { PredictRequest } from 'generative-ai-use-cases';
 import api from './utils/api';
 import { defaultModel } from './utils/models';
+import { invokeStreamWithTools } from './utils/bedrockApiWithTools';
 
 declare global {
   namespace awslambda {
@@ -19,13 +20,26 @@ export const handler = awslambda.streamifyResponse(
   async (event, responseStream, context) => {
     context.callbackWaitsForEmptyEventLoop = false;
     const model = event.model || defaultModel;
-    for await (const token of api[model.type].invokeStream?.(
-      model,
-      event.messages,
-      event.id,
-      event.idToken
-    ) ?? []) {
-      responseStream.write(token);
+
+    // Web検索が有効な場合はTool Use対応のストリームを使用
+    if (event.webSearchEnabled && model.type === 'bedrock') {
+      for await (const token of invokeStreamWithTools(
+        model,
+        event.messages,
+        event.id
+      )) {
+        responseStream.write(token);
+      }
+    } else {
+      // 通常のストリーム処理
+      for await (const token of api[model.type].invokeStream?.(
+        model,
+        event.messages,
+        event.id,
+        event.idToken
+      ) ?? []) {
+        responseStream.write(token);
+      }
     }
     responseStream.end();
   }

--- a/packages/cdk/lambda/utils/bedrockApiWithTools.ts
+++ b/packages/cdk/lambda/utils/bedrockApiWithTools.ts
@@ -232,7 +232,7 @@ export async function* invokeStreamWithTools(
           currentToolUse = {
             toolUseId: event.contentBlockStart.start.toolUse.toolUseId,
             name: event.contentBlockStart.start.toolUse.name,
-            input: {},
+            input: '', // JSON文字列として累積するため空文字列で初期化
           };
 
           // ツール使用開始を通知

--- a/packages/cdk/lambda/utils/bedrockApiWithTools.ts
+++ b/packages/cdk/lambda/utils/bedrockApiWithTools.ts
@@ -205,10 +205,19 @@ export async function* invokeStreamWithTools(
         inferenceConfig: modelConfig.defaultParams.inferenceConfig,
       };
 
+      console.log(
+        `Iteration ${iteration}: Calling Converse API with ${conversationMessages.length} messages`
+      );
+
       const command = new ConverseStreamCommand(input);
       const response = await client.send(command);
 
       if (!response.stream) {
+        console.error('No stream in response');
+        yield streamingChunk({
+          text: 'Error: No response stream received from the model.',
+          stopReason: 'error',
+        });
         return;
       }
 
@@ -253,13 +262,28 @@ export async function* invokeStreamWithTools(
               typeof currentToolUse.input === 'string'
                 ? JSON.parse(currentToolUse.input)
                 : currentToolUse.input;
+            console.log(
+              `Tool use block completed: ${currentToolUse.name}`,
+              JSON.stringify(parsedInput)
+            );
             toolUseBlocks.push({
               toolUseId: currentToolUse.toolUseId!,
               name: currentToolUse.name!,
               input: parsedInput,
             });
           } catch (e) {
-            console.error('Failed to parse tool input:', e);
+            console.error(
+              'Failed to parse tool input:',
+              e,
+              'Raw input:',
+              currentToolUse.input
+            );
+            // パース失敗時もツールブロックを追加（空の入力で）
+            toolUseBlocks.push({
+              toolUseId: currentToolUse.toolUseId!,
+              name: currentToolUse.name!,
+              input: {},
+            });
           }
           currentToolUse = null;
         } else if (event.contentBlockDelta?.delta?.text) {
@@ -286,6 +310,10 @@ export async function* invokeStreamWithTools(
         }
       }
 
+      console.log(
+        `Stream completed. stopReason: ${stopReason}, toolUseBlocks: ${toolUseBlocks.length}, assistantText length: ${assistantText.length}`
+      );
+
       // ツール使用がある場合
       if (stopReason === 'tool_use' && toolUseBlocks.length > 0) {
         // アシスタントメッセージを追加
@@ -305,16 +333,23 @@ export async function* invokeStreamWithTools(
         // 各ツールを実行
         const toolResults: ContentBlock[] = [];
         for (const toolUse of toolUseBlocks) {
+          console.log(`Executing tool: ${toolUse.name}`);
           const { content, updatedMetadata } = await executeToolUse(
             toolUse,
             webSearchMetadata
           );
           webSearchMetadata = updatedMetadata;
+          console.log(`Tool ${toolUse.name} completed, result count: ${content.length}`);
 
+          // ツール結果にstatusフィールドを追加
+          const isError = content.some(
+            (c) => 'text' in c && (c.text as string)?.startsWith('Error:')
+          );
           toolResults.push({
             toolResult: {
               toolUseId: toolUse.toolUseId,
               content,
+              status: isError ? 'error' : 'success',
             },
           });
 
@@ -338,7 +373,20 @@ export async function* invokeStreamWithTools(
         });
 
         // 次のイテレーションへ
+        console.log('Continuing to next iteration...');
         continue;
+      }
+
+      // stopReasonがtool_useだがtoolUseBlocksが空の場合（パースエラーなど）
+      if (stopReason === 'tool_use' && toolUseBlocks.length === 0) {
+        console.error(
+          'Tool use stop reason received but no tool use blocks were captured'
+        );
+        yield streamingChunk({
+          text: '\n\nError: Failed to process tool use request.',
+          stopReason: 'error',
+        });
+        break;
       }
 
       // 終了

--- a/packages/cdk/lambda/utils/bedrockApiWithTools.ts
+++ b/packages/cdk/lambda/utils/bedrockApiWithTools.ts
@@ -374,6 +374,9 @@ export async function* invokeStreamWithTools(
 
         // 次のイテレーションへ
         console.log('Continuing to next iteration...');
+        console.log(
+          `Message count: ${conversationMessages.length}, Last message role: ${conversationMessages[conversationMessages.length - 1]?.role}`
+        );
         continue;
       }
 

--- a/packages/cdk/lambda/utils/bedrockApiWithTools.ts
+++ b/packages/cdk/lambda/utils/bedrockApiWithTools.ts
@@ -32,7 +32,7 @@ import {
 import { fetchWebText, createFetchResultContent } from './webTextFetcher';
 
 const MODEL_REGION = process.env.MODEL_REGION as string;
-const MAX_TOOL_USE_ITERATIONS = 5;
+const MAX_TOOL_USE_ITERATIONS = 3; // パフォーマンスのため3回に制限
 
 // Web検索用のシステムプロンプト追加
 const WEB_SEARCH_SYSTEM_PROMPT = `

--- a/packages/cdk/lambda/utils/bedrockApiWithTools.ts
+++ b/packages/cdk/lambda/utils/bedrockApiWithTools.ts
@@ -1,0 +1,387 @@
+import {
+  ConverseStreamCommand,
+  ConverseStreamCommandInput,
+  ContentBlock,
+  Message,
+  Tool,
+  ToolUseBlock,
+  ToolResultContentBlock,
+  ServiceQuotaExceededException,
+  ThrottlingException,
+  AccessDeniedException,
+  StopReason,
+  ConversationRole,
+} from '@aws-sdk/client-bedrock-runtime';
+import {
+  Model,
+  StreamingChunk,
+  UnrecordedMessage,
+  WebSearchMetadata,
+  WebSearchQuery,
+} from 'generative-ai-use-cases';
+import { streamingChunk } from './streamingChunk';
+import { initBedrockRuntimeClient } from './bedrockClient';
+import { BEDROCK_TEXT_GEN_MODELS } from './models';
+import {
+  WEB_SEARCH_TOOLS,
+  executeWebSearch,
+  createToolResultContent,
+  createToolErrorContent,
+  SearchEngine,
+} from './webSearchTool';
+import { fetchWebText, createFetchResultContent } from './webTextFetcher';
+
+const MODEL_REGION = process.env.MODEL_REGION as string;
+const MAX_TOOL_USE_ITERATIONS = 5;
+
+// Web検索用のシステムプロンプト追加
+const WEB_SEARCH_SYSTEM_PROMPT = `
+You have access to web search capabilities. When the user asks for current information, recent events, or topics requiring up-to-date data:
+1. Formulate effective search queries (consider using multiple related queries if needed)
+2. Analyze search results and identify which URLs might need deeper investigation
+3. Use the fetch_url tool to get full content when snippets are insufficient
+4. Synthesize information from multiple sources
+5. Always cite your sources with URLs in your response
+
+Important:
+- You can search up to 5 times per conversation
+- Be specific with search queries for better results
+- Prefer authoritative sources (official documentation, academic papers, reputable news)
+`;
+
+// UnrecordedMessageをBedrock Message形式に変換
+function convertToBedrockMessages(messages: UnrecordedMessage[]): Message[] {
+  return messages
+    .filter((msg) => msg.role !== 'system')
+    .map((message) => {
+      const contentBlocks: ContentBlock[] = [];
+
+      if (message.extraData) {
+        // 画像やファイルの処理（既存の実装と同様）
+        message.extraData.forEach((extra) => {
+          if (extra.type === 'image' && extra.source.type === 'base64') {
+            contentBlocks.push({
+              image: {
+                format: extra.source.mediaType.split('/')[1] as
+                  | 'png'
+                  | 'jpeg'
+                  | 'gif'
+                  | 'webp',
+                source: {
+                  bytes: Buffer.from(extra.source.data, 'base64'),
+                },
+              },
+            } as ContentBlock.ImageMember);
+          }
+        });
+      }
+
+      contentBlocks.push({ text: message.content });
+
+      return {
+        role:
+          message.role === 'user'
+            ? ConversationRole.USER
+            : ConversationRole.ASSISTANT,
+        content: contentBlocks,
+      };
+    });
+}
+
+// ToolUseBlockを処理してToolResultを返す
+async function executeToolUse(
+  toolUse: ToolUseBlock,
+  webSearchMetadata: WebSearchMetadata
+): Promise<{
+  content: ToolResultContentBlock[];
+  updatedMetadata: WebSearchMetadata;
+}> {
+  const toolName = toolUse.name;
+  const input = toolUse.input as Record<string, unknown>;
+
+  console.log(`Executing tool: ${toolName}`, JSON.stringify(input));
+
+  try {
+    if (toolName === 'web_search') {
+      const query = input.query as string;
+      const numResults = (input.num_results as number) || 3;
+      const searchEngine = process.env.SEARCH_ENGINE as SearchEngine;
+
+      const results = await executeWebSearch(query, numResults, searchEngine);
+
+      // メタデータを更新
+      const newQuery: WebSearchQuery = {
+        query,
+        timestamp: new Date().toISOString(),
+        results,
+      };
+
+      const updatedMetadata: WebSearchMetadata = {
+        ...webSearchMetadata,
+        queries: [...webSearchMetadata.queries, newQuery],
+        totalResultsCount:
+          webSearchMetadata.totalResultsCount + results.length,
+        searchEngineUsed: searchEngine,
+      };
+
+      return {
+        content: createToolResultContent(results),
+        updatedMetadata,
+      };
+    } else if (toolName === 'fetch_url') {
+      const url = input.url as string;
+      const result = await fetchWebText(url, { maxLength: 10000 });
+
+      return {
+        content: createFetchResultContent(result),
+        updatedMetadata: webSearchMetadata,
+      };
+    } else {
+      return {
+        content: createToolErrorContent(`Unknown tool: ${toolName}`),
+        updatedMetadata: webSearchMetadata,
+      };
+    }
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : 'Unknown error';
+    console.error(`Tool execution error: ${errorMessage}`);
+    return {
+      content: createToolErrorContent(errorMessage),
+      updatedMetadata: webSearchMetadata,
+    };
+  }
+}
+
+// Tool Use対応のストリーミング関数
+export async function* invokeStreamWithTools(
+  model: Model,
+  messages: UnrecordedMessage[],
+  id: string
+): AsyncGenerator<string> {
+  const region = model.region || MODEL_REGION;
+  const client = await initBedrockRuntimeClient({ region });
+
+  // Web検索メタデータの初期化
+  let webSearchMetadata: WebSearchMetadata = {
+    queries: [],
+    totalResultsCount: 0,
+    referencedResultsCount: 0,
+  };
+
+  // システムプロンプトを取得して検索ガイダンスを追加
+  const systemMessage = messages.find((msg) => msg.role === 'system');
+  const systemPrompt = systemMessage
+    ? systemMessage.content + '\n\n' + WEB_SEARCH_SYSTEM_PROMPT
+    : WEB_SEARCH_SYSTEM_PROMPT;
+
+  // メッセージを変換
+  let conversationMessages = convertToBedrockMessages(messages);
+
+  // モデル設定を取得
+  const modelConfig = BEDROCK_TEXT_GEN_MODELS[model.modelId];
+  if (!modelConfig) {
+    yield streamingChunk({
+      text: `Model ${model.modelId} is not supported for web search.`,
+      stopReason: 'error',
+    });
+    return;
+  }
+
+  let iteration = 0;
+
+  try {
+    while (iteration < MAX_TOOL_USE_ITERATIONS) {
+      iteration++;
+
+      // Converse API呼び出し
+      const input: ConverseStreamCommandInput = {
+        modelId: model.modelId,
+        messages: conversationMessages,
+        system: [{ text: systemPrompt }],
+        toolConfig: {
+          tools: WEB_SEARCH_TOOLS,
+        },
+        inferenceConfig: modelConfig.defaultParams.inferenceConfig,
+      };
+
+      const command = new ConverseStreamCommand(input);
+      const response = await client.send(command);
+
+      if (!response.stream) {
+        return;
+      }
+
+      let assistantText = '';
+      let toolUseBlocks: ToolUseBlock[] = [];
+      let currentToolUse: Partial<ToolUseBlock> | null = null;
+      let stopReason: StopReason | undefined;
+
+      for await (const event of response.stream) {
+        if (event.contentBlockStart?.start?.toolUse) {
+          // ツール使用開始
+          currentToolUse = {
+            toolUseId: event.contentBlockStart.start.toolUse.toolUseId,
+            name: event.contentBlockStart.start.toolUse.name,
+            input: {},
+          };
+
+          // ツール使用開始を通知
+          yield streamingChunk({
+            text: '',
+            toolUse: {
+              toolName: currentToolUse.name!,
+              toolUseId: currentToolUse.toolUseId!,
+              status: 'invoking',
+              input: {},
+            },
+          });
+        } else if (event.contentBlockDelta?.delta?.toolUse) {
+          // ツール入力の累積
+          if (currentToolUse) {
+            const inputDelta = event.contentBlockDelta.delta.toolUse.input;
+            if (inputDelta) {
+              // JSON文字列として累積
+              currentToolUse.input =
+                ((currentToolUse.input as string) || '') + inputDelta;
+            }
+          }
+        } else if (event.contentBlockStop && currentToolUse) {
+          // ツール使用ブロック完了
+          try {
+            const parsedInput =
+              typeof currentToolUse.input === 'string'
+                ? JSON.parse(currentToolUse.input)
+                : currentToolUse.input;
+            toolUseBlocks.push({
+              toolUseId: currentToolUse.toolUseId!,
+              name: currentToolUse.name!,
+              input: parsedInput,
+            });
+          } catch (e) {
+            console.error('Failed to parse tool input:', e);
+          }
+          currentToolUse = null;
+        } else if (event.contentBlockDelta?.delta?.text) {
+          // テキスト出力
+          const text = event.contentBlockDelta.delta.text;
+          assistantText += text;
+          yield streamingChunk({ text });
+        } else if (event.messageStop) {
+          stopReason = event.messageStop.stopReason;
+        } else if (event.metadata?.usage) {
+          // メタデータを送信
+          yield streamingChunk({
+            text: '',
+            metadata: {
+              usage: {
+                inputTokens: event.metadata.usage.inputTokens || 0,
+                outputTokens: event.metadata.usage.outputTokens || 0,
+                totalTokens:
+                  (event.metadata.usage.inputTokens || 0) +
+                  (event.metadata.usage.outputTokens || 0),
+              },
+            },
+          });
+        }
+      }
+
+      // ツール使用がある場合
+      if (stopReason === 'tool_use' && toolUseBlocks.length > 0) {
+        // アシスタントメッセージを追加
+        const assistantContent: ContentBlock[] = [];
+        if (assistantText) {
+          assistantContent.push({ text: assistantText });
+        }
+        toolUseBlocks.forEach((toolUse) => {
+          assistantContent.push({ toolUse });
+        });
+
+        conversationMessages.push({
+          role: ConversationRole.ASSISTANT,
+          content: assistantContent,
+        });
+
+        // 各ツールを実行
+        const toolResults: ContentBlock[] = [];
+        for (const toolUse of toolUseBlocks) {
+          const { content, updatedMetadata } = await executeToolUse(
+            toolUse,
+            webSearchMetadata
+          );
+          webSearchMetadata = updatedMetadata;
+
+          toolResults.push({
+            toolResult: {
+              toolUseId: toolUse.toolUseId,
+              content,
+            },
+          });
+
+          // ツール完了を通知
+          yield streamingChunk({
+            text: '',
+            toolUse: {
+              toolName: toolUse.name!,
+              toolUseId: toolUse.toolUseId!,
+              status: 'completed',
+              input: toolUse.input as Record<string, unknown>,
+            },
+            webSearchMetadata,
+          });
+        }
+
+        // ツール結果をメッセージに追加
+        conversationMessages.push({
+          role: ConversationRole.USER,
+          content: toolResults,
+        });
+
+        // 次のイテレーションへ
+        continue;
+      }
+
+      // 終了
+      yield streamingChunk({
+        text: '',
+        stopReason: stopReason || 'end_turn',
+        webSearchMetadata:
+          webSearchMetadata.queries.length > 0 ? webSearchMetadata : undefined,
+      });
+      break;
+    }
+
+    // 最大イテレーション数を超えた場合
+    if (iteration >= MAX_TOOL_USE_ITERATIONS) {
+      yield streamingChunk({
+        text: '\n\n[Maximum search iterations reached]',
+        stopReason: 'end_turn',
+        webSearchMetadata,
+      });
+    }
+  } catch (e) {
+    if (
+      e instanceof ThrottlingException ||
+      e instanceof ServiceQuotaExceededException
+    ) {
+      yield streamingChunk({
+        text: 'The server is currently experiencing high access. Please try again later.',
+        stopReason: 'error',
+      });
+    } else if (e instanceof AccessDeniedException) {
+      const modelAccessURL = `https://${region}.console.aws.amazon.com/bedrock/home?region=${region}#/modelaccess`;
+      yield streamingChunk({
+        text: `The selected model is not enabled. Please enable the model in the [Bedrock console Model Access screen](${modelAccessURL}).`,
+        stopReason: 'error',
+      });
+    } else {
+      console.error(e);
+      yield streamingChunk({
+        text:
+          'An error occurred. Please report the following error to the administrator.\n' +
+          e,
+        stopReason: 'error',
+      });
+    }
+  }
+}

--- a/packages/cdk/lambda/utils/webSearchTool.ts
+++ b/packages/cdk/lambda/utils/webSearchTool.ts
@@ -1,0 +1,217 @@
+import { Tool, ToolResultContentBlock } from '@aws-sdk/client-bedrock-runtime';
+import {
+  BraveSearchResult,
+  TavilySearchResult,
+  WebSearchResult,
+} from 'generative-ai-use-cases';
+
+// Web検索ツールの定義
+export const WEB_SEARCH_TOOL: Tool = {
+  toolSpec: {
+    name: 'web_search',
+    description:
+      'Search the web for current information. Use this when asked about recent events, current data, or topics requiring up-to-date information. You can call this tool multiple times with different queries to gather comprehensive information.',
+    inputSchema: {
+      json: {
+        type: 'object',
+        properties: {
+          query: {
+            type: 'string',
+            description: 'Search query keywords',
+          },
+          num_results: {
+            type: 'number',
+            description: 'Number of results to return (default: 3, max: 5)',
+          },
+        },
+        required: ['query'],
+      },
+    },
+  },
+};
+
+// URL本文取得ツールの定義
+export const FETCH_URL_TOOL: Tool = {
+  toolSpec: {
+    name: 'fetch_url',
+    description:
+      'Fetch full content from a URL. Use this to get detailed information from a specific web page when the search snippet is not enough.',
+    inputSchema: {
+      json: {
+        type: 'object',
+        properties: {
+          url: {
+            type: 'string',
+            description: 'URL to fetch content from',
+          },
+        },
+        required: ['url'],
+      },
+    },
+  },
+};
+
+// 全てのWeb検索関連ツール
+export const WEB_SEARCH_TOOLS: Tool[] = [WEB_SEARCH_TOOL, FETCH_URL_TOOL];
+
+// 内部用の検索結果型
+type InternalSearchResult = {
+  title: string;
+  content: string;
+  url: string;
+  extraSnippets?: string[];
+};
+
+// Brave Search APIを使用した検索
+export const searchUsingBrave = async (
+  query: string,
+  numResults: number = 3,
+  apiKey?: string
+): Promise<InternalSearchResult[]> => {
+  const searchApiKey = apiKey || process.env.SEARCH_API_KEY || '';
+
+  if (!searchApiKey) {
+    throw new Error('SEARCH_API_KEY is not configured');
+  }
+
+  const count = Math.min(Math.max(numResults, 1), 5);
+  const encodedQuery = encodeURIComponent(query);
+  const searchUrl = `https://api.search.brave.com/res/v1/web/search?q=${encodedQuery}&count=${count}&text_decorations=0`;
+
+  const response = await fetch(searchUrl, {
+    headers: {
+      'X-Subscription-Token': searchApiKey,
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Brave Search API error: ${response.status}`);
+  }
+
+  const data = await response.json();
+  console.log('Brave Search response:', JSON.stringify(data));
+
+  if (!data.web?.results) {
+    return [];
+  }
+
+  return data.web.results.map(
+    (result: BraveSearchResult): InternalSearchResult => ({
+      title: result.title,
+      content: result.description,
+      url: result.url,
+      extraSnippets: result.extra_snippets,
+    })
+  );
+};
+
+// Tavily APIを使用した検索
+export const searchUsingTavily = async (
+  query: string,
+  numResults: number = 3,
+  apiKey?: string
+): Promise<InternalSearchResult[]> => {
+  const searchApiKey = apiKey || process.env.SEARCH_API_KEY || '';
+
+  if (!searchApiKey) {
+    throw new Error('SEARCH_API_KEY is not configured');
+  }
+
+  const maxResults = Math.min(Math.max(numResults, 1), 5);
+  const searchUrl = 'https://api.tavily.com/search';
+
+  const response = await fetch(searchUrl, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${searchApiKey}`,
+    },
+    body: JSON.stringify({
+      query,
+      search_depth: 'basic',
+      include_answer: false,
+      include_images: false,
+      include_raw_content: true,
+      max_results: maxResults,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Tavily API error: ${response.status}`);
+  }
+
+  const data = await response.json();
+  console.log('Tavily Search response:', JSON.stringify(data));
+
+  if (!data.results) {
+    return [];
+  }
+
+  return data.results.map(
+    (result: TavilySearchResult): InternalSearchResult => ({
+      title: result.title,
+      content: result.raw_content ?? result.content,
+      url: result.url,
+    })
+  );
+};
+
+// 検索エンジンに応じた検索実行
+export type SearchEngine = 'Brave' | 'Tavily';
+
+export const executeWebSearch = async (
+  query: string,
+  numResults: number = 3,
+  searchEngine?: SearchEngine,
+  apiKey?: string
+): Promise<WebSearchResult[]> => {
+  const engine = searchEngine || (process.env.SEARCH_ENGINE as SearchEngine);
+
+  if (!engine) {
+    throw new Error('SEARCH_ENGINE is not configured');
+  }
+
+  const internalResults =
+    engine === 'Brave'
+      ? await searchUsingBrave(query, numResults, apiKey)
+      : await searchUsingTavily(query, numResults, apiKey);
+
+  // WebSearchResult型に変換
+  return internalResults.map((result) => ({
+    title: result.title,
+    url: result.url,
+    snippet:
+      result.content.substring(0, 500) +
+      (result.content.length > 500 ? '...' : ''),
+    content: result.content,
+  }));
+};
+
+// ツール実行結果をToolResultContentBlockに変換
+export const createToolResultContent = (
+  results: WebSearchResult[]
+): ToolResultContentBlock[] => {
+  return [
+    {
+      json: {
+        results: results.map((r) => ({
+          title: r.title,
+          url: r.url,
+          snippet: r.snippet,
+          content: r.content ?? '',
+        })),
+      },
+    },
+  ];
+};
+
+// ツール実行エラーをToolResultContentBlockに変換
+export const createToolErrorContent = (
+  error: string
+): ToolResultContentBlock[] => {
+  return [
+    {
+      text: `Error: ${error}`,
+    },
+  ];
+};

--- a/packages/cdk/lambda/utils/webSearchTool.ts
+++ b/packages/cdk/lambda/utils/webSearchTool.ts
@@ -188,6 +188,7 @@ export const executeWebSearch = async (
 };
 
 // ツール実行結果をToolResultContentBlockに変換
+// 注: contentは大きくなりがちなので、snippetのみを使用してモデルの処理負荷を軽減
 export const createToolResultContent = (
   results: WebSearchResult[]
 ): ToolResultContentBlock[] => {
@@ -198,7 +199,8 @@ export const createToolResultContent = (
           title: r.title,
           url: r.url,
           snippet: r.snippet,
-          content: r.content ?? '',
+          // contentは送信せず、snippetで十分な情報を提供
+          // 詳細が必要な場合はfetch_urlツールを使用
         })),
       },
     },

--- a/packages/cdk/lambda/utils/webTextFetcher.ts
+++ b/packages/cdk/lambda/utils/webTextFetcher.ts
@@ -1,0 +1,298 @@
+import { parse } from 'node-html-parser';
+import sanitizeHtml from 'sanitize-html';
+import { URL } from 'url';
+import dns from 'dns';
+import { promisify } from 'util';
+import { ToolResultContentBlock } from '@aws-sdk/client-bedrock-runtime';
+
+const dnsLookup = promisify(dns.lookup);
+
+// フェッチ結果の型
+export type FetchResult = {
+  url: string;
+  title?: string;
+  content?: string;
+  success: boolean;
+  error?: string;
+};
+
+// フェッチオプション
+export type FetchOptions = {
+  maxLength?: number; // デフォルト: 10000
+  timeoutMs?: number; // デフォルト: 30000
+};
+
+const DEFAULT_MAX_LENGTH = 10000;
+const DEFAULT_TIMEOUT_MS = 30000;
+
+// IPアドレスを数値に変換
+const ipToLong = (ip: string): number => {
+  return (
+    ip.split('.').reduce((acc, octet) => (acc << 8) + parseInt(octet), 0) >>> 0
+  );
+};
+
+// ブロックするIPアドレス範囲
+const BLOCKED_RANGES = [
+  // ループバックアドレス
+  { start: '127.0.0.0', end: '127.255.255.255' },
+  // リンクローカルアドレス
+  { start: '169.254.0.0', end: '169.254.255.255' },
+  // プライベートネットワークアドレス
+  { start: '10.0.0.0', end: '10.255.255.255' },
+  { start: '172.16.0.0', end: '172.31.255.255' },
+  { start: '192.168.0.0', end: '192.168.255.255' },
+  // AWSメタデータサービス
+  { start: '169.254.169.254', end: '169.254.169.254' },
+  // localhost
+  { start: '0.0.0.0', end: '0.255.255.255' },
+];
+
+// ブロックするホスト名
+const BLOCKED_HOSTNAMES = ['localhost', '127.0.0.1', 'loopback', 'internal'];
+
+/**
+ * IPアドレスがプライベートIPかどうかを判定
+ */
+export function isPrivateIP(ip: string): boolean {
+  const ipLong = ipToLong(ip);
+  return BLOCKED_RANGES.some((range) => {
+    const startLong = ipToLong(range.start);
+    const endLong = ipToLong(range.end);
+    return ipLong >= startLong && ipLong <= endLong;
+  });
+}
+
+/**
+ * URLの安全性を検証
+ */
+export async function validateUrl(
+  urlString: string
+): Promise<{ valid: boolean; message?: string }> {
+  try {
+    const url = new URL(urlString);
+
+    // HTTPおよびHTTPSスキームのみ許可
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+      return {
+        valid: false,
+        message: 'Unauthorized URL scheme. Only HTTP or HTTPS is allowed.',
+      };
+    }
+
+    // IPv4アドレスが直接指定されている場合の検証
+    const ipv4Regex = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/;
+    if (ipv4Regex.test(url.hostname)) {
+      if (isPrivateIP(url.hostname)) {
+        return {
+          valid: false,
+          message: 'Access to internal networks is not allowed.',
+        };
+      }
+    } else {
+      // ドメイン名の場合、DNS解決後のIPをチェック
+      try {
+        const { address } = await dnsLookup(url.hostname);
+        if (isPrivateIP(address)) {
+          return {
+            valid: false,
+            message:
+              'Access to domains resolving to internal networks is not allowed.',
+          };
+        }
+      } catch (error) {
+        console.error(`DNS lookup error: ${error}`);
+        return {
+          valid: false,
+          message: 'Failed to resolve the specified domain.',
+        };
+      }
+    }
+
+    // localhostに関連するホスト名をブロック
+    const hostname = url.hostname.toLowerCase();
+    if (BLOCKED_HOSTNAMES.some((blocked) => hostname.includes(blocked))) {
+      return {
+        valid: false,
+        message: 'Access to internal networks is not allowed.',
+      };
+    }
+
+    return { valid: true };
+  } catch (error) {
+    console.error(`URL validation error: ${error}`);
+    return { valid: false, message: 'Invalid URL format.' };
+  }
+}
+
+/**
+ * HTMLからタイトルを抽出
+ */
+function extractTitle(html: string): string | undefined {
+  try {
+    const root = parse(html);
+    const titleElement = root.querySelector('title');
+    return titleElement?.text?.trim();
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * HTMLからテキストを抽出
+ */
+function extractText(html: string, maxLength: number): string {
+  // 不正なタグを修正
+  const cleanHtml = sanitizeHtml(html, {
+    allowedTags: [...sanitizeHtml.defaults.allowedTags, 'body', 'html'],
+  });
+
+  const root = parse(cleanHtml, {
+    comment: false,
+    blockTextElements: {
+      script: false,
+      noScript: false,
+      style: false,
+      pre: false,
+    },
+  });
+
+  const text = root?.querySelector('body')?.removeWhitespace().text || '';
+
+  // 最大長に切り詰め
+  if (text.length > maxLength) {
+    return text.substring(0, maxLength) + '...';
+  }
+  return text;
+}
+
+/**
+ * タイムアウト付きフェッチ
+ */
+async function fetchWithTimeout(
+  url: string,
+  timeoutMs: number
+): Promise<Response> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+
+  try {
+    const response = await fetch(url, {
+      signal: controller.signal,
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (compatible; GenAI-UseCases-Bot/1.0; +https://github.com/aws-samples/generative-ai-use-cases-jp)',
+      },
+    });
+    return response;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+/**
+ * 単一URLからテキストを取得
+ */
+export async function fetchWebText(
+  url: string,
+  options?: FetchOptions
+): Promise<FetchResult> {
+  const maxLength = options?.maxLength ?? DEFAULT_MAX_LENGTH;
+  const timeoutMs = options?.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  try {
+    // URL検証
+    const validation = await validateUrl(url);
+    if (!validation.valid) {
+      return {
+        url,
+        success: false,
+        error: validation.message || 'URL validation failed',
+      };
+    }
+
+    // コンテンツ取得
+    const response = await fetchWithTimeout(url, timeoutMs);
+
+    if (!response.ok) {
+      return {
+        url,
+        success: false,
+        error: `HTTP error: ${response.status}`,
+      };
+    }
+
+    const html = await response.text();
+    const title = extractTitle(html);
+    const content = extractText(html, maxLength);
+
+    return {
+      url,
+      title,
+      content,
+      success: true,
+    };
+  } catch (error) {
+    const errorMessage =
+      error instanceof Error ? error.message : 'Unknown error';
+    console.error(`Error fetching ${url}: ${errorMessage}`);
+    return {
+      url,
+      success: false,
+      error: errorMessage,
+    };
+  }
+}
+
+/**
+ * 複数URLから並列でテキストを取得
+ */
+export async function fetchMultipleWebTexts(
+  urls: string[],
+  options?: FetchOptions
+): Promise<FetchResult[]> {
+  // 最大5URLに制限
+  const limitedUrls = urls.slice(0, 5);
+
+  const results = await Promise.allSettled(
+    limitedUrls.map((url) => fetchWebText(url, options))
+  );
+
+  return results.map((result, index) => {
+    if (result.status === 'fulfilled') {
+      return result.value;
+    } else {
+      return {
+        url: limitedUrls[index],
+        success: false,
+        error: result.reason?.message || 'Unknown error',
+      };
+    }
+  });
+}
+
+/**
+ * フェッチ結果をToolResultContentBlockに変換
+ */
+export const createFetchResultContent = (
+  result: FetchResult
+): ToolResultContentBlock[] => {
+  if (result.success) {
+    return [
+      {
+        json: {
+          url: result.url,
+          title: result.title || '',
+          content: result.content || '',
+          success: true,
+        },
+      },
+    ];
+  } else {
+    return [
+      {
+        text: `Error fetching ${result.url}: ${result.error}`,
+      },
+    ];
+  }
+};

--- a/packages/cdk/lib/construct/api/index.ts
+++ b/packages/cdk/lib/construct/api/index.ts
@@ -93,6 +93,11 @@ export interface BackendApiProps {
   readonly openai?: {
     readonly apiKey: string; // OPENAI_API_KEY
   };
+
+  // Web Search in Chat
+  readonly webSearchInChatEnabled: boolean;
+  readonly searchApiKey?: string | null;
+  readonly searchEngine: 'Brave' | 'Tavily';
 }
 
 export class Api extends Construct {

--- a/packages/cdk/lib/construct/api/predict.ts
+++ b/packages/cdk/lib/construct/api/predict.ts
@@ -85,7 +85,7 @@ class PredictApi extends Construct {
       runtime: LAMBDA_RUNTIME_NODEJS,
       entry: './lambda/predictStream.ts',
       timeout: Duration.minutes(15),
-      memorySize: 256,
+      memorySize: 512, // Tool Use処理のためメモリを増加
       environment: {
         USER_POOL_ID: userPool.userPoolId,
         USER_POOL_CLIENT_ID: userPoolClient.userPoolClientId,

--- a/packages/cdk/lib/construct/api/predict.ts
+++ b/packages/cdk/lib/construct/api/predict.ts
@@ -41,6 +41,9 @@ class PredictApi extends Construct {
       logsPolicy,
       assumeRolePolicy,
       litellmProxy,
+      webSearchInChatEnabled,
+      searchApiKey,
+      searchEngine,
     } = props;
 
     const predictFunction = new NodejsFunction(this, 'Predict', {
@@ -104,6 +107,11 @@ class PredictApi extends Construct {
 
         // LangChain Credentials
         OPENAI_API_KEY: openai?.apiKey ?? '',
+
+        // Web Search in Chat
+        WEB_SEARCH_IN_CHAT_ENABLED: JSON.stringify(webSearchInChatEnabled),
+        SEARCH_API_KEY: searchApiKey ?? '',
+        SEARCH_ENGINE: searchEngine,
 
         // Tenant Management Environment Variables
         ...(tenantManager

--- a/packages/cdk/lib/construct/api/props.ts
+++ b/packages/cdk/lib/construct/api/props.ts
@@ -58,6 +58,11 @@ export type GenericApiProps = {
     readonly apiKey: string; // OPENAI_API_KEY
   };
 
+  // Web Search in Chat
+  readonly webSearchInChatEnabled: boolean;
+  readonly searchApiKey?: string | null;
+  readonly searchEngine: 'Brave' | 'Tavily';
+
   api: RestApi;
   fileBucket: Bucket;
 

--- a/packages/cdk/lib/construct/web.ts
+++ b/packages/cdk/lib/construct/web.ts
@@ -60,6 +60,7 @@ export interface WebProps {
   readonly mcpEnabled: boolean;
   readonly mcpEndpoint: string | null;
   readonly pptxEnabled: boolean;
+  readonly webSearchInChatEnabled: boolean;
 }
 
 export class Web extends Construct {
@@ -270,6 +271,8 @@ export class Web extends Construct {
         VITE_APP_MCP_ENABLED: props.mcpEnabled.toString(),
         VITE_APP_MCP_ENDPOINT: props.mcpEndpoint ?? '',
         VITE_APP_PPTX_ENABLED: props.pptxEnabled.toString(),
+        VITE_APP_WEB_SEARCH_IN_CHAT_ENABLED:
+          props.webSearchInChatEnabled.toString(),
       },
     });
     // Enhance computing resources

--- a/packages/cdk/lib/stack-input.ts
+++ b/packages/cdk/lib/stack-input.ts
@@ -129,6 +129,7 @@ const baseStackInputSchema = z.object({
   // Agent
   agentEnabled: z.boolean().default(false),
   searchAgentEnabled: z.boolean().default(false),
+  webSearchInChatEnabled: z.boolean().default(false),
   searchApiKey: z.string().nullish(),
   searchEngine: z.enum(['Brave', 'Tavily']).default('Brave'),
   agents: z

--- a/packages/cdk/lib/stacks/common/assistant-api-stack.ts
+++ b/packages/cdk/lib/stacks/common/assistant-api-stack.ts
@@ -113,6 +113,11 @@ class AssistantApiStack extends NestedStack {
 
       // OpenAI
       openai: params.openai,
+
+      // Web Search in Chat
+      webSearchInChatEnabled: params.webSearchInChatEnabled,
+      searchApiKey: params.searchApiKey,
+      searchEngine: params.searchEngine,
     });
 
     this.assistantApi = assistantApi;

--- a/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
@@ -439,6 +439,10 @@ export class GenerativeAiUseCasesStack extends Stack {
       value: params.pptxEnabled.toString(),
     });
 
+    new CfnOutput(this, 'WebSearchInChatEnabled', {
+      value: params.webSearchInChatEnabled.toString(),
+    });
+
     new CfnOutput(this, 'LitellmProxyEnabled', {
       value: params.litellmProxyEnabled.toString(),
     });

--- a/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
@@ -141,6 +141,11 @@ export class GenerativeAiUseCasesStack extends Stack {
 
       // LangChain Credentials
       openai: params.openai,
+
+      // Web Search in Chat
+      webSearchInChatEnabled: params.webSearchInChatEnabled,
+      searchApiKey: params.searchApiKey,
+      searchEngine: params.searchEngine,
     });
 
     // WAF

--- a/packages/cdk/lib/stacks/common/web-stack.ts
+++ b/packages/cdk/lib/stacks/common/web-stack.ts
@@ -78,6 +78,7 @@ class WebStack extends NestedStack {
       mcpEnabled: params.mcpEnabled,
       mcpEndpoint,
       pptxEnabled: params.pptxEnabled,
+      webSearchInChatEnabled: params.webSearchInChatEnabled,
       // Frontend
       // Custom Domain
       cert: cert,

--- a/packages/types/src/message.d.ts
+++ b/packages/types/src/message.d.ts
@@ -113,10 +113,41 @@ export type ShownMessage = Partial<PrimaryKey> &
   Partial<MessageAttributes> &
   UnrecordedMessage & {
     traceInlineMessage?: string;
+    webSearchMetadata?: WebSearchMetadata;
   };
 
 export type DocumentComment = {
   excerpt: string;
   replace?: string;
   comment?: string;
+};
+
+// Web検索関連の型定義
+export type WebSearchResult = {
+  title: string;
+  url: string;
+  snippet: string;
+  content?: string;
+  isReferenced?: boolean;
+};
+
+export type WebSearchQuery = {
+  query: string;
+  timestamp?: string;
+  results: WebSearchResult[];
+};
+
+export type WebSearchMetadata = {
+  queries: WebSearchQuery[];
+  totalResultsCount: number;
+  referencedResultsCount: number;
+  searchEngineUsed?: string;
+};
+
+export type ToolUseInfo = {
+  toolName: string;
+  toolUseId: string;
+  status: 'invoking' | 'completed' | 'error';
+  input?: Record<string, unknown>;
+  output?: Record<string, unknown>;
 };

--- a/packages/types/src/message.d.ts
+++ b/packages/types/src/message.d.ts
@@ -49,6 +49,8 @@ export type UnrecordedMessage = {
   extraData?: ExtraData[];
   llmType?: string;
   metadata?: Metadata;
+  // Web検索メタデータ（検索過程を保存するため）
+  webSearchMetadata?: WebSearchMetadata;
 };
 
 export type ExtraData = {
@@ -113,7 +115,6 @@ export type ShownMessage = Partial<PrimaryKey> &
   Partial<MessageAttributes> &
   UnrecordedMessage & {
     traceInlineMessage?: string;
-    webSearchMetadata?: WebSearchMetadata;
   };
 
 export type DocumentComment = {

--- a/packages/types/src/protocol.d.ts
+++ b/packages/types/src/protocol.d.ts
@@ -4,6 +4,8 @@ import {
   ToBeRecordedMessage,
   UnrecordedMessage,
   Metadata,
+  ToolUseInfo,
+  WebSearchMetadata,
 } from './message';
 import { Chat } from './chat';
 import {
@@ -25,6 +27,8 @@ export type StreamingChunk = {
   metadata?: Metadata;
   stopReason?: StopReason | 'error';
   sessionId?: string;
+  toolUse?: ToolUseInfo;
+  webSearchMetadata?: WebSearchMetadata;
 };
 
 export type Pagination<T> = {
@@ -78,6 +82,7 @@ export type PredictRequest = {
   idToken?: string;
   messages: UnrecordedMessage[];
   id: string;
+  webSearchEnabled?: boolean;
 };
 
 export type PredictResponse = string;

--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -225,6 +225,16 @@ chat:
   create_link_message: >-
     By creating a link, you will share the conversation history with all users
     who can log in to this application.
+  webSearch:
+    toggle_label: Web Search
+    trace_title: Web Search Process
+    query_label: Search Query
+    results_label: Search Results
+    referenced: Referenced
+    searching: Searching...
+    summary: 'Referenced: {{referenced}} / Total: {{total}}'
+    no_results: No results
+    fetching_url: Fetching URL...
   create_system_prompt: Create System Prompt
   delete_chat_confirmation: Are you sure you want to delete the chat "{{title}}"?
   delete_confirmation: Delete Confirmation

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -222,6 +222,16 @@ chat:
   button:
     newChat: 新しいチャット
   create_link: リンクの作成
+  webSearch:
+    toggle_label: Web検索
+    trace_title: Web検索過程
+    query_label: 検索クエリ
+    results_label: 検索結果
+    referenced: 参照済み
+    searching: 検索中...
+    summary: '参照: {{referenced}}件 / 検索結果: {{total}}件'
+    no_results: 検索結果なし
+    fetching_url: URL取得中...
   create_link_message: リンクを作成することで、このアプリケーションにログイン可能な全ユーザーに対して会話履歴を公開します。
   create_system_prompt: システムプロンプトの作成
   delete_chat_confirmation: チャット「{{title}}」を削除しますか？

--- a/packages/web/src/components/ChatMessage.tsx
+++ b/packages/web/src/components/ChatMessage.tsx
@@ -26,6 +26,7 @@ import useTyping from '../hooks/useTyping';
 import FileCard from './FileCard';
 import FeedbackForm from './FeedbackForm';
 import Textarea from './Textarea';
+import WebSearchTrace from './WebSearchTrace';
 import useFiles from '../hooks/useFiles';
 import { useTranslation } from 'react-i18next';
 
@@ -258,6 +259,13 @@ const ChatMessage: React.FC<Props> = (props) => {
                         </Markdown>
                       )}
                   </div>
+                )}
+
+                {chatContent?.webSearchMetadata && (
+                  <WebSearchTrace
+                    metadata={chatContent.webSearchMetadata}
+                    loading={props.loading}
+                  />
                 )}
 
                 {chatContent?.extraData && chatContent.extraData.length > 0 && (

--- a/packages/web/src/components/WebSearchTrace.tsx
+++ b/packages/web/src/components/WebSearchTrace.tsx
@@ -1,0 +1,147 @@
+import React, { useState } from 'react';
+import { WebSearchMetadata, WebSearchQuery, WebSearchResult } from 'generative-ai-use-cases';
+import { useTranslation } from 'react-i18next';
+import { PiGlobeSimple, PiCaretDown, PiCaretRight, PiLink, PiCheck } from 'react-icons/pi';
+
+type WebSearchResultCardProps = {
+  result: WebSearchResult;
+};
+
+const WebSearchResultCard: React.FC<WebSearchResultCardProps> = ({ result }) => {
+  return (
+    <a
+      href={result.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="group block rounded-lg border border-gray-200 p-3 transition-colors hover:border-blue-300 hover:bg-blue-50"
+    >
+      <div className="flex items-start gap-2">
+        <PiLink className="mt-1 size-4 shrink-0 text-gray-400 group-hover:text-blue-500" />
+        <div className="min-w-0 flex-1">
+          <h4 className="truncate text-sm font-medium text-gray-900 group-hover:text-blue-600">
+            {result.title}
+          </h4>
+          <p className="mt-1 line-clamp-2 text-xs text-gray-500">
+            {result.snippet}
+          </p>
+          <p className="mt-1 truncate text-xs text-gray-400">
+            {result.url}
+          </p>
+        </div>
+        {result.isReferenced && (
+          <span className="shrink-0 rounded-full bg-green-100 p-1">
+            <PiCheck className="size-3 text-green-600" />
+          </span>
+        )}
+      </div>
+    </a>
+  );
+};
+
+type WebSearchQuerySectionProps = {
+  query: WebSearchQuery;
+  index: number;
+};
+
+const WebSearchQuerySection: React.FC<WebSearchQuerySectionProps> = ({ query, index }) => {
+  const { t } = useTranslation();
+  const [isExpanded, setIsExpanded] = useState(index === 0);
+
+  return (
+    <div className="rounded-lg border border-gray-200 bg-white">
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="flex w-full items-center justify-between p-3 text-left hover:bg-gray-50"
+      >
+        <div className="flex items-center gap-2">
+          {isExpanded ? (
+            <PiCaretDown className="size-4 text-gray-500" />
+          ) : (
+            <PiCaretRight className="size-4 text-gray-500" />
+          )}
+          <span className="text-sm font-medium text-gray-700">
+            {t('chat.webSearch.query_label')}: {query.query}
+          </span>
+        </div>
+        <span className="text-xs text-gray-500">
+          {query.results.length} {t('chat.webSearch.results_label')}
+        </span>
+      </button>
+
+      {isExpanded && (
+        <div className="border-t border-gray-100 p-3">
+          {query.results.length > 0 ? (
+            <div className="grid gap-2">
+              {query.results.map((result, idx) => (
+                <WebSearchResultCard key={idx} result={result} />
+              ))}
+            </div>
+          ) : (
+            <p className="text-sm text-gray-500">{t('chat.webSearch.no_results')}</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+type Props = {
+  metadata: WebSearchMetadata;
+  loading?: boolean;
+};
+
+const WebSearchTrace: React.FC<Props> = ({ metadata, loading }) => {
+  const { t } = useTranslation();
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  if (!metadata.queries || metadata.queries.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="mb-2 rounded-lg border border-blue-200 bg-blue-50 p-3">
+      <button
+        onClick={() => setIsExpanded(!isExpanded)}
+        className="flex w-full items-center justify-between text-left"
+      >
+        <div className="flex items-center gap-2">
+          <PiGlobeSimple className="size-5 text-blue-500" />
+          <span className="text-sm font-medium text-blue-700">
+            {t('chat.webSearch.trace_title')}
+          </span>
+          {loading && (
+            <div className="size-4 animate-spin rounded-full border-2 border-blue-300 border-t-blue-600"></div>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          <span className="text-xs text-blue-600">
+            {t('chat.webSearch.summary', {
+              referenced: metadata.referencedResultsCount,
+              total: metadata.totalResultsCount,
+            })}
+          </span>
+          {isExpanded ? (
+            <PiCaretDown className="size-4 text-blue-500" />
+          ) : (
+            <PiCaretRight className="size-4 text-blue-500" />
+          )}
+        </div>
+      </button>
+
+      {isExpanded && (
+        <div className="mt-3 space-y-2">
+          {metadata.queries.map((query, idx) => (
+            <WebSearchQuerySection key={idx} query={query} index={idx} />
+          ))}
+          {metadata.searchEngineUsed && (
+            <p className="text-right text-xs text-gray-400">
+              Powered by {metadata.searchEngineUsed}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default WebSearchTrace;

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -15,6 +15,8 @@ import {
   ListChatsResponse,
   AdditionalModelRequestFields,
   Metadata,
+  ToolUseInfo,
+  WebSearchMetadata,
 } from 'generative-ai-use-cases';
 import { useEffect, useMemo, useCallback } from 'react';
 import { v4 as uuid } from 'uuid';
@@ -71,7 +73,8 @@ const useChatState = create<{
     overrideModelType: Model['type'] | undefined,
     setSessionId: (sessionId: string) => void,
     base64Cache: Record<string, string> | undefined,
-    overrideModelParameters: AdditionalModelRequestFields | undefined
+    overrideModelParameters: AdditionalModelRequestFields | undefined,
+    webSearchEnabled?: boolean
   ) => void;
   edit: (
     id: string,
@@ -86,7 +89,8 @@ const useChatState = create<{
     overrideModelType: Model['type'] | undefined,
     setSessionId: (sessionId: string) => void,
     base64Cache: Record<string, string> | undefined,
-    overrideModelParameters: AdditionalModelRequestFields | undefined
+    overrideModelParameters: AdditionalModelRequestFields | undefined,
+    webSearchEnabled?: boolean
   ) => void;
   continueGeneration: (
     generationMode: GenerationMode,
@@ -101,7 +105,8 @@ const useChatState = create<{
     overrideModelType: Model['type'] | undefined,
     setSessionId: (sessionId: string) => void,
     base64Cache: Record<string, string> | undefined,
-    overrideModelParameters: AdditionalModelRequestFields | undefined
+    overrideModelParameters: AdditionalModelRequestFields | undefined,
+    webSearchEnabled?: boolean
   ) => void;
   retryGeneration: (
     generationMode: GenerationMode,
@@ -116,7 +121,8 @@ const useChatState = create<{
     overrideModelType: Model['type'] | undefined,
     setSessionId: (sessionId: string) => void,
     base64Cache: Record<string, string> | undefined,
-    overrideModelParameters: AdditionalModelRequestFields | undefined
+    overrideModelParameters: AdditionalModelRequestFields | undefined,
+    webSearchEnabled?: boolean
   ) => void;
   sendFeedback: (
     id: string,
@@ -390,7 +396,9 @@ const useChatState = create<{
     chunk: string,
     trace?: string,
     model?: Model,
-    metadata?: Metadata
+    metadata?: Metadata,
+    toolUse?: ToolUseInfo,
+    webSearchMetadata?: WebSearchMetadata
   ) => {
     set((state) => {
       const newChats = produce(state.chats, (draft) => {
@@ -401,7 +409,19 @@ const useChatState = create<{
           traceInlineMessage = trace.trim();
         }
 
+        // Tool Use中の場合はトレースとして表示
+        if (toolUse?.status === 'invoking') {
+          traceInlineMessage = `Searching: ${toolUse.toolName}...`;
+        }
+
         const oldAssistantMessage = draft[id].messages.pop()!;
+
+        // WebSearchMetadataをマージ
+        let mergedWebSearchMetadata = oldAssistantMessage.webSearchMetadata;
+        if (webSearchMetadata) {
+          mergedWebSearchMetadata = webSearchMetadata;
+        }
+
         const newAssistantMessage: ShownMessage = {
           ...oldAssistantMessage,
           role: 'assistant',
@@ -416,6 +436,7 @@ const useChatState = create<{
           metadata: metadata || oldAssistantMessage.metadata,
           traceInlineMessage:
             traceInlineMessage ?? oldAssistantMessage.traceInlineMessage,
+          webSearchMetadata: mergedWebSearchMetadata,
         };
         draft[id].messages.push(newAssistantMessage);
       });
@@ -470,7 +491,8 @@ const useChatState = create<{
     base64Cache: Record<string, string> | undefined = undefined,
     overrideModelParameters:
       | AdditionalModelRequestFields
-      | undefined = undefined
+      | undefined = undefined,
+    webSearchEnabled: boolean = false
   ) => {
     const modelId = get().modelIds[id];
 
@@ -569,6 +591,7 @@ const useChatState = create<{
       model: model,
       messages: formattedMessages,
       id: id,
+      webSearchEnabled: webSearchEnabled,
     });
 
     // Update the assistant's message
@@ -612,6 +635,31 @@ const useChatState = create<{
               undefined,
               model,
               payload.metadata
+            );
+          }
+
+          // Tool Use
+          if (payload.toolUse) {
+            addChunkToAssistantMessage(
+              id,
+              '',
+              undefined,
+              model,
+              undefined,
+              payload.toolUse
+            );
+          }
+
+          // Web Search Metadata
+          if (payload.webSearchMetadata) {
+            addChunkToAssistantMessage(
+              id,
+              '',
+              undefined,
+              model,
+              undefined,
+              undefined,
+              payload.webSearchMetadata
             );
           }
 
@@ -846,7 +894,8 @@ const useChatState = create<{
       base64Cache: Record<string, string> | undefined = undefined,
       overrideModelParameters:
         | AdditionalModelRequestFields
-        | undefined = undefined
+        | undefined = undefined,
+      webSearchEnabled: boolean = false
     ) => {
       const unrecordedUserMessage: UnrecordedMessage = {
         role: 'user',
@@ -899,7 +948,8 @@ const useChatState = create<{
         overrideModelType,
         setSessionId,
         base64Cache,
-        overrideModelParameters
+        overrideModelParameters,
+        webSearchEnabled
       );
     },
 
@@ -920,7 +970,8 @@ const useChatState = create<{
       base64Cache: Record<string, string> | undefined = undefined,
       overrideModelParameters:
         | AdditionalModelRequestFields
-        | undefined = undefined
+        | undefined = undefined,
+      webSearchEnabled: boolean = false
     ) => {
       set((state) => {
         const newChats = produce(state.chats, (draft) => {
@@ -963,7 +1014,8 @@ const useChatState = create<{
         overrideModelType,
         setSessionId,
         base64Cache,
-        overrideModelParameters
+        overrideModelParameters,
+        webSearchEnabled
       );
     },
 
@@ -1173,7 +1225,8 @@ ${baseSystemContext}
       base64Cache: Record<string, string> | undefined = undefined,
       overrideModelParameters:
         | AdditionalModelRequestFields
-        | undefined = undefined
+        | undefined = undefined,
+      webSearchEnabled: boolean = false
     ) => {
       post(
         id,
@@ -1188,7 +1241,8 @@ ${baseSystemContext}
         overrideModelType,
         setSessionId,
         base64Cache,
-        overrideModelParameters
+        overrideModelParameters,
+        webSearchEnabled
       );
     },
     postChatWithId: (
@@ -1207,7 +1261,8 @@ ${baseSystemContext}
       base64Cache: Record<string, string> | undefined = undefined,
       overrideModelParameters:
         | AdditionalModelRequestFields
-        | undefined = undefined
+        | undefined = undefined,
+      webSearchEnabled: boolean = false
     ) => {
       post(
         targetId,
@@ -1222,7 +1277,8 @@ ${baseSystemContext}
         overrideModelType,
         setSessionId,
         base64Cache,
-        overrideModelParameters
+        overrideModelParameters,
+        webSearchEnabled
       );
     },
     editChat: (
@@ -1240,7 +1296,8 @@ ${baseSystemContext}
       base64Cache: Record<string, string> | undefined = undefined,
       overrideModelParameters:
         | AdditionalModelRequestFields
-        | undefined = undefined
+        | undefined = undefined,
+      webSearchEnabled: boolean = false
     ) => {
       edit(
         id,
@@ -1255,7 +1312,8 @@ ${baseSystemContext}
         overrideModelType,
         setSessionId,
         base64Cache,
-        overrideModelParameters
+        overrideModelParameters,
+        webSearchEnabled
       );
     },
     continueGeneration: (
@@ -1272,7 +1330,8 @@ ${baseSystemContext}
       base64Cache: Record<string, string> | undefined = undefined,
       overrideModelParameters:
         | AdditionalModelRequestFields
-        | undefined = undefined
+        | undefined = undefined,
+      webSearchEnabled: boolean = false
     ) => {
       continueGeneration(
         'continue',
@@ -1287,7 +1346,8 @@ ${baseSystemContext}
         overrideModelType,
         setSessionId,
         base64Cache,
-        overrideModelParameters
+        overrideModelParameters,
+        webSearchEnabled
       );
     },
     retryGeneration: (
@@ -1304,7 +1364,8 @@ ${baseSystemContext}
       base64Cache: Record<string, string> | undefined = undefined,
       overrideModelParameters:
         | AdditionalModelRequestFields
-        | undefined = undefined
+        | undefined = undefined,
+      webSearchEnabled: boolean = false
     ) => {
       retryGeneration(
         'retry',
@@ -1319,7 +1380,8 @@ ${baseSystemContext}
         overrideModelType,
         setSessionId,
         base64Cache,
-        overrideModelParameters
+        overrideModelParameters,
+        webSearchEnabled
       );
     },
     sendFeedback: async (feedbackData: UpdateFeedbackRequest) => {

--- a/packages/web/src/hooks/useModel.ts
+++ b/packages/web/src/hooks/useModel.ts
@@ -8,11 +8,27 @@ import {
   modelMetadata as originalModelMetadata,
 } from '@generative-ai-use-cases/common';
 
+/**
+ * 環境変数から安全にJSONをパースする
+ * 空文字列やundefinedの場合はfallbackを返す
+ */
+const safeJsonParse = <T>(jsonString: string | undefined, fallback: T): T => {
+  if (!jsonString || jsonString.trim() === '') {
+    return fallback;
+  }
+  try {
+    return JSON.parse(jsonString) as T;
+  } catch {
+    return fallback;
+  }
+};
+
 const modelRegion = import.meta.env.VITE_APP_MODEL_REGION;
 
 // Get model names and other environment variables
-const bedrockModelConfigs = (
-  JSON.parse(import.meta.env.VITE_APP_MODEL_IDS) as ModelConfiguration[]
+const bedrockModelConfigs = safeJsonParse<ModelConfiguration[]>(
+  import.meta.env.VITE_APP_MODEL_IDS,
+  []
 )
   .map((model) => ({
     modelId: model.modelId.trim(),
@@ -38,14 +54,16 @@ const visionModelIds: string[] = bedrockModelIds.filter(
 );
 const visionEnabled: boolean = visionModelIds.length > 0;
 
-const endpointNames: string[] = JSON.parse(
-  import.meta.env.VITE_APP_ENDPOINT_NAMES
+const endpointNames: string[] = safeJsonParse<string[]>(
+  import.meta.env.VITE_APP_ENDPOINT_NAMES,
+  []
 )
   .map((name: string) => name.trim())
   .filter((name: string) => name);
 
-const imageModelConfigs = (
-  JSON.parse(import.meta.env.VITE_APP_IMAGE_MODEL_IDS) as ModelConfiguration[]
+const imageModelConfigs = safeJsonParse<ModelConfiguration[]>(
+  import.meta.env.VITE_APP_IMAGE_MODEL_IDS,
+  []
 )
   .map(
     (model: ModelConfiguration): ModelConfiguration => ({
@@ -58,8 +76,9 @@ const imageGenModelIds: string[] = imageModelConfigs.map(
   (model) => model.modelId
 );
 
-const videoModelConfigs = (
-  JSON.parse(import.meta.env.VITE_APP_VIDEO_MODEL_IDS) as ModelConfiguration[]
+const videoModelConfigs = safeJsonParse<ModelConfiguration[]>(
+  import.meta.env.VITE_APP_VIDEO_MODEL_IDS,
+  []
 )
   .map(
     (model: ModelConfiguration): ModelConfiguration => ({
@@ -71,10 +90,9 @@ const videoModelConfigs = (
 const videoGenModelIds: string[] = videoModelConfigs.map(
   (model) => model.modelId
 );
-const speechToSpeechModelConfigs = (
-  JSON.parse(
-    import.meta.env.VITE_APP_SPEECH_TO_SPEECH_MODEL_IDS
-  ) as ModelConfiguration[]
+const speechToSpeechModelConfigs = safeJsonParse<ModelConfiguration[]>(
+  import.meta.env.VITE_APP_SPEECH_TO_SPEECH_MODEL_IDS,
+  []
 )
   .map(
     (model: ModelConfiguration): ModelConfiguration => ({
@@ -87,7 +105,10 @@ const speechToSpeechModelIds: string[] = speechToSpeechModelConfigs.map(
   (model) => model.modelId
 );
 
-const agentNames: string[] = JSON.parse(import.meta.env.VITE_APP_AGENT_NAMES)
+const agentNames: string[] = safeJsonParse<string[]>(
+  import.meta.env.VITE_APP_AGENT_NAMES,
+  []
+)
   .map((name: string) => name.trim())
   .filter((name: string) => name);
 

--- a/packages/web/src/pages/ChatPage.tsx
+++ b/packages/web/src/pages/ChatPage.tsx
@@ -10,6 +10,7 @@ import ButtonCopy from '../components/ButtonCopy';
 import ModalDialog from '../components/ModalDialog';
 import ExpandableField from '../components/ExpandableField';
 import ModelSelector from '../components/ModelSelector';
+import Switch from '../components/Switch';
 import useFollow from '../hooks/useFollow';
 import { create } from 'zustand';
 import { ChatPageQueryParams } from '../@types/navigate';
@@ -26,6 +27,7 @@ import { AcceptedDotExtensions } from '../utils/MediaUtils';
 import { useTranslation } from 'react-i18next';
 import LoadingWave from '../components/LoadingWave';
 import { useSettings } from '../hooks/useSettings';
+import { PiGlobeSimple } from 'react-icons/pi';
 
 const fileLimit: FileLimit = {
   accept: AcceptedDotExtensions,
@@ -106,6 +108,7 @@ const ChatPage: React.FC = () => {
     AdditionalModelRequestFields | undefined
   >(undefined);
   const [showSetting, setShowSetting] = useState(false);
+  const [webSearchEnabled, setWebSearchEnabled] = useState(false);
   const { t } = useTranslation();
   const { settings } = useSettings();
 
@@ -230,7 +233,8 @@ ${baseContext}
       undefined,
       undefined,
       base64Cache,
-      overrideModelParameters
+      overrideModelParameters,
+      webSearchEnabled
     );
     setContent('');
     clearFiles();
@@ -249,6 +253,7 @@ ${baseContext}
     postChatWithId,
     uploadedFiles,
     pathname,
+    webSearchEnabled,
   ]);
 
   const onRetry = useCallback(() => {
@@ -262,9 +267,10 @@ ${baseContext}
       undefined,
       undefined,
       base64Cache,
-      overrideModelParameters
+      overrideModelParameters,
+      webSearchEnabled
     );
-  }, [retryGeneration, base64Cache, overrideModelParameters]);
+  }, [retryGeneration, base64Cache, overrideModelParameters, webSearchEnabled]);
 
   const onStop = useCallback(() => {
     forceToStop();
@@ -284,10 +290,11 @@ ${baseContext}
         undefined,
         undefined,
         base64Cache,
-        overrideModelParameters
+        overrideModelParameters,
+        webSearchEnabled
       );
     },
-    [editChat, base64Cache, setFollowing, overrideModelParameters]
+    [editChat, base64Cache, setFollowing, overrideModelParameters, webSearchEnabled]
   );
 
   const [creatingShareId, setCreatingShareId] = useState(false);
@@ -384,6 +391,18 @@ ${baseContext}
             })}
             featuredModelIds={featuredModelIds}
           />
+
+          {/* Web Search Toggle */}
+          {import.meta.env.VITE_APP_WEB_SEARCH_IN_CHAT_ENABLED === 'true' && (
+            <div className="flex items-center gap-1">
+              <PiGlobeSimple className="size-4 text-gray-500" />
+              <Switch
+                checked={webSearchEnabled}
+                onSwitch={setWebSearchEnabled}
+                label={t('chat.webSearch.toggle_label')}
+              />
+            </div>
+          )}
 
           {/* Spacer */}
           <div className="flex-1" />

--- a/packages/web/src/vite-env.d.ts
+++ b/packages/web/src/vite-env.d.ts
@@ -35,6 +35,7 @@ interface ImportMetaEnv {
   readonly VITE_APP_MCP_ENABLED: string;
   readonly VITE_APP_MCP_ENDPOINT: string;
   readonly VITE_APP_PPTX_ENABLED: string;
+  readonly VITE_APP_WEB_SEARCH_IN_CHAT_ENABLED: string;
 }
 
 interface ImportMeta {

--- a/setup-env.sh
+++ b/setup-env.sh
@@ -54,3 +54,4 @@ export VITE_APP_SPEECH_TO_SPEECH_MODEL_IDS=$(extract_value "$stack_output" Speec
 export VITE_APP_MCP_ENABLED=$(extract_value "$stack_output" McpEnabled)
 export VITE_APP_MCP_ENDPOINT=$(extract_value "$stack_output" McpEndpoint)
 export VITE_APP_ASSISTANT_MESSAGE_STREAM_FUNCTION_ARN=$(extract_value "$stack_output" AssistantMessageStreamFunctionArn)
+export VITE_APP_WEB_SEARCH_IN_CHAT_ENABLED=$(extract_value "$stack_output" WebSearchInChatEnabled)


### PR DESCRIPTION
## Summary

- Converse API + Tool Useパターンを使用して、通常のチャットからWeb検索を呼び出せる機能を実装
- 検索結果URLから本文を取得する深掘り機能
- 検索過程をUIで可視化するWebSearchTraceコンポーネント
- Brave/Tavilyの両検索エンジンに対応（設定で切り替え可能）
- デフォルトはOFF（ユーザーが明示的にトグルでONにする）

## Test plan

- [ ] `cdk.json`で`webSearchInChatEnabled: true`を設定
- [ ] `searchApiKey`に検索エンジンのAPIキーを設定
- [ ] デプロイ後、チャット画面でWeb検索トグルが表示されることを確認
- [ ] Web検索をONにしてメッセージを送信し、検索結果が表示されることを確認
- [ ] WebSearchTraceで検索過程が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)