### PR TITLE
✨  feat(chat) タイトル自動生成の改善：脚注除去とサーバー保存の追加

### DIFF
--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -142,6 +142,7 @@ const useChatState = create<{
     updateFeedback,
     predictStream,
     predictTitle,
+    updateTitle,
   } = useChatApi();
   const { getS3Uri } = useFileApi();
 
@@ -218,7 +219,8 @@ const useChatState = create<{
   };
 
   const setPredictedTitle = async (id: string) => {
-    const currentTitle = get().chats[id].chat?.title;
+    const chat = get().chats[id].chat;
+    const currentTitle = chat?.title;
     if (currentTitle && currentTitle.length > 0) return;
 
     // If the title is an empty string, predict the title and set it
@@ -227,13 +229,18 @@ const useChatState = create<{
     const prompter = getPrompter(modelId);
     const title = await predictTitle({
       model,
-      chat: get().chats[id].chat!,
+      chat: chat!,
       prompt: prompter.setTitlePrompt({
         messages: omitUnusedMessageProperties(get().chats[id].messages),
       }),
       id: '/title',
     });
     setTitle(id, title);
+
+    // Save the title to the server
+    if (chat?.chatId && title && title.trim() !== '') {
+      await updateTitle(chat.chatId, title);
+    }
   };
 
   const createChatIfNotExist = async (id: string): Promise<string> => {
@@ -373,12 +380,17 @@ const useChatState = create<{
   const omitUnusedMessageProperties = (
     messages: ShownMessage[]
   ): UnrecordedMessage[] => {
-    return messages.map((m) => {
-      return {
-        role: m.role,
-        content: m.content,
-      };
-    });
+    return messages
+      .filter((m) => m.role !== 'system')
+      .map((m) => {
+        return {
+          role: m.role,
+          content: m.content
+            .replace(/\[\^0\]:[\s\S]*/s, '')
+            .replace(/\[\^(\d+)\]/g, '')
+            .trim(),
+        };
+      });
   };
 
   const isExactlyCodeBlock = (text: string): boolean => {

--- a/packages/web/src/pages/AssistantChatPage.tsx
+++ b/packages/web/src/pages/AssistantChatPage.tsx
@@ -220,10 +220,14 @@ const AssistantChatPage: React.FC = () => {
       }
 
       // Convert assistant messages to the format needed for title generation
+      // Remove footnotes from content for cleaner title generation
       const messagesForTitle: UnrecordedMessage[] = response.messages.map(
         (msg) => ({
           role: msg.role,
-          content: msg.content,
+          content: msg.content
+            .replace(/\[\^0\]:[\s\S]*/s, '')
+            .replace(/\[\^(\d+)\]/g, '')
+            .trim(),
         })
       );
 
@@ -247,6 +251,7 @@ const AssistantChatPage: React.FC = () => {
       // Update the title
       if (title && title.trim() !== '') {
         await updateTitle(newChatId, title);
+        mutateChatList();
       }
     } catch (error) {
       console.error('Failed to generate chat title:', error);


### PR DESCRIPTION
## Summary
- タイトル生成時にメッセージから脚注（`[^0]:...`形式）を除去してクリーンなタイトルを生成
- systemロールのメッセージをタイトル生成対象から除外
- 生成したタイトルをサーバーに保存し、チャットリストを即時更新

## Changes
- `useChat.ts`: `updateTitle` APIを使用してタイトルをサーバーに保存
- `useChat.ts`: `omitUnusedMessageProperties`でsystemメッセージ除外と脚注削除を追加
- `AssistantChatPage.tsx`: タイトル生成用メッセージから脚注を除去、`mutateChatList()`でリスト更新

## Test plan
- [ ] チャットでメッセージを送信し、タイトルが正しく生成されることを確認
- [ ] 脚注を含むメッセージでもタイトルに脚注が含まれないことを確認
- [ ] 生成されたタイトルがサイドバーのチャットリストに即時反映されることを確認
