### PR TITLE
画像の入力制限の対応を追加

### DIFF
--- a/packages/cdk/lambda/billing/admin/plan-management/createPlan.ts
+++ b/packages/cdk/lambda/billing/admin/plan-management/createPlan.ts
@@ -31,11 +31,11 @@ function generateEntitlementId(planId: string): string {
 
 /**
  * featureIdからリソースタイプとIDを抽出する
- * @param featureId 機能ID (例: "llm:gemini-2.5-flash", "assistant:chat", or "chat")
- * @returns { type: 'llm' | 'assistant' | 'feature', id: string }
+ * @param featureId 機能ID (例: "llm:gemini-2.5-flash", "assistant:chat", "prompt-media:image", or "chat")
+ * @returns { type: 'llm' | 'assistant' | 'prompt-media' | 'feature', id: string }
  */
 function parseFeatureId(featureId: string): {
-  type: 'llm' | 'assistant' | 'feature';
+  type: 'llm' | 'assistant' | 'prompt-media' | 'feature';
   id: string;
 } {
   if (featureId.startsWith('llm:')) {
@@ -43,6 +43,9 @@ function parseFeatureId(featureId: string): {
   }
   if (featureId.startsWith('assistant:')) {
     return { type: 'assistant', id: featureId.substring(10) };
+  }
+  if (featureId.startsWith('prompt-media:')) {
+    return { type: 'prompt-media', id: featureId.substring(13) };
   }
   return { type: 'feature', id: featureId };
 }
@@ -75,6 +78,12 @@ async function registerEntitlementToOpenFga(
         user: `entitlement:${entitlementId}`,
         relation: 'via_access',
         object: `assistant:${id}`,
+      };
+    } else if (type === 'prompt-media') {
+      return {
+        user: `entitlement:${entitlementId}`,
+        relation: 'via_access',
+        object: `prompt-media:${id}`,
       };
     } else {
       return {

--- a/packages/cdk/lambda/billing/user-api/usage/getUsageStatus.ts
+++ b/packages/cdk/lambda/billing/user-api/usage/getUsageStatus.ts
@@ -131,6 +131,7 @@ function getRelationForFeatureType(featureId: string): string {
   switch (type) {
     case 'llm':
     case 'assistant':
+    case 'prompt-media':
       return 'accessor';
     case 'feature':
       return 'enabled_user';

--- a/packages/cdk/lambda/predictStream.ts
+++ b/packages/cdk/lambda/predictStream.ts
@@ -29,8 +29,7 @@ declare global {
 function countImages(messages: UnrecordedMessage[]): number {
   return messages
     .flatMap((m) => m.extraData ?? [])
-    .filter((e) => e.type === 'image')
-    .length;
+    .filter((e) => e.type === 'image').length;
 }
 
 export const handler = awslambda.streamifyResponse(
@@ -95,8 +94,10 @@ export const handler = awslambda.streamifyResponse(
         return;
       }
 
-      // Count images in the request
-      const imageCount = countImages(event.messages);
+      // Count images in the current user message only (last message)
+      // 過去のメッセージに含まれる画像は既にカウント済みなので、今回送信されたメッセージのみをカウント対象とする
+      const lastMessage = event.messages[event.messages.length - 1];
+      const imageCount = lastMessage ? countImages([lastMessage]) : 0;
 
       // Check image input limit if there are images
       if (imageCount > 0) {
@@ -135,7 +136,10 @@ export const handler = awslambda.streamifyResponse(
       }
 
       // Increment usage count after successful streaming and return latest usage info
-      if (accessCheckResult.limitType && accessCheckResult.limitType !== 'unlimited') {
+      if (
+        accessCheckResult.limitType &&
+        accessCheckResult.limitType !== 'unlimited'
+      ) {
         try {
           await incrementUsage(
             event.idToken,
@@ -145,7 +149,11 @@ export const handler = awslambda.streamifyResponse(
           );
 
           // Get latest usage info after incrementing
-          const latestUsage = await getLatestUsage(event.idToken, 'llm', model.modelId);
+          const latestUsage = await getLatestUsage(
+            event.idToken,
+            'llm',
+            model.modelId
+          );
 
           // Send final chunk with updated usage info
           if (latestUsage) {
@@ -167,7 +175,9 @@ export const handler = awslambda.streamifyResponse(
         mediaCheckResult.limitType &&
         mediaCheckResult.limitType !== 'unlimited'
       ) {
-        const imageCount = countImages(event.messages);
+        // チェック時と同じく、最後のメッセージのみを対象とする
+        const lastMsg = event.messages[event.messages.length - 1];
+        const imageCount = lastMsg ? countImages([lastMsg]) : 0;
         try {
           await incrementUsage(
             event.idToken,

--- a/packages/cdk/lambda/predictStream.ts
+++ b/packages/cdk/lambda/predictStream.ts
@@ -1,5 +1,5 @@
 import { Handler, Context } from 'aws-lambda';
-import { PredictRequest } from 'generative-ai-use-cases';
+import { PredictRequest, UnrecordedMessage } from 'generative-ai-use-cases';
 import api from './utils/api';
 import { defaultModel } from './utils/models';
 import {
@@ -21,11 +21,24 @@ declare global {
   }
 }
 
+/**
+ * メッセージ配列から画像ファイルの数をカウントする
+ * @param messages メッセージ配列
+ * @returns 画像ファイルの数
+ */
+function countImages(messages: UnrecordedMessage[]): number {
+  return messages
+    .flatMap((m) => m.extraData ?? [])
+    .filter((e) => e.type === 'image')
+    .length;
+}
+
 export const handler = awslambda.streamifyResponse(
   async (event, responseStream, context) => {
     context.callbackWaitsForEmptyEventLoop = false;
 
     let accessCheckResult: AccessCheckResult | null = null;
+    let mediaCheckResult: AccessCheckResult | null = null;
 
     try {
       const model = event.model || defaultModel;
@@ -75,10 +88,40 @@ export const handler = awslambda.streamifyResponse(
         const errorMessage = JSON.stringify({
           text: errorText,
           stopReason: 'error',
+          errorReason: accessCheckResult.reason,
         });
         responseStream.write(errorMessage);
         responseStream.end();
         return;
+      }
+
+      // Count images in the request
+      const imageCount = countImages(event.messages);
+
+      // Check image input limit if there are images
+      if (imageCount > 0) {
+        mediaCheckResult = await checkAccessWithQuota(
+          event.idToken,
+          'prompt-media',
+          'image',
+          imageCount
+        );
+
+        if (!mediaCheckResult.allowed) {
+          const userId = mediaCheckResult.userContext?.userId || 'unknown';
+          console.warn(
+            `User ${userId} has exceeded image input limit - requested: ${imageCount}`
+          );
+
+          const errorMessage = JSON.stringify({
+            text: `画像入力の利用回数上限に達しました（リクエスト: ${imageCount}枚）`,
+            stopReason: 'error',
+            errorReason: 'media_limit_exceeded',
+          });
+          responseStream.write(errorMessage);
+          responseStream.end();
+          return;
+        }
       }
 
       // If authorized, proceed with streaming
@@ -115,6 +158,29 @@ export const handler = awslambda.streamifyResponse(
           }
         } catch (error) {
           console.error('Failed to increment usage count:', error);
+        }
+      }
+
+      // Increment image usage count after successful streaming
+      if (
+        mediaCheckResult &&
+        mediaCheckResult.limitType &&
+        mediaCheckResult.limitType !== 'unlimited'
+      ) {
+        const imageCount = countImages(event.messages);
+        try {
+          await incrementUsage(
+            event.idToken,
+            'prompt-media',
+            'image',
+            mediaCheckResult.limitType,
+            imageCount
+          );
+          console.log(
+            `[PredictStream] Image usage incremented - count: ${imageCount}`
+          );
+        } catch (error) {
+          console.error('Failed to increment image usage count:', error);
         }
       }
 

--- a/packages/cdk/lambda/utils/accessChecker.ts
+++ b/packages/cdk/lambda/utils/accessChecker.ts
@@ -43,8 +43,9 @@ export interface AccessCheckResult {
  * リソースタイプの定義
  * - llm: LLMモデル（例: gemini-2.5-flash）
  * - assistant: アシスタント機能（例: chat）
+ * - prompt-media: プロンプトに含めるメディア（例: image）
  */
-export type ResourceType = 'llm' | 'assistant';
+export type ResourceType = 'llm' | 'assistant' | 'prompt-media';
 
 /**
  * テーブル名を生成するヘルパー関数
@@ -105,12 +106,14 @@ export function buildFeatureId(
  * @param idToken - Cognito ID Token
  * @param resourceType - リソースの種別（例: 'llm'）
  * @param resourceId - リソースのID（例: 'gemini-2.5-flash'）
+ * @param requestedCount - 今回リクエストする利用回数（デフォルト: 1）
  * @returns AccessCheckResult - アクセス可否と使用状況
  */
 export async function checkAccessWithQuota(
   idToken: string,
   resourceType: ResourceType,
-  resourceId: string
+  resourceId: string,
+  requestedCount: number = 1
 ): Promise<AccessCheckResult> {
   // 1. トークン検証とユーザー情報の取得
   const payload = await verifyToken(idToken);
@@ -246,7 +249,7 @@ export async function checkAccessWithQuota(
       );
 
       console.log(
-        `[AccessCheck] Daily limit found - currentCount: ${dailyCount}, limitCount: ${dailyLimit}`
+        `[AccessCheck] Daily limit found - currentCount: ${dailyCount}, limitCount: ${dailyLimit}, requestedCount: ${requestedCount}`
       );
 
       const remaining = dailyLimit - dailyCount;
@@ -256,9 +259,9 @@ export async function checkAccessWithQuota(
         remaining: Math.max(0, remaining),
       };
 
-      if (dailyCount >= dailyLimit) {
+      if (dailyCount + requestedCount > dailyLimit) {
         console.log(
-          `[AccessCheck] Daily quota exceeded - User ${userId}, featureId: ${featureId}, current: ${dailyCount}, limit: ${dailyLimit}`
+          `[AccessCheck] Daily quota exceeded - User ${userId}, featureId: ${featureId}, current: ${dailyCount}, requested: ${requestedCount}, limit: ${dailyLimit}`
         );
         return {
           allowed: false,
@@ -269,7 +272,7 @@ export async function checkAccessWithQuota(
         };
       }
       console.log(
-        `[AccessCheck] Daily quota check passed - remaining: ${remaining}`
+        `[AccessCheck] Daily quota check passed - remaining: ${remaining}, requested: ${requestedCount}`
       );
     } else {
       console.log(`[AccessCheck] No daily limit configured for ${featureId}`);
@@ -286,7 +289,7 @@ export async function checkAccessWithQuota(
       );
 
       console.log(
-        `[AccessCheck] Monthly limit found - currentCount: ${monthlyCount}, limitCount: ${monthlyLimit}`
+        `[AccessCheck] Monthly limit found - currentCount: ${monthlyCount}, limitCount: ${monthlyLimit}, requestedCount: ${requestedCount}`
       );
 
       const remaining = monthlyLimit - monthlyCount;
@@ -296,9 +299,9 @@ export async function checkAccessWithQuota(
         remaining: Math.max(0, remaining),
       };
 
-      if (monthlyCount >= monthlyLimit) {
+      if (monthlyCount + requestedCount > monthlyLimit) {
         console.log(
-          `[AccessCheck] Monthly quota exceeded - User ${userId}, featureId: ${featureId}, current: ${monthlyCount}, limit: ${monthlyLimit}`
+          `[AccessCheck] Monthly quota exceeded - User ${userId}, featureId: ${featureId}, current: ${monthlyCount}, requested: ${requestedCount}, limit: ${monthlyLimit}`
         );
         return {
           allowed: false,
@@ -309,7 +312,7 @@ export async function checkAccessWithQuota(
         };
       }
       console.log(
-        `[AccessCheck] Monthly quota check passed - remaining: ${remaining}`
+        `[AccessCheck] Monthly quota check passed - remaining: ${remaining}, requested: ${requestedCount}`
       );
     } else {
       console.log(`[AccessCheck] No monthly limit configured for ${featureId}`);
@@ -479,23 +482,33 @@ export async function getLatestUsage(
  * @param resourceType - リソースの種別（例: 'llm'）
  * @param resourceId - リソースのID（例: 'gemini-2.5-flash'）
  * @param limitType - 回数制限のタイプ（checkAccessWithQuotaの結果から取得）
+ * @param count - 記録するイベント数（デフォルト: 1）
  */
 export async function incrementUsage(
   idToken: string,
   resourceType: ResourceType,
   resourceId: string,
-  limitType: 'unlimited' | 'daily' | 'monthly'
+  limitType: 'unlimited' | 'daily' | 'monthly',
+  count: number = 1
 ): Promise<void> {
   const featureId = buildFeatureId(resourceType, resourceId);
 
   console.log(
-    `[IncrementUsage] Start - featureId: ${featureId}, limitType: ${limitType}`
+    `[IncrementUsage] Start - featureId: ${featureId}, limitType: ${limitType}, count: ${count}`
   );
 
   // unlimitedの場合はイベント記録不要
   if (limitType === 'unlimited') {
     console.log(
       `[IncrementUsage] Skipping event recording for unlimited feature: ${featureId}`
+    );
+    return;
+  }
+
+  // countが0以下の場合は何もしない
+  if (count <= 0) {
+    console.log(
+      `[IncrementUsage] Skipping event recording for count: ${count}`
     );
     return;
   }
@@ -517,7 +530,7 @@ export async function incrementUsage(
   }
 
   console.log(
-    `[IncrementUsage] Parameters - tenantId: ${tenantId}, userId: ${userId}, featureId: ${featureId}, limitType: ${limitType}`
+    `[IncrementUsage] Parameters - tenantId: ${tenantId}, userId: ${userId}, featureId: ${featureId}, limitType: ${limitType}, count: ${count}`
   );
 
   try {
@@ -534,22 +547,25 @@ export async function incrementUsage(
       usageEventTableName
     );
 
-    const now = Date.now();
-    const ttl = Math.floor(now / 1000) + 120 * 24 * 60 * 60; // 120日後に自動削除
+    const ttl = Math.floor(Date.now() / 1000) + 120 * 24 * 60 * 60; // 120日後に自動削除
 
     console.log(
-      `[IncrementUsage] Recording usage event - tableName: ${usageEventTableName}, userId: ${userId}, featureId: ${featureId}, timestamp: ${now}`
+      `[IncrementUsage] Recording ${count} usage event(s) - tableName: ${usageEventTableName}, userId: ${userId}, featureId: ${featureId}`
     );
 
-    await usageEventRepository.recordEvent({
-      userId,
-      timestamp: now,
-      featureId,
-      ttl,
-    });
+    // count回分のイベントを記録する
+    for (let i = 0; i < count; i++) {
+      const now = Date.now();
+      await usageEventRepository.recordEvent({
+        userId,
+        timestamp: now,
+        featureId,
+        ttl,
+      });
+    }
 
     console.log(
-      `[IncrementUsage] Success - user: ${userId}, feature: ${featureId}, timestamp: ${now}`
+      `[IncrementUsage] Success - user: ${userId}, feature: ${featureId}, count: ${count}`
     );
   } catch (error) {
     // イベント記録に失敗しても処理を止めない（ログのみ）

--- a/packages/cdk/lib/stacks/tenant/custom-resources/openFgaSchema.ts
+++ b/packages/cdk/lib/stacks/tenant/custom-resources/openFgaSchema.ts
@@ -16,6 +16,14 @@
  *   relations
  *     define via_access: [entitlement]
  *     define accessor: [user, group] or holder from via_access
+ * type assistant
+ *   relations
+ *     define via_access: [entitlement]
+ *     define accessor: [user, group] or holder from via_access
+ * type prompt-media
+ *   relations
+ *     define via_access: [entitlement]
+ *     define accessor: [user, group] or holder from via_access
  * type feature
  *   relations
  *     define via_enable: [entitlement]
@@ -98,6 +106,37 @@ export const AUTHORIZATION_MODEL_TYPE_DEFINITIONS = [
   },
   {
     type: 'assistant',
+    relations: {
+      via_access: {
+        this: {},
+      },
+      accessor: {
+        union: {
+          child: [
+            { this: {} },
+            { tupleToUserset: { tupleset: { relation: 'via_access' }, computedUserset: { relation: 'holder' } } },
+          ],
+        },
+      },
+    },
+    metadata: {
+      relations: {
+        via_access: {
+          directly_related_user_types: [
+            { type: 'entitlement' },
+          ],
+        },
+        accessor: {
+          directly_related_user_types: [
+            { type: 'user' },
+            { type: 'group', relation: 'member' },
+          ],
+        },
+      },
+    },
+  },
+  {
+    type: 'prompt-media',
     relations: {
       via_access: {
         this: {},

--- a/packages/types/src/protocol.d.ts
+++ b/packages/types/src/protocol.d.ts
@@ -19,11 +19,25 @@ import { GenerateImageParams } from './image';
 import { GenerateVideoParams, VideoJob } from './video';
 import { ShareId, UserIdAndChatId } from './share';
 
+/**
+ * エラー理由の型定義
+ * - no_permission: 権限がない
+ * - quota_exceeded: 利用回数制限超過
+ * - media_limit_exceeded: メディア入力制限超過
+ * - invalid_token: トークンが無効
+ */
+export type StreamingErrorReason =
+  | 'no_permission'
+  | 'quota_exceeded'
+  | 'media_limit_exceeded'
+  | 'invalid_token';
+
 export type StreamingChunk = {
   text: string;
   trace?: string;
   metadata?: Metadata;
   stopReason?: StopReason | 'error';
+  errorReason?: StreamingErrorReason;
   sessionId?: string;
   usage?: {
     daily?: { current: number; limit: number; remaining: number };


### PR DESCRIPTION
## 変更の概要
チャット機能において、画像入力を枚数単位で制限する機能を追加

## 申し送り事項

<!-- レビュワーに伝えておきたい事柄等を書く（Draftの理由など） -->

## Checklist（レビュワー用）

- [ ] `npm run lint`でエラーが出ない
- [ ] TypeScriptのビルドで型エラーが出ない
- [ ] 手元でフォーマットした際に差分が出ない
