### PR TITLE
:sparkles: feat(billing): ペアレンタルコントロール新規購入の保留状態管理とステータス確認APIの追加

### DIFF
--- a/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
+++ b/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
@@ -81,6 +81,10 @@ const dynamoDbClient = new DynamoDBClient({});
 const PENDING_PLAN_CHANGES_TABLE_NAME =
   process.env.PENDING_PLAN_CHANGES_TABLE_NAME || '';
 
+// ペアレンタルコントロール用新規購入リクエストテーブル
+const PENDING_PARENTAL_CHECKOUTS_TABLE_NAME =
+  process.env.PENDING_PARENTAL_CHECKOUTS_TABLE_NAME || '';
+
 /**
  * デフォルトプランを取得
  * データベースからis_default=trueのプランを取得する
@@ -2261,8 +2265,14 @@ async function handleParentalControlActivation(
   // イベントデータから抽出情報を取得
   const stripeData = eventData as StripeEventData;
   const extracted = stripeData._extracted ?? {};
-  const { sessionId, platformSubscriptionId, userId, planId, childEmail } =
-    extracted;
+  const {
+    sessionId,
+    platformSubscriptionId,
+    userId,
+    planId,
+    childEmail,
+    parentalCheckoutRequestId,
+  } = extracted;
 
   console.log('Extracted parental control data from event', {
     sessionId,
@@ -2270,6 +2280,7 @@ async function handleParentalControlActivation(
     userId,
     planId,
     childEmail,
+    parentalCheckoutRequestId,
     hasExtracted: !!stripeData._extracted,
   });
 
@@ -2288,6 +2299,9 @@ async function handleParentalControlActivation(
   if (!planId) {
     throw new Error('Plan ID not found in event data');
   }
+
+  // ステップ間でデータを共有するための変数
+  let activatedSubscriptionId: string | undefined;
 
   // ステップ設定
   const steps: StepConfig[] = [
@@ -2369,6 +2383,9 @@ async function handleParentalControlActivation(
           );
         }
 
+        // 次のステップで使用するためにsubscriptionIdを保存
+        activatedSubscriptionId = flowOutput.subscriptionId;
+
         return {
           success: true,
           subscriptionId: flowOutput.subscriptionId,
@@ -2377,6 +2394,63 @@ async function handleParentalControlActivation(
       },
       retryable: true,
       maxRetries: 3,
+    },
+
+    // ステップ1.5: ペアレンタルチェックアウトリクエストのステータスを更新
+    {
+      stepName: 'update_parental_checkout_request_status',
+      stepType: 'api_call',
+      targetService: 'DynamoDB',
+      executeFunction: async () => {
+        if (!parentalCheckoutRequestId) {
+          console.warn(
+            'Parental checkout request ID not found in metadata, skipping status update'
+          );
+          return { skipped: true, reason: 'no_request_id_in_metadata' };
+        }
+
+        if (!PENDING_PARENTAL_CHECKOUTS_TABLE_NAME) {
+          console.warn(
+            'PENDING_PARENTAL_CHECKOUTS_TABLE_NAME not configured, skipping status update'
+          );
+          return { skipped: true, reason: 'table_not_configured' };
+        }
+
+        // クロージャ変数からsubscriptionIdを取得（ステップ1で設定）
+        const subscriptionId = activatedSubscriptionId || '';
+
+        console.log('Updating parental checkout request status to approved', {
+          parentalCheckoutRequestId,
+          subscriptionId,
+        });
+
+        await dynamoDbClient.send(
+          new UpdateItemCommand({
+            TableName: PENDING_PARENTAL_CHECKOUTS_TABLE_NAME,
+            Key: {
+              requestId: { S: parentalCheckoutRequestId as string },
+            },
+            UpdateExpression:
+              'SET #status = :status, approvedAt = :approvedAt, subscriptionId = :subscriptionId',
+            ExpressionAttributeNames: {
+              '#status': 'status',
+            },
+            ExpressionAttributeValues: {
+              ':status': { S: 'approved' },
+              ':approvedAt': { N: Date.now().toString() },
+              ':subscriptionId': { S: subscriptionId },
+            },
+          })
+        );
+
+        console.log('Parental checkout request status updated to approved', {
+          parentalCheckoutRequestId,
+        });
+
+        return { success: true, parentalCheckoutRequestId };
+      },
+      retryable: true,
+      maxRetries: 2,
     },
 
     // ステップ2: 領収書メール送信（ペアレンタルコントロール：保護者に送信）

--- a/packages/cdk/lambda/billing/orchestration/types/eventTypes.ts
+++ b/packages/cdk/lambda/billing/orchestration/types/eventTypes.ts
@@ -110,6 +110,7 @@ export interface StripeEventData {
     planId?: string;
     childEmail?: string;
     parentEmail?: string;
+    parentalCheckoutRequestId?: string;
     // サブスクリプション更新（プラン変更）用フィールド
     subscriptionId?: string;
     currentPriceId?: string;

--- a/packages/cdk/lambda/billing/payment-gateway/webhook/stripe/eventExtractor.ts
+++ b/packages/cdk/lambda/billing/payment-gateway/webhook/stripe/eventExtractor.ts
@@ -505,6 +505,7 @@ function extractFromParentalControlCheckout(
   const userId = metadata.userId ?? '';
   const planId = metadata.planId ?? '';
   const childEmail = metadata.childEmail ?? '';
+  const parentalCheckoutRequestId = metadata.parentalCheckoutRequestId ?? '';
 
   // StripeのサブスクリプションIDを取得
   const platformSubscriptionId =
@@ -545,6 +546,7 @@ function extractFromParentalControlCheckout(
         planId,
         childEmail,
         parentEmail: metadata.parentEmail ?? '',
+        parentalCheckoutRequestId,
       },
     },
   };

--- a/packages/cdk/lambda/billing/user-api/subscriptions/getParentalCheckoutRequestStatus.ts
+++ b/packages/cdk/lambda/billing/user-api/subscriptions/getParentalCheckoutRequestStatus.ts
@@ -1,0 +1,215 @@
+/**
+ * Get Parental Checkout Request Status API
+ *
+ * 保留中のペアレンタルコントロール新規購入リクエストのステータスを取得するAPI。
+ * フロントエンドが保護者の決済完了をポーリングで検知するために使用します。
+ */
+
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import {
+  DynamoDBClient,
+  GetItemCommand,
+  UpdateItemCommand,
+} from '@aws-sdk/client-dynamodb';
+import { getTenantId } from '../../../utils/tenantUtils';
+import { getUserIdFromCognitoEvent } from '../../../utils/cognitoUtils';
+import {
+  ok200Response,
+  badRequest400Response,
+  unauthorized401Response,
+  notFound404Response,
+  internalServerError500Response,
+} from '../../../utils/apiResponse';
+
+const PENDING_PARENTAL_CHECKOUTS_TABLE_NAME =
+  process.env.PENDING_PARENTAL_CHECKOUTS_TABLE_NAME || '';
+
+/**
+ * レスポンスボディの型（フロントエンドAPI契約）
+ */
+interface ParentalCheckoutRequestStatusResponse {
+  /** リクエストID */
+  requestId: string;
+  /** ステータス */
+  status: 'pending' | 'approved' | 'expired';
+  /** プランID */
+  planId: string;
+  /** 保護者のメールアドレス */
+  parentEmail: string;
+  /** 作成日時（Unix timestamp） */
+  createdAt: number;
+  /** 有効期限（Unix timestamp） */
+  expiresAt: number;
+  /** 承認日時（Unix timestamp、承認済みの場合のみ） */
+  approvedAt?: number;
+  /** サブスクリプションID（承認済みの場合のみ） */
+  subscriptionId?: string;
+}
+
+/**
+ * DynamoDB Client
+ */
+const dynamoDbClient = new DynamoDBClient({});
+
+/**
+ * Lambda関数のメインハンドラー
+ */
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  console.log(
+    'User API: Get Parental Checkout Request Status request received'
+  );
+
+  try {
+    // 1. 認証情報からユーザID、テナントIDを取得
+    const userId = getUserIdFromCognitoEvent(event);
+    const tenantId = getTenantId(event);
+
+    if (!userId || !tenantId) {
+      console.error('Missing authentication information');
+      return unauthorized401Response({
+        message: '認証が必要です',
+        code: 'UNAUTHORIZED',
+        details: undefined,
+      });
+    }
+
+    console.log('Request context:', { userId, tenantId });
+
+    // 2. パスパラメータからrequestIdを取得
+    const requestId = event.pathParameters?.requestId;
+
+    if (!requestId) {
+      return badRequest400Response({
+        message: 'リクエストIDが指定されていません',
+        code: 'MISSING_REQUEST_ID',
+      });
+    }
+
+    console.log('Fetching parental checkout request status:', { requestId });
+
+    // 3. DynamoDBから保留リクエストを取得
+    const result = await dynamoDbClient.send(
+      new GetItemCommand({
+        TableName: PENDING_PARENTAL_CHECKOUTS_TABLE_NAME,
+        Key: {
+          requestId: { S: requestId },
+        },
+      })
+    );
+
+    if (!result.Item) {
+      console.error('Parental checkout request not found:', requestId);
+      return notFound404Response({
+        message: '購入リクエストが見つかりません',
+        code: 'REQUEST_NOT_FOUND',
+        details: { requestId },
+      });
+    }
+
+    const item = result.Item;
+
+    // 4. ユーザーIDとテナントIDを検証（自分のリクエストのみ取得可能）
+    const requestUserId = item.userId?.S;
+    const requestTenantId = item.tenantId?.S;
+
+    if (requestUserId !== userId || requestTenantId !== tenantId) {
+      console.error('Unauthorized access to parental checkout request:', {
+        requestId,
+        requestUserId,
+        requestTenantId,
+        userId,
+        tenantId,
+      });
+      return notFound404Response({
+        message: '購入リクエストが見つかりません',
+        code: 'REQUEST_NOT_FOUND',
+        details: { requestId },
+      });
+    }
+
+    // 5. ステータスを確認し、期限切れの場合は更新
+    let status = (item.status?.S as 'pending' | 'approved' | 'expired') ||
+      'pending';
+    const expiresAt = Number(item.expiresAt?.N || 0);
+    const now = Date.now();
+
+    if (status === 'pending' && now > expiresAt) {
+      // 期限切れの場合、ステータスをDynamoDBに永続化
+      status = 'expired';
+      console.log('Parental checkout request expired, updating status:', {
+        requestId,
+        expiresAt,
+        now,
+      });
+
+      // 非同期でステータスを更新（レスポンスをブロックしない）
+      dynamoDbClient
+        .send(
+          new UpdateItemCommand({
+            TableName: PENDING_PARENTAL_CHECKOUTS_TABLE_NAME,
+            Key: {
+              requestId: { S: requestId },
+            },
+            UpdateExpression: 'SET #status = :status, expiredAt = :expiredAt',
+            ConditionExpression: '#status = :pendingStatus',
+            ExpressionAttributeNames: {
+              '#status': 'status',
+            },
+            ExpressionAttributeValues: {
+              ':status': { S: 'expired' },
+              ':expiredAt': { N: now.toString() },
+              ':pendingStatus': { S: 'pending' },
+            },
+          })
+        )
+        .then(() => {
+          console.log('Parental checkout request status updated to expired:', {
+            requestId,
+          });
+        })
+        .catch((err) => {
+          // 条件チェック失敗（既に更新済み）の場合は無視
+          if (err.name !== 'ConditionalCheckFailedException') {
+            console.error('Failed to update expired status:', err);
+          }
+        });
+    }
+
+    // 6. レスポンスを構築
+    const response: ParentalCheckoutRequestStatusResponse = {
+      requestId: item.requestId?.S || '',
+      status,
+      planId: item.planId?.S || '',
+      parentEmail: item.parentEmail?.S || '',
+      createdAt: Number(item.createdAt?.N || 0),
+      expiresAt,
+    };
+
+    // 承認済みの場合、追加情報を含める
+    if (status === 'approved') {
+      if (item.approvedAt?.N) {
+        response.approvedAt = Number(item.approvedAt.N);
+      }
+      if (item.subscriptionId?.S) {
+        response.subscriptionId = item.subscriptionId.S;
+      }
+    }
+
+    console.log('Parental checkout request status retrieved:', {
+      requestId,
+      status: response.status,
+    });
+
+    return ok200Response(response);
+  } catch (error) {
+    console.error('Error getting parental checkout request status:', error);
+
+    return internalServerError500Response({
+      message: 'サーバー内部エラーが発生しました',
+      code: 'INTERNAL_SERVER_ERROR',
+      details: undefined,
+    });
+  }
+};

