### PR TITLE
新規登録時の処理がパスワードリセット時に実行される不具合の修正

### DIFF
--- a/packages/cdk/lambda/assignTenant.ts
+++ b/packages/cdk/lambda/assignTenant.ts
@@ -30,7 +30,7 @@ const findTenantId = (email: string): string | null => {
 exports.handler = async (event: PostConfirmationTriggerEvent) => {
   try {
     console.log('Received event:', JSON.stringify(event, null, 2));
-    // パスワードリセット時は以降の処理をスキップ
+    // Skip subsequent processing for password reset
     if (event.triggerSource === 'PostConfirmation_ConfirmForgotPassword') {
       console.log(
         'postConfirmHandler - Skipping processing for ConfirmForgotPassword (password reset)'

--- a/packages/cdk/lambda/assignTenant.ts
+++ b/packages/cdk/lambda/assignTenant.ts
@@ -30,6 +30,14 @@ const findTenantId = (email: string): string | null => {
 exports.handler = async (event: PostConfirmationTriggerEvent) => {
   try {
     console.log('Received event:', JSON.stringify(event, null, 2));
+    // パスワードリセット時は以降の処理をスキップ
+    if (event.triggerSource === 'PostConfirmation_ConfirmForgotPassword') {
+      console.log(
+        'postConfirmHandler - Skipping processing for ConfirmForgotPassword (password reset)'
+      );
+      return event;
+    }
+
     const email = event.request.userAttributes.email;
     const tenantId = findTenantId(email);
     if (!tenantId) {


### PR DESCRIPTION
## 変更の概要

新規登録時の処理がパスワードリセット時に実行される不具合を修正
パスワードリセットの場合は後続の処理をスキップする

## 申し送り事項

<!-- レビュワーに伝えておきたい事柄等を書く（Draftの理由など） -->

## Checklist（レビュワー用）

- [ ] `npm run lint`でエラーが出ない
- [ ] TypeScriptのビルドで型エラーが出ない
- [ ] 手元でフォーマットした際に差分が出ない
