### PR TITLE
:bug: fix(transcribe): 議事録生成でmp4ファイルアップロードに失敗する問題を修正

### DIFF
--- a/packages/cdk/lambda/getTranscription.ts
+++ b/packages/cdk/lambda/getTranscription.ts
@@ -29,8 +29,9 @@ export const handler = async (
 ): Promise<APIGatewayProxyResult> => {
   try {
     const jobName = event.pathParameters!.jobName;
-    // Use flat context - Lambda Request Authorizer provides sub at top level
-    const userId = event.requestContext.authorizer!.sub;
+    // Cognito User Pools Authorizer provides claims as nested object
+    const userId = (event.requestContext.authorizer!.claims as { sub: string })
+      .sub;
     const tenantId = getTenantId(event);
 
     console.log(

--- a/packages/cdk/lambda/startTranscription.ts
+++ b/packages/cdk/lambda/startTranscription.ts
@@ -24,8 +24,9 @@ export const handler = async (
 ): Promise<APIGatewayProxyResult> => {
   try {
     const req: StartTranscriptionRequest = JSON.parse(event.body!);
-    // Use flat context - Lambda Request Authorizer provides sub at top level
-    const userId = event.requestContext.authorizer!.sub;
+    // Cognito User Pools Authorizer provides claims as nested object
+    const userId = (event.requestContext.authorizer!.claims as { sub: string })
+      .sub;
     const tenantId = getTenantId(event);
 
     console.log(


### PR DESCRIPTION
## Summary

- Transcribe API で `CognitoUserPoolsAuthorizer` を使用しているが、Lambda関数のコードが `Lambda Request Authorizer` のフラット構造を想定していたため `userId` が `undefined` になり、AWS Transcribe API のタグバリデーションエラーが発生していた問題を修正
- `startTranscription.ts` と `getTranscription.ts` で `authorizer.claims.sub` を使用してユーザーIDを取得するように変更

## Test plan

- [ ] 議事録生成機能でMP4ファイルをアップロードし、500エラーが発生しないことを確認
- [ ] CloudWatch Logsで `user: undefined` ではなく正しいユーザーIDがログに出力されることを確認
- [ ] 文字起こし結果が正常に取得できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)