--- a/packages/cdk/lambda/billing/user-api/subscriptions/getPendingParentalConsentRequest.ts
+++ b/packages/cdk/lambda/billing/user-api/subscriptions/getPendingParentalConsentRequest.ts
@@ -1,0 +1,294 @@
+/**
+ * Get Pending Parental Consent Request API
+ *
+ * 現在のユーザーの保護者同意待ちリクエストを取得するAPI。
+ * 新規購入・プラン変更の両方に対応し、重複購入を防止するために使用します。
+ */
+
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { DynamoDBClient, QueryCommand } from '@aws-sdk/client-dynamodb';
+import { getTenantId } from '../../../utils/tenantUtils';
+import { getUserIdFromCognitoEvent } from '../../../utils/cognitoUtils';
+import {
+  ok200Response,
+  unauthorized401Response,
+  notFound404Response,
+  internalServerError500Response,
+} from '../../../utils/apiResponse';
+
+const PENDING_PLAN_CHANGES_TABLE_NAME =
+  process.env.PENDING_PLAN_CHANGES_TABLE_NAME || '';
+const PENDING_PARENTAL_CHECKOUTS_TABLE_NAME =
+  process.env.PENDING_PARENTAL_CHECKOUTS_TABLE_NAME || '';
+
+/**
+ * レスポンスボディの型（フロントエンドAPI契約）
+ */
+interface PendingParentalConsentResponse {
+  /** リクエストID */
+  requestId: string;
+  /** ステータス */
+  status: 'pending' | 'approved' | 'expired';
+  /** リクエストの種類 */
+  type: 'purchase' | 'change';
+  /** 保護者のメールアドレス */
+  parentEmail: string;
+  /** 購入/変更先のプランID */
+  planId: string;
+  /** 作成日時（Unix timestamp ミリ秒） */
+  createdAt: number;
+  /** 有効期限（Unix timestamp ミリ秒） */
+  expiresAt: number;
+  /** 承認日時（Unix timestamp ミリ秒、承認済みの場合のみ） */
+  approvedAt?: number;
+
+  // 購入モード (type === 'purchase') の場合
+  /** Stripe Checkout Session ID */
+  sessionId?: string;
+  /** サブスクリプションID（承認後に付与） */
+  subscriptionId?: string;
+
+  // 変更モード (type === 'change') の場合
+  /** 現在のプランID */
+  currentPlanId?: string;
+  /** 変更タイプ */
+  changeType?: 'upgrade' | 'downgrade';
+  /** 変更適用日 (ダウングレードの場合) */
+  effectiveDate?: string;
+}
+
+/**
+ * DynamoDB Client
+ */
+const dynamoDbClient = new DynamoDBClient({});
+
+/**
+ * DynamoDBアイテムからpurchaseタイプのレスポンスを構築
+ */
+const buildPurchaseResponse = (
+  item: Record<string, { S?: string; N?: string }>
+): PendingParentalConsentResponse => {
+  const response: PendingParentalConsentResponse = {
+    requestId: item.requestId?.S || '',
+    status: (item.status?.S as 'pending' | 'approved' | 'expired') || 'pending',
+    type: 'purchase',
+    parentEmail: item.parentEmail?.S || '',
+    planId: item.planId?.S || '',
+    createdAt: Number(item.createdAt?.N || 0),
+    expiresAt: Number(item.expiresAt?.N || 0),
+    sessionId: item.checkoutSessionId?.S,
+  };
+
+  if (response.status === 'approved') {
+    if (item.approvedAt?.N) {
+      response.approvedAt = Number(item.approvedAt.N);
+    }
+    if (item.subscriptionId?.S) {
+      response.subscriptionId = item.subscriptionId.S;
+    }
+  }
+
+  return response;
+};
+
+/**
+ * DynamoDBアイテムからchangeタイプのレスポンスを構築
+ */
+const buildChangeResponse = (
+  item: Record<string, { S?: string; N?: string }>
+): PendingParentalConsentResponse => {
+  const response: PendingParentalConsentResponse = {
+    requestId: item.requestId?.S || '',
+    status: (item.status?.S as 'pending' | 'approved' | 'expired') || 'pending',
+    type: 'change',
+    parentEmail: item.parentEmail?.S || '',
+    planId: item.newPlanId?.S || '', // changeの場合はnewPlanId
+    createdAt: Number(item.createdAt?.N || 0),
+    expiresAt: Number(item.expiresAt?.N || 0),
+    currentPlanId: item.currentPlanId?.S,
+    changeType: item.changeType?.S as 'upgrade' | 'downgrade' | undefined,
+  };
+
+  if (response.status === 'approved') {
+    if (item.approvedAt?.N) {
+      response.approvedAt = Number(item.approvedAt.N);
+    }
+  }
+
+  // effectiveDateがあれば追加
+  if (item.effectiveDate?.S) {
+    response.effectiveDate = item.effectiveDate.S;
+  }
+
+  return response;
+};
+
+/**
+ * ステータスを確認し、期限切れの場合は'expired'を返す
+ */
+const checkExpiredStatus = (
+  status: string,
+  expiresAt: number
+): 'pending' | 'approved' | 'expired' => {
+  if (status === 'pending' && Date.now() > expiresAt) {
+    return 'expired';
+  }
+  return status as 'pending' | 'approved' | 'expired';
+};
+
+/**
+ * Lambda関数のメインハンドラー
+ */
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  console.log('User API: Get Pending Parental Consent Request received');
+
+  try {
+    // 1. 認証情報からユーザID、テナントIDを取得
+    const userId = getUserIdFromCognitoEvent(event);
+    const tenantId = getTenantId(event);
+
+    if (!userId || !tenantId) {
+      console.error('Missing authentication information');
+      return unauthorized401Response({
+        message: '認証が必要です',
+        code: 'UNAUTHORIZED',
+        details: undefined,
+      });
+    }
+
+    console.log('Request context:', { userId, tenantId });
+
+    // 2. 両方のテーブルからpendingリクエストを検索
+    const [purchaseResult, changeResult] = await Promise.all([
+      // 新規購入テーブルを検索
+      PENDING_PARENTAL_CHECKOUTS_TABLE_NAME
+        ? dynamoDbClient.send(
+            new QueryCommand({
+              TableName: PENDING_PARENTAL_CHECKOUTS_TABLE_NAME,
+              IndexName: 'userId-index',
+              KeyConditionExpression: 'userId = :userId',
+              FilterExpression: 'tenantId = :tenantId AND #status = :status',
+              ExpressionAttributeNames: {
+                '#status': 'status',
+              },
+              ExpressionAttributeValues: {
+                ':userId': { S: userId },
+                ':tenantId': { S: tenantId },
+                ':status': { S: 'pending' },
+              },
+              Limit: 1,
+            })
+          )
+        : Promise.resolve({ Items: [] }),
+
+      // プラン変更テーブルを検索
+      PENDING_PLAN_CHANGES_TABLE_NAME
+        ? dynamoDbClient.send(
+            new QueryCommand({
+              TableName: PENDING_PLAN_CHANGES_TABLE_NAME,
+              IndexName: 'userId-index',
+              KeyConditionExpression: 'userId = :userId',
+              FilterExpression: 'tenantId = :tenantId AND #status = :status',
+              ExpressionAttributeNames: {
+                '#status': 'status',
+              },
+              ExpressionAttributeValues: {
+                ':userId': { S: userId },
+                ':tenantId': { S: tenantId },
+                ':status': { S: 'pending' },
+              },
+              Limit: 1,
+            })
+          )
+        : Promise.resolve({ Items: [] }),
+    ]);
+
+    // 3. 結果を処理
+    const purchaseItems = purchaseResult.Items || [];
+    const changeItems = changeResult.Items || [];
+
+    console.log('Query results:', {
+      purchaseCount: purchaseItems.length,
+      changeCount: changeItems.length,
+    });
+
+    // 購入リクエストが見つかった場合
+    if (purchaseItems.length > 0) {
+      const item = purchaseItems[0] as Record<string, { S?: string; N?: string }>;
+      const response = buildPurchaseResponse(item);
+
+      // 期限切れチェック
+      response.status = checkExpiredStatus(response.status, response.expiresAt);
+
+      // pending以外（期限切れ含む）は404を返す
+      if (response.status !== 'pending') {
+        console.log('Purchase request is not pending (expired or approved):', {
+          requestId: response.requestId,
+          status: response.status,
+        });
+        return notFound404Response({
+          message: '保留中のリクエストはありません',
+          code: 'NO_PENDING_REQUEST',
+          details: undefined,
+        });
+      }
+
+      console.log('Pending purchase request found:', {
+        requestId: response.requestId,
+        planId: response.planId,
+      });
+
+      return ok200Response(response);
+    }
+
+    // プラン変更リクエストが見つかった場合
+    if (changeItems.length > 0) {
+      const item = changeItems[0] as Record<string, { S?: string; N?: string }>;
+      const response = buildChangeResponse(item);
+
+      // 期限切れチェック
+      response.status = checkExpiredStatus(response.status, response.expiresAt);
+
+      // pending以外（期限切れ含む）は404を返す
+      if (response.status !== 'pending') {
+        console.log('Change request is not pending (expired or approved):', {
+          requestId: response.requestId,
+          status: response.status,
+        });
+        return notFound404Response({
+          message: '保留中のリクエストはありません',
+          code: 'NO_PENDING_REQUEST',
+          details: undefined,
+        });
+      }
+
+      console.log('Pending change request found:', {
+        requestId: response.requestId,
+        planId: response.planId,
+        currentPlanId: response.currentPlanId,
+        changeType: response.changeType,
+      });
+
+      return ok200Response(response);
+    }
+
+    // 4. 保留中のリクエストが見つからない場合
+    console.log('No pending parental consent request found for user:', userId);
+
+    return notFound404Response({
+      message: '保留中のリクエストはありません',
+      code: 'NO_PENDING_REQUEST',
+      details: undefined,
+    });
+  } catch (error) {
+    console.error('Error getting pending parental consent request:', error);
+
+    return internalServerError500Response({
+      message: 'サーバー内部エラーが発生しました',
+      code: 'INTERNAL_SERVER_ERROR',
+      details: undefined,
+    });
+  }
+};

--- a/packages/cdk/lambda/billing/user-api/subscriptions/getPendingParentalConsentRequest.ts
+++ b/packages/cdk/lambda/billing/user-api/subscriptions/getPendingParentalConsentRequest.ts
@@ -3,16 +3,27 @@
  *
  * 現在のユーザーの保護者同意待ちリクエストを取得するAPI。
  * 新規購入・プラン変更の両方に対応し、重複購入を防止するために使用します。
+ *
+ * Stripe Checkout Sessionの状態を確認し、決済完了済みの場合は204を返します。
  */
 
+import Stripe from 'stripe';
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
-import { DynamoDBClient, QueryCommand } from '@aws-sdk/client-dynamodb';
+import {
+  DynamoDBClient,
+  QueryCommand,
+  UpdateItemCommand,
+} from '@aws-sdk/client-dynamodb';
+import {
+  SecretsManagerClient,
+  GetSecretValueCommand,
+} from '@aws-sdk/client-secrets-manager';
 import { getTenantId } from '../../../utils/tenantUtils';
 import { getUserIdFromCognitoEvent } from '../../../utils/cognitoUtils';
 import {
   ok200Response,
   unauthorized401Response,
-  notFound404Response,
+  noContent204Response,
   internalServerError500Response,
 } from '../../../utils/apiResponse';
 
@@ -61,6 +72,99 @@ interface PendingParentalConsentResponse {
  * DynamoDB Client
  */
 const dynamoDbClient = new DynamoDBClient({});
+
+/**
+ * Secrets Manager Client
+ */
+const secretsManagerClient = new SecretsManagerClient({});
+
+/**
+ * シークレットのキャッシュ
+ */
+const stripeApiKeyCache: { [key: string]: string } = {};
+
+/**
+ * Secrets ManagerからStripe APIキーを取得する
+ */
+async function getStripeApiKey(tenantId: string): Promise<string> {
+  if (stripeApiKeyCache[tenantId]) {
+    return stripeApiKeyCache[tenantId];
+  }
+
+  const secretName = `${tenantId}/billing/stripe`;
+  const command = new GetSecretValueCommand({ SecretId: secretName });
+  const response = await secretsManagerClient.send(command);
+
+  if (!response.SecretString) {
+    throw new Error(`Secret ${secretName} is empty`);
+  }
+
+  const secret = JSON.parse(response.SecretString);
+  stripeApiKeyCache[tenantId] = secret.apiKey;
+
+  return secret.apiKey;
+}
+
+/**
+ * Stripe Checkout Sessionの決済完了状態を確認
+ * @returns true: 決済完了, false: 未完了
+ */
+async function isCheckoutSessionCompleted(
+  tenantId: string,
+  sessionId: string
+): Promise<boolean> {
+  try {
+    const apiKey = await getStripeApiKey(tenantId);
+    const stripe = new Stripe(apiKey, { apiVersion: '2025-10-29.clover' });
+
+    const session = await stripe.checkout.sessions.retrieve(sessionId);
+    return session.status === 'complete';
+  } catch (error) {
+    console.error('Error checking Stripe checkout session:', {
+      sessionId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    // エラー時はfalseを返し、pendingとして扱う
+    return false;
+  }
+}
+
+/**
+ * DynamoDBのリクエストステータスをapprovedに更新（非同期）
+ */
+async function updateRequestStatusToApproved(
+  tableName: string,
+  requestId: string
+): Promise<void> {
+  try {
+    await dynamoDbClient.send(
+      new UpdateItemCommand({
+        TableName: tableName,
+        Key: {
+          requestId: { S: requestId },
+        },
+        UpdateExpression: 'SET #status = :status, approvedAt = :approvedAt',
+        ExpressionAttributeNames: {
+          '#status': 'status',
+        },
+        ExpressionAttributeValues: {
+          ':status': { S: 'approved' },
+          ':approvedAt': { N: Date.now().toString() },
+        },
+      })
+    );
+
+    console.log('Updated parental checkout request status to approved:', {
+      requestId,
+    });
+  } catch (error) {
+    // 更新失敗はログのみ（レスポンスには影響させない）
+    console.error('Error updating request status to approved:', {
+      requestId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
 
 /**
  * DynamoDBアイテムからpurchaseタイプのレスポンスを構築
@@ -160,46 +264,40 @@ export const handler = async (
 
     console.log('Request context:', { userId, tenantId });
 
-    // 2. 両方のテーブルからpendingリクエストを検索
+    // 2. 両方のテーブルから最新のリクエストを検索（statusフィルターなし、Limit外して全件取得）
+    // NOTE: DynamoDBのFilterExpressionはLimit適用後に評価されるため、Limitを外して
+    // 全件取得し、コード側でpendingを探す必要がある
     const [purchaseResult, changeResult] = await Promise.all([
-      // 新規購入テーブルを検索
+      // 新規購入テーブルを検索（最新順）
       PENDING_PARENTAL_CHECKOUTS_TABLE_NAME
         ? dynamoDbClient.send(
             new QueryCommand({
               TableName: PENDING_PARENTAL_CHECKOUTS_TABLE_NAME,
               IndexName: 'userId-index',
               KeyConditionExpression: 'userId = :userId',
-              FilterExpression: 'tenantId = :tenantId AND #status = :status',
-              ExpressionAttributeNames: {
-                '#status': 'status',
-              },
+              FilterExpression: 'tenantId = :tenantId',
               ExpressionAttributeValues: {
                 ':userId': { S: userId },
                 ':tenantId': { S: tenantId },
-                ':status': { S: 'pending' },
               },
-              Limit: 1,
+              ScanIndexForward: false, // 降順（最新が最初）
             })
           )
         : Promise.resolve({ Items: [] }),
 
-      // プラン変更テーブルを検索
+      // プラン変更テーブルを検索（最新順）
       PENDING_PLAN_CHANGES_TABLE_NAME
         ? dynamoDbClient.send(
             new QueryCommand({
               TableName: PENDING_PLAN_CHANGES_TABLE_NAME,
               IndexName: 'userId-index',
               KeyConditionExpression: 'userId = :userId',
-              FilterExpression: 'tenantId = :tenantId AND #status = :status',
-              ExpressionAttributeNames: {
-                '#status': 'status',
-              },
+              FilterExpression: 'tenantId = :tenantId',
               ExpressionAttributeValues: {
                 ':userId': { S: userId },
                 ':tenantId': { S: tenantId },
-                ':status': { S: 'pending' },
               },
-              Limit: 1,
+              ScanIndexForward: false, // 降順（最新が最初）
             })
           )
         : Promise.resolve({ Items: [] }),
@@ -214,27 +312,53 @@ export const handler = async (
       changeCount: changeItems.length,
     });
 
-    // 購入リクエストが見つかった場合
-    if (purchaseItems.length > 0) {
-      const item = purchaseItems[0] as Record<string, { S?: string; N?: string }>;
+    // 全件の中から最新のpendingを探す（期限切れでないもの）
+    // DynamoDBは降順ソートされているので、最初に見つかったpendingが最新
+
+    // 購入リクエストからpendingを探す
+    for (const item of purchaseItems as Record<
+      string,
+      { S?: string; N?: string }
+    >[]) {
       const response = buildPurchaseResponse(item);
 
       // 期限切れチェック
       response.status = checkExpiredStatus(response.status, response.expiresAt);
 
-      // pending以外（期限切れ含む）は404を返す
+      // pendingでなければスキップ（次のレコードを確認）
       if (response.status !== 'pending') {
-        console.log('Purchase request is not pending (expired or approved):', {
-          requestId: response.requestId,
-          status: response.status,
-        });
-        return notFound404Response({
-          message: '保留中のリクエストはありません',
-          code: 'NO_PENDING_REQUEST',
-          details: undefined,
-        });
+        continue;
       }
 
+      // ステータスが pending の場合、Stripe Checkout Session の状態を確認
+      if (response.sessionId) {
+        const isCompleted = await isCheckoutSessionCompleted(
+          tenantId,
+          response.sessionId
+        );
+
+        if (isCompleted) {
+          console.log(
+            'Stripe checkout is complete, updating DynamoDB and returning 204:',
+            {
+              requestId: response.requestId,
+              sessionId: response.sessionId,
+            }
+          );
+
+          // DynamoDBのステータスを非同期で更新（awaitしない）
+          updateRequestStatusToApproved(
+            PENDING_PARENTAL_CHECKOUTS_TABLE_NAME,
+            response.requestId
+          ).catch((err) => {
+            console.error('Background DynamoDB update failed:', err);
+          });
+
+          return noContent204Response();
+        }
+      }
+
+      // Stripe未完了のpendingが見つかった
       console.log('Pending purchase request found:', {
         requestId: response.requestId,
         planId: response.planId,
@@ -243,27 +367,51 @@ export const handler = async (
       return ok200Response(response);
     }
 
-    // プラン変更リクエストが見つかった場合
-    if (changeItems.length > 0) {
-      const item = changeItems[0] as Record<string, { S?: string; N?: string }>;
+    // プラン変更リクエストからpendingを探す
+    for (const item of changeItems as Record<
+      string,
+      { S?: string; N?: string }
+    >[]) {
       const response = buildChangeResponse(item);
 
       // 期限切れチェック
       response.status = checkExpiredStatus(response.status, response.expiresAt);
 
-      // pending以外（期限切れ含む）は404を返す
+      // pendingでなければスキップ（次のレコードを確認）
       if (response.status !== 'pending') {
-        console.log('Change request is not pending (expired or approved):', {
-          requestId: response.requestId,
-          status: response.status,
-        });
-        return notFound404Response({
-          message: '保留中のリクエストはありません',
-          code: 'NO_PENDING_REQUEST',
-          details: undefined,
-        });
+        continue;
       }
 
+      // ステータスが pending の場合、Checkout Session があれば Stripe の状態を確認
+      const sessionId = item.checkoutSessionId?.S;
+      if (sessionId) {
+        const isCompleted = await isCheckoutSessionCompleted(
+          tenantId,
+          sessionId
+        );
+
+        if (isCompleted) {
+          console.log(
+            'Stripe checkout is complete, updating DynamoDB and returning 204:',
+            {
+              requestId: response.requestId,
+              sessionId,
+            }
+          );
+
+          // DynamoDBのステータスを非同期で更新（awaitしない）
+          updateRequestStatusToApproved(
+            PENDING_PLAN_CHANGES_TABLE_NAME,
+            response.requestId
+          ).catch((err) => {
+            console.error('Background DynamoDB update failed:', err);
+          });
+
+          return noContent204Response();
+        }
+      }
+
+      // Stripe未完了のpendingが見つかった
       console.log('Pending change request found:', {
         requestId: response.requestId,
         planId: response.planId,
@@ -274,14 +422,10 @@ export const handler = async (
       return ok200Response(response);
     }
 
-    // 4. 保留中のリクエストが見つからない場合
-    console.log('No pending parental consent request found for user:', userId);
+    // 4. 保留中のリクエストが見つからない場合は 204 No Content を返す
+    console.log('No parental consent request found for user:', userId);
 
-    return notFound404Response({
-      message: '保留中のリクエストはありません',
-      code: 'NO_PENDING_REQUEST',
-      details: undefined,
-    });
+    return noContent204Response();
   } catch (error) {
     console.error('Error getting pending parental consent request:', error);
 

--- a/packages/cdk/lambda/billing/user-api/subscriptions/sendCheckoutLinkToParent.ts
+++ b/packages/cdk/lambda/billing/user-api/subscriptions/sendCheckoutLinkToParent.ts
@@ -11,6 +11,8 @@ import {
   SecretsManagerClient,
   GetSecretValueCommand,
 } from '@aws-sdk/client-secrets-manager';
+import { DynamoDBClient, PutItemCommand } from '@aws-sdk/client-dynamodb';
+import { randomUUID } from 'crypto';
 import { getTenantId } from '../../../utils/tenantUtils';
 import { getUserIdFromCognitoEvent, getUserEmailFromCognitoEvent } from '../../../utils/cognitoUtils';
 import { invokeDataAccessFunction } from '../../utils/dataAccessClient';
@@ -27,6 +29,13 @@ const SERVICE_NAME = process.env.SERVICE_NAME || 'GenU';
 const SENDGRID_API_KEY = process.env.SENDGRID_API_KEY || '';
 const SENDGRID_FROM_EMAIL = process.env.SENDGRID_FROM_EMAIL || '';
 const SENDGRID_API_URL = 'https://api.sendgrid.com/v3/mail/send';
+const PENDING_PARENTAL_CHECKOUTS_TABLE_NAME =
+  process.env.PENDING_PARENTAL_CHECKOUTS_TABLE_NAME || '';
+
+// Expiration time: 24 hours
+const EXPIRATION_HOURS = 24;
+// TTL: 7 days (for DynamoDB cleanup)
+const TTL_DAYS = 7;
 
 /**
  * カラーテーマ（既存のメールテンプレートと統一）
@@ -69,6 +78,11 @@ interface SendCheckoutLinkRequest {
  * シークレットのキャッシュ
  */
 const stripeApiKeyCache: { [key: string]: string } = {};
+
+/**
+ * DynamoDB Client
+ */
+const dynamoDbClient = new DynamoDBClient({});
 
 /**
  * Secrets ManagerからStripe APIキーを取得する
@@ -431,6 +445,9 @@ export const handler = async (
     const successUrl = `${baseUrl}/billing/parental-complete`;
     const cancelUrl = `${baseUrl}/billing/cancel`;
 
+    // 9.5. requestIdを生成（状態管理用）
+    const requestId = randomUUID();
+
     // 10. Checkout Sessionを作成（リダイレクトモード）
     const session = await stripe.checkout.sessions.create({
       mode: 'subscription',
@@ -451,6 +468,7 @@ export const handler = async (
         childName: childName || '',
         childEmail: childEmail || '', // 子供のメールをメタデータに保存
         isParentalControl: 'true', // ペアレンタルコントロールフラグ
+        parentalCheckoutRequestId: requestId, // 状態管理用リクエストID
       },
       // サブスクリプションにもmetadataを設定（領収書メールでplanIdを取得するため）
       subscription_data: {
@@ -460,6 +478,7 @@ export const handler = async (
           planId,
           childEmail: childEmail || '',
           isParentalControl: 'true',
+          parentalCheckoutRequestId: requestId, // 状態管理用リクエストID
         },
       },
       allow_promotion_codes: true,
@@ -470,6 +489,39 @@ export const handler = async (
     });
 
     console.log('Checkout Session created for parental control:', session.id);
+
+    // 10.5. DynamoDBに状態を保存
+    if (PENDING_PARENTAL_CHECKOUTS_TABLE_NAME) {
+      const nowTimestamp = Date.now();
+      const expiresAt = nowTimestamp + EXPIRATION_HOURS * 60 * 60 * 1000;
+      const ttl = Math.floor(
+        (nowTimestamp + TTL_DAYS * 24 * 60 * 60 * 1000) / 1000
+      );
+
+      await dynamoDbClient.send(
+        new PutItemCommand({
+          TableName: PENDING_PARENTAL_CHECKOUTS_TABLE_NAME,
+          Item: {
+            requestId: { S: requestId },
+            checkoutSessionId: { S: session.id },
+            tenantId: { S: tenantId },
+            userId: { S: userId },
+            planId: { S: planId },
+            parentEmail: { S: parentEmail },
+            childEmail: { S: childEmail || '' },
+            status: { S: 'pending' },
+            createdAt: { N: nowTimestamp.toString() },
+            expiresAt: { N: expiresAt.toString() },
+            ttl: { N: ttl.toString() },
+          },
+        })
+      );
+
+      console.log('Pending parental checkout request saved:', {
+        requestId,
+        checkoutSessionId: session.id,
+      });
+    }
 
     // 11. 保護者にメール送信（子供のメールアドレスを使用）
     const emailContent = createParentPaymentRequestEmail(
@@ -490,6 +542,7 @@ export const handler = async (
     return ok200Response({
       message: '決済リンクを保護者のメールアドレスに送信しました',
       sessionId: session.id,
+      requestId,
       expiresAt: session.expires_at,
     });
   } catch (error) {

--- a/packages/cdk/lib/construct/api/orchestration.ts
+++ b/packages/cdk/lib/construct/api/orchestration.ts
@@ -80,6 +80,11 @@ export interface OrchestrationApiProps {
    * Pending Plan Changes Table for parental control plan change requests
    */
   readonly pendingPlanChangesTable?: ITable;
+
+  /**
+   * Pending Parental Checkouts Table for parental control new purchase requests
+   */
+  readonly pendingParentalCheckoutsTable?: ITable;
 }
 
 /**
@@ -243,6 +248,10 @@ class OrchestrationApi extends Construct {
           ...(props.pendingPlanChangesTable && {
             PENDING_PLAN_CHANGES_TABLE_NAME: props.pendingPlanChangesTable.tableName,
           }),
+          // Pending Parental Checkouts Table for parental control new purchase status update
+          ...(props.pendingParentalCheckoutsTable && {
+            PENDING_PARENTAL_CHECKOUTS_TABLE_NAME: props.pendingParentalCheckoutsTable.tableName,
+          }),
         },
       }
     );
@@ -308,7 +317,10 @@ class OrchestrationApi extends Construct {
           'dynamodb:UpdateItem',
           'dynamodb:DeleteItem',
         ],
-        resources: [`arn:aws:dynamodb:*:*:table/${environment}-pending-plan-changes`],
+        resources: [
+          `arn:aws:dynamodb:*:*:table/${environment}-pending-plan-changes`,
+          `arn:aws:dynamodb:*:*:table/${environment}-pending-parental-checkouts`,
+        ],
       })
     );
 

--- a/packages/cdk/lib/construct/api/user-billing-api.ts
+++ b/packages/cdk/lib/construct/api/user-billing-api.ts
@@ -86,6 +86,11 @@ export interface UserBillingApiProps {
    * DynamoDB table for pending plan change requests (parental approval)
    */
   readonly pendingPlanChangesTable?: ITable;
+
+  /**
+   * DynamoDB table for pending parental checkout requests (parental approval for new purchases)
+   */
+  readonly pendingParentalCheckoutsTable?: ITable;
 }
 
 class UserBillingApi extends Construct {
@@ -96,6 +101,8 @@ class UserBillingApi extends Construct {
   public readonly sendCheckoutLinkToParentFunction: NodejsFunction;
   public readonly sendPlanChangeLinkToParentFunction?: NodejsFunction;
   public readonly getPlanChangeRequestStatusFunction?: NodejsFunction;
+  public readonly getParentalCheckoutRequestStatusFunction?: NodejsFunction;
+  public readonly getPendingParentalConsentRequestFunction?: NodejsFunction;
   public readonly activateFromSessionFunction?: NodejsFunction;
   public readonly getCurrentSubscriptionFunction?: NodejsFunction;
   public readonly cancelSubscriptionFunction?: NodejsFunction;
@@ -350,6 +357,10 @@ class UserBillingApi extends Construct {
           SERVICE_NAME: props.emailServiceName,
           SENDGRID_API_KEY: props.sendgridApiKey,
           SENDGRID_FROM_EMAIL: props.sendgridFromEmail,
+          ...(props.pendingParentalCheckoutsTable && {
+            PENDING_PARENTAL_CHECKOUTS_TABLE_NAME:
+              props.pendingParentalCheckoutsTable.tableName,
+          }),
         },
       }
     );
@@ -358,6 +369,13 @@ class UserBillingApi extends Construct {
     tenantManager.tenantsTable.grantReadData(
       this.sendCheckoutLinkToParentFunction
     );
+
+    // Grant DynamoDB write access for pending parental checkouts
+    if (props.pendingParentalCheckoutsTable) {
+      props.pendingParentalCheckoutsTable.grantReadWriteData(
+        this.sendCheckoutLinkToParentFunction
+      );
+    }
 
     // Secrets Manager読み取り権限（Stripe APIキー取得用）
     this.sendCheckoutLinkToParentFunction.addToRolePolicy(
@@ -545,6 +563,116 @@ class UserBillingApi extends Construct {
       planChangeRequestStatusResource.addMethod(
         'GET',
         new LambdaIntegration(this.getPlanChangeRequestStatusFunction),
+        {
+          authorizer: authorizer,
+          authorizationType: AuthorizationType.COGNITO,
+        }
+      );
+    }
+
+    // ========================================
+    // API 3.8: ペアレンタルチェックアウトリクエストステータス確認API
+    // GET /api/subscriptions/parental-checkout-request/{requestId}/status
+    // ========================================
+
+    if (props.pendingParentalCheckoutsTable) {
+      this.getParentalCheckoutRequestStatusFunction = new NodejsFunction(
+        this,
+        'GetParentalCheckoutRequestStatus',
+        {
+          runtime: LAMBDA_RUNTIME_NODEJS,
+          entry:
+            './lambda/billing/user-api/subscriptions/getParentalCheckoutRequestStatus.ts',
+          timeout: Duration.seconds(10),
+          memorySize: 256,
+          environment: {
+            ...commonEnvironment,
+            PENDING_PARENTAL_CHECKOUTS_TABLE_NAME:
+              props.pendingParentalCheckoutsTable.tableName,
+          },
+        }
+      );
+
+      // Grant Tenants table read access
+      tenantManager.tenantsTable.grantReadData(
+        this.getParentalCheckoutRequestStatusFunction
+      );
+
+      // Grant DynamoDB read access for pending parental checkouts
+      props.pendingParentalCheckoutsTable.grantReadData(
+        this.getParentalCheckoutRequestStatusFunction
+      );
+
+      // API Gatewayエンドポイント
+      const parentalCheckoutRequestResource = subscriptionsResource.addResource(
+        'parental-checkout-request'
+      );
+      const parentalCheckoutRequestIdResource =
+        parentalCheckoutRequestResource.addResource('{requestId}');
+      const parentalCheckoutRequestStatusResource =
+        parentalCheckoutRequestIdResource.addResource('status');
+      parentalCheckoutRequestStatusResource.addMethod(
+        'GET',
+        new LambdaIntegration(this.getParentalCheckoutRequestStatusFunction),
+        {
+          authorizer: authorizer,
+          authorizationType: AuthorizationType.COGNITO,
+        }
+      );
+    }
+
+    // ========================================
+    // API 3.9: 保留中の保護者同意リクエスト取得API
+    // GET /api/subscriptions/parental-consent-request/pending
+    // ========================================
+
+    // 両方のテーブルがある場合に有効化
+    if (props.pendingParentalCheckoutsTable || props.pendingPlanChangesTable) {
+      this.getPendingParentalConsentRequestFunction = new NodejsFunction(
+        this,
+        'GetPendingParentalConsentRequest',
+        {
+          runtime: LAMBDA_RUNTIME_NODEJS,
+          entry:
+            './lambda/billing/user-api/subscriptions/getPendingParentalConsentRequest.ts',
+          timeout: Duration.seconds(10),
+          memorySize: 256,
+          environment: {
+            ...commonEnvironment,
+            PENDING_PARENTAL_CHECKOUTS_TABLE_NAME:
+              props.pendingParentalCheckoutsTable?.tableName || '',
+            PENDING_PLAN_CHANGES_TABLE_NAME:
+              props.pendingPlanChangesTable?.tableName || '',
+          },
+        }
+      );
+
+      // Grant Tenants table read access
+      tenantManager.tenantsTable.grantReadData(
+        this.getPendingParentalConsentRequestFunction
+      );
+
+      // Grant DynamoDB read access for both tables
+      if (props.pendingParentalCheckoutsTable) {
+        props.pendingParentalCheckoutsTable.grantReadData(
+          this.getPendingParentalConsentRequestFunction
+        );
+      }
+      if (props.pendingPlanChangesTable) {
+        props.pendingPlanChangesTable.grantReadData(
+          this.getPendingParentalConsentRequestFunction
+        );
+      }
+
+      // API Gatewayエンドポイント
+      const parentalConsentRequestResource = subscriptionsResource.addResource(
+        'parental-consent-request'
+      );
+      const pendingResource =
+        parentalConsentRequestResource.addResource('pending');
+      pendingResource.addMethod(
+        'GET',
+        new LambdaIntegration(this.getPendingParentalConsentRequestFunction),
         {
           authorizer: authorizer,
           authorizationType: AuthorizationType.COGNITO,
@@ -1160,6 +1288,11 @@ class UserBillingApi extends Construct {
       console.log('  - POST /api/subscriptions/send-plan-change-to-parent');
       console.log(
         '  - GET /api/subscriptions/plan-change-request/{requestId}/status'
+      );
+    }
+    if (props.pendingParentalCheckoutsTable) {
+      console.log(
+        '  - GET /api/subscriptions/parental-checkout-request/{requestId}/status'
       );
     }
     console.log('  - GET /api/subscriptions/current');

--- a/packages/cdk/lib/stacks/nested/billing-management-stack.ts
+++ b/packages/cdk/lib/stacks/nested/billing-management-stack.ts
@@ -162,6 +162,46 @@ export class BillingManagementStack extends NestedStack {
       },
     });
 
+    // GSI for userId lookup (ユーザーの保留中リクエスト検索用)
+    // NOTE: 既存テーブルへのGSI追加はCloudFormationでサポートされていますが、
+    // データ量によっては追加に時間がかかる場合があります。
+    // 本番環境へのデプロイ前に、既存データへの影響を確認してください。
+    pendingPlanChangesTable.addGlobalSecondaryIndex({
+      indexName: 'userId-index',
+      partitionKey: {
+        name: 'userId',
+        type: AttributeType.STRING,
+      },
+    });
+
+    // ========================================
+    // Create Pending Parental Checkouts Table
+    // ========================================
+    // 保護者承認待ちの新規購入リクエストを保存するテーブル
+    const pendingParentalCheckoutsTable = new Table(
+      this,
+      'PendingParentalCheckoutsTable',
+      {
+        tableName: `${props.environment}-pending-parental-checkouts`,
+        partitionKey: {
+          name: 'requestId',
+          type: AttributeType.STRING,
+        },
+        billingMode: BillingMode.PAY_PER_REQUEST,
+        removalPolicy: RemovalPolicy.DESTROY,
+        timeToLiveAttribute: 'ttl',
+      }
+    );
+
+    // GSI for userId lookup (ユーザーの保留中リクエスト検索用)
+    pendingParentalCheckoutsTable.addGlobalSecondaryIndex({
+      indexName: 'userId-index',
+      partitionKey: {
+        name: 'userId',
+        type: AttributeType.STRING,
+      },
+    });
+
     // ========================================
     // Create Independent REST API for Billing
     // ========================================
@@ -255,6 +295,8 @@ export class BillingManagementStack extends NestedStack {
       serviceName: props.emailServiceName,
       // Pending Plan Changes Table for parental control status update
       pendingPlanChangesTable: pendingPlanChangesTable,
+      // Pending Parental Checkouts Table for parental control new purchase status update
+      pendingParentalCheckoutsTable: pendingParentalCheckoutsTable,
     });
 
     // User Billing API (ユーザ向けエンドポイント)
@@ -271,6 +313,7 @@ export class BillingManagementStack extends NestedStack {
       sendgridFromEmail: props.sendgridFromEmail,
       emailServiceName: props.emailServiceName,
       pendingPlanChangesTable: pendingPlanChangesTable,
+      pendingParentalCheckoutsTable: pendingParentalCheckoutsTable,
     });
 
     // ========================================


### PR DESCRIPTION
## Summary

- ペアレンタルコントロールの新規購入リクエストの保留状態を `pending-parental-checkouts` テーブルで管理するように実装
- 子ユーザーが保護者の決済完了をポーリングで検知するための `GET /parental-checkout-request/{requestId}/status` API を追加
- 重複購入防止のための保留中リクエスト取得API `GET /pending-parental-consent-request` を追加
- Stripe Webhook処理で決済完了時に保留状態を `approved` に更新

## Test plan

- [ ] 子ユーザーが新規購入リクエストを作成し、`pending-parental-checkouts` テーブルにレコードが作成されることを確認
- [ ] `GET /parental-checkout-request/{requestId}/status` でステータスが取得できることを確認
- [ ] 保護者が決済完了後、Webhook経由でステータスが `approved` に更新されることを確認
- [ ] 期限切れリクエストが `expired` ステータスを返すことを確認
- [ ] `GET /pending-parental-consent-request` で保留中のリクエストが取得できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
