### PR TITLE
契約終了日時にフォールバックの値が適用されていた問題を修正

### DIFF
--- a/packages/cdk/lambda/billing/orchestration/flows/purchaseFlow.ts
+++ b/packages/cdk/lambda/billing/orchestration/flows/purchaseFlow.ts
@@ -337,14 +337,13 @@ export const handler = async (
           throw new Error('Subscription ID not found in previous step result');
         }
 
-        // validFromパラメータは廃止。applyPlanToUser内部で現在時刻が自動設定される
         const result = await planClient.applyPlanToUser({
           tenantId,
           userId,
           planId,
           applicationSource: 'subscription',
           applicationSourceId: subscriptionData.subscriptionId,
-          // validUntilは指定しない（サブスクリプションの期限に従う）
+          validFrom: new Date().toISOString(),
         });
 
         console.log('Plan applied successfully', {

--- a/packages/cdk/lambda/billing/orchestration/flows/purchaseFlow.ts
+++ b/packages/cdk/lambda/billing/orchestration/flows/purchaseFlow.ts
@@ -45,7 +45,10 @@ import { IdempotencyRepository } from '../repositories/idempotencyRepository';
  * @param platformType - プラットフォーム種別
  * @returns セッションID（冪等性キーの一部として使用）
  */
-function extractSessionId(receiptData: unknown, platformType: PlatformType): string {
+function extractSessionId(
+  receiptData: unknown,
+  platformType: PlatformType
+): string {
   if (platformType === 'stripe') {
     // Stripeの場合
     if (typeof receiptData === 'string') {
@@ -72,9 +75,8 @@ function extractSessionId(receiptData: unknown, platformType: PlatformType): str
 
   // Apple/Googleの場合、またはStripeでsessionIdが見つからない場合
   // receiptData全体をJSON文字列化してハッシュ的に使用
-  const receiptString = typeof receiptData === 'string'
-    ? receiptData
-    : JSON.stringify(receiptData);
+  const receiptString =
+    typeof receiptData === 'string' ? receiptData : JSON.stringify(receiptData);
 
   // 長すぎる場合は先頭64文字を使用（実運用ではハッシュ関数を使うべき）
   return receiptString.length > 64
@@ -105,15 +107,22 @@ export const handler = async (
   // ========================================
   // IdempotencyRepositoryはtenantIdを使用してテナント固有のテーブルにアクセス
   const idempotencyRepo = new IdempotencyRepository(tenantId);
-  const sessionId = extractSessionId(receiptData, paymentPlatform as PlatformType);
+  const sessionId = extractSessionId(
+    receiptData,
+    paymentPlatform as PlatformType
+  );
   const idempotencyKey = IdempotencyRepository.generateKey(tenantId, sessionId);
 
   console.log('Checking idempotency', { idempotencyKey, sessionId });
 
-  const idempotencyResult = await idempotencyRepo.reserveOrGetExisting(idempotencyKey);
+  const idempotencyResult =
+    await idempotencyRepo.reserveOrGetExisting(idempotencyKey);
 
   // 既に処理済みの場合は既存の結果を返す
-  if (idempotencyResult.alreadyProcessed && idempotencyResult.existingRecord?.result) {
+  if (
+    idempotencyResult.alreadyProcessed &&
+    idempotencyResult.existingRecord?.result
+  ) {
     console.log('Request already processed, returning existing result', {
       idempotencyKey,
       existingStatus: idempotencyResult.existingRecord.status,
@@ -131,7 +140,8 @@ export const handler = async (
       flowExecutionId: '',
       errorDetails: {
         errorCode: 'CONCURRENT_REQUEST',
-        errorMessage: 'Another request is currently processing this session. Please wait and retry.',
+        errorMessage:
+          'Another request is currently processing this session. Please wait and retry.',
       },
     };
   }
@@ -251,6 +261,13 @@ export const handler = async (
           );
         }
 
+        if (!receiptResult?.expiresAt) {
+          throw new Error(
+            'Expiration date not found in receipt verification result. ' +
+              'Payment provider must return expiration date.'
+          );
+        }
+
         const params: CreateSubscriptionParams = {
           tenantId,
           userId,
@@ -259,8 +276,7 @@ export const handler = async (
           platformSubscriptionId: receiptResult.platformSubscriptionId,
           subscriptionStatus: 'active',
           currentPeriodStart: new Date().toISOString(),
-          currentPeriodEnd:
-            receiptResult.expiresAt || getDefaultExpirationDate(),
+          currentPeriodEnd: receiptResult.expiresAt,
         };
 
         const result = await subscriptionClient.createSubscription(params);
@@ -321,13 +337,13 @@ export const handler = async (
           throw new Error('Subscription ID not found in previous step result');
         }
 
+        // validFromパラメータは廃止。applyPlanToUser内部で現在時刻が自動設定される
         const result = await planClient.applyPlanToUser({
           tenantId,
           userId,
           planId,
           applicationSource: 'subscription',
           applicationSourceId: subscriptionData.subscriptionId,
-          validFrom: new Date().toISOString(),
           // validUntilは指定しない（サブスクリプションの期限に従う）
         });
 
@@ -440,7 +456,11 @@ export const handler = async (
     await orchestrator.completeFlow(flowExecutionId, output);
 
     // 冪等性レコードを成功として記録
-    await idempotencyRepo.markCompleted(idempotencyKey, flowExecutionId, output);
+    await idempotencyRepo.markCompleted(
+      idempotencyKey,
+      flowExecutionId,
+      output
+    );
 
     console.log('Purchase flow completed successfully', {
       flowExecutionId,
@@ -500,19 +520,12 @@ export const handler = async (
 
     // 冪等性レコードを失敗として記録
     // 同じsessionIdで再度リクエストされた場合、同じエラーを返す（案B）
-    await idempotencyRepo.markFailed(idempotencyKey, flowExecutionId, errorOutput);
+    await idempotencyRepo.markFailed(
+      idempotencyKey,
+      flowExecutionId,
+      errorOutput
+    );
 
     return errorOutput;
   }
 };
-
-/**
- * デフォルトの有効期限を取得（30日後）
- *
- * @returns ISO 8601形式の日時文字列
- */
-function getDefaultExpirationDate(): string {
-  const expirationDate = new Date();
-  expirationDate.setDate(expirationDate.getDate() + 30);
-  return expirationDate.toISOString();
-}

--- a/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
+++ b/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
@@ -1956,61 +1956,20 @@ function extractSubscriptionId(
 }
 
 /**
- * イベントデータから有効期限を抽出
- *
- * @param platform 決済プラットフォーム
- * @param eventData イベントデータ
- * @returns 有効期限（ISO 8601形式）
- */
-function extractExpirationDate(
-  platform: PlatformType,
-  eventData: Record<string, unknown>
-): string {
-  if (platform === 'stripe') {
-    const stripeData = eventData as StripeEventData;
-    if (stripeData.periodEnd) {
-      // StripeはUnixタイムスタンプ（秒）なので、ミリ秒に変換してISO 8601形式にする
-      return new Date(stripeData.periodEnd * 1000).toISOString();
-    }
-  }
-
-  if (platform === 'apple') {
-    const appleData = eventData as AppleEventData;
-    if (appleData.expiresDate) {
-      // AppleはUnixタイムスタンプ（ミリ秒）なので、そのままISO 8601形式にする
-      return new Date(appleData.expiresDate).toISOString();
-    }
-  }
-
-  if (platform === 'google') {
-    const googleData = eventData as GoogleEventData;
-    if (googleData.expiryTimeMillis) {
-      // GoogleはUnixタイムスタンプ（ミリ秒）なので、そのままISO 8601形式にする
-      return new Date(googleData.expiryTimeMillis).toISOString();
-    }
-  }
-
-  // デフォルト: 30日後
-  const defaultDate = new Date();
-  defaultDate.setDate(defaultDate.getDate() + 30);
-  return defaultDate.toISOString();
-}
-
-/**
  * イベントデータから請求期間（periodStart/periodEnd）を抽出
+ *
+ * 決済プロバイダーから取得した正確な期間情報のみを使用します。
+ * フォールバック値は使用せず、必須データが存在しない場合はエラーをthrowします。
  *
  * @param platform 決済プラットフォーム
  * @param eventData イベントデータ
  * @returns { periodStart, periodEnd } ISO 8601形式
+ * @throws Error 必須の期間データが存在しない場合、または未実装のプラットフォームの場合
  */
 function extractPeriodDates(
   platform: PlatformType,
   eventData: Record<string, unknown>
 ): { periodStart: string; periodEnd: string } {
-  const now = new Date();
-  const defaultEnd = new Date(now);
-  defaultEnd.setDate(defaultEnd.getDate() + 30);
-
   if (platform === 'stripe') {
     const stripeData = eventData as StripeEventData;
 
@@ -2021,26 +1980,30 @@ function extractPeriodDates(
       | number
       | undefined;
 
-    const periodStart = rawPeriodStart
-      ? new Date(rawPeriodStart * 1000).toISOString()
-      : stripeData.periodStart
-        ? new Date(stripeData.periodStart * 1000).toISOString()
-        : now.toISOString();
+    // eventDataのトップレベル、またはstripeDataから取得
+    const periodStartValue = rawPeriodStart ?? stripeData.periodStart;
+    const periodEndValue = rawPeriodEnd ?? stripeData.periodEnd;
 
-    const periodEnd = rawPeriodEnd
-      ? new Date(rawPeriodEnd * 1000).toISOString()
-      : stripeData.periodEnd
-        ? new Date(stripeData.periodEnd * 1000).toISOString()
-        : defaultEnd.toISOString();
+    // 必須データの存在チェック
+    if (!periodStartValue || !periodEndValue) {
+      throw new Error(
+        `Required billing period data not found in Stripe event. ` +
+          `periodStart: ${periodStartValue}, periodEnd: ${periodEndValue}. ` +
+          `This may indicate a bug in event extraction or an unexpected event structure.`
+      );
+    }
 
-    return { periodStart, periodEnd };
+    return {
+      periodStart: new Date(periodStartValue * 1000).toISOString(),
+      periodEnd: new Date(periodEndValue * 1000).toISOString(),
+    };
   }
 
-  // Apple/Googleの場合はデフォルト値を使用
-  return {
-    periodStart: now.toISOString(),
-    periodEnd: defaultEnd.toISOString(),
-  };
+  // Apple/Googleは現時点で未実装
+  throw new Error(
+    `Platform '${platform}' is not implemented for billing period extraction. ` +
+      `Only Stripe is currently supported.`
+  );
 }
 
 /**

--- a/packages/cdk/lambda/billing/orchestration/services/receiptEmailService.ts
+++ b/packages/cdk/lambda/billing/orchestration/services/receiptEmailService.ts
@@ -56,11 +56,12 @@ function createReceiptBodyContent(data: ReceiptData): string {
   const serviceName = getServiceName();
   const safePlanName = escapeHtml(data.planName);
 
-  const parentalControlNote = data.isParentalControl && data.childEmail
-    ? `<p style="margin: 0 0 16px 0; color: ${COLORS.text}; font-size: 14px;">
+  const parentalControlNote =
+    data.isParentalControl && data.childEmail
+      ? `<p style="margin: 0 0 16px 0; color: ${COLORS.text}; font-size: 14px;">
         お子様（${escapeHtml(data.childEmail)}）のサブスクリプションに関する領収書です。
       </p>`
-    : '';
+      : '';
 
   return `
     <h2 style="margin: 0 0 16px 0; color: ${COLORS.primary}; font-size: 20px;">お支払い完了のお知らせ</h2>
@@ -147,7 +148,9 @@ export async function buildReceiptDataFromInvoice(
   invoiceId: string,
   tenantId: string,
   planId?: string
-): Promise<Omit<ReceiptData, 'recipientEmail' | 'isParentalControl' | 'childEmail'>> {
+): Promise<
+  Omit<ReceiptData, 'recipientEmail' | 'isParentalControl' | 'childEmail'>
+> {
   // インボイスを取得（payments.data.payment.payment_intent と subscription を展開）
   const invoiceResponse = await stripe.invoices.retrieve(invoiceId, {
     expand: ['payments.data.payment.payment_intent', 'subscription'],
@@ -158,7 +161,8 @@ export async function buildReceiptDataFromInvoice(
   const amount = invoice.amount_paid ?? 0;
   const currency = invoice.currency || 'jpy';
   const paymentDate = new Date(invoice.created * 1000);
-  const invoiceNumber = invoice.number || `INV-${invoice.id.slice(-8).toUpperCase()}`;
+  const invoiceNumber =
+    invoice.number || `INV-${invoice.id.slice(-8).toUpperCase()}`;
 
   console.log('Building receipt data from invoice', {
     invoiceId,
@@ -172,22 +176,29 @@ export async function buildReceiptDataFromInvoice(
 
   // 請求期間
   const lineItem = invoice.lines?.data?.[0];
-  const billingPeriodStart = lineItem?.period?.start
-    ? new Date(lineItem.period.start * 1000)
-    : paymentDate;
-  const billingPeriodEnd = lineItem?.period?.end
-    ? new Date(lineItem.period.end * 1000)
-    : new Date(paymentDate.getTime() + 30 * 24 * 60 * 60 * 1000);
+  if (!lineItem?.period?.start || !lineItem?.period?.end) {
+    throw new Error(
+      `Unable to determine billing period from invoice ${invoice.id}. ` +
+        `Invoice must contain line item with period information.`
+    );
+  }
+  const billingPeriodStart = new Date(lineItem.period.start * 1000);
+  const billingPeriodEnd = new Date(lineItem.period.end * 1000);
   const nextBillingDate = billingPeriodEnd;
 
   // プラン名取得
   let planName = 'サブスクリプションプラン';
 
   // subscription が展開されている場合は直接メタデータを取得
-  const subscriptionObj = (invoice as unknown as Record<string, any>).subscription;
+  const subscriptionObj = (invoice as unknown as Record<string, any>)
+    .subscription;
   let effectivePlanId = planId;
 
-  if (!effectivePlanId && subscriptionObj && typeof subscriptionObj === 'object') {
+  if (
+    !effectivePlanId &&
+    subscriptionObj &&
+    typeof subscriptionObj === 'object'
+  ) {
     // 展開されたサブスクリプションから直接メタデータを取得
     const metadata = subscriptionObj.metadata;
     effectivePlanId = metadata?.planId || metadata?.newPlanId || null;
@@ -227,7 +238,10 @@ export async function buildReceiptDataFromInvoice(
         planName = plan.display_name;
       }
     } catch (error) {
-      console.warn('Failed to fetch plan name', { planId: effectivePlanId, error });
+      console.warn('Failed to fetch plan name', {
+        planId: effectivePlanId,
+        error,
+      });
     }
   } else {
     console.warn('No plan ID available for receipt, using default plan name');
@@ -248,14 +262,21 @@ export async function buildReceiptDataFromInvoice(
   };
 
   // ヘルパー関数: 顧客の支払い方法を取得してlast4を返す
-  const getPaymentMethodLast4 = async (customerId: string, pmId: string): Promise<string | null> => {
+  const getPaymentMethodLast4 = async (
+    customerId: string,
+    pmId: string
+  ): Promise<string | null> => {
     try {
       const pm = await stripe.customers.retrievePaymentMethod(customerId, pmId);
       if (pm.card?.last4) {
         return pm.card.last4;
       }
     } catch (error) {
-      console.warn('Failed to retrieve customer payment method', { customerId, pmId, error });
+      console.warn('Failed to retrieve customer payment method', {
+        customerId,
+        pmId,
+        error,
+      });
     }
     return null;
   };
@@ -281,7 +302,9 @@ export async function buildReceiptDataFromInvoice(
         const last4 = await getPaymentMethodLast4(customerId, pmId);
         if (last4) {
           paymentMethodLast4 = `****${last4}`;
-          console.log('Got last4 from subscription.default_payment_method', { last4 });
+          console.log('Got last4 from subscription.default_payment_method', {
+            last4,
+          });
         }
       }
     }
@@ -293,29 +316,41 @@ export async function buildReceiptDataFromInvoice(
         const last4 = await getPaymentMethodLast4(customerId, pmId);
         if (last4) {
           paymentMethodLast4 = `****${last4}`;
-          console.log('Got last4 from invoice.default_payment_method', { last4 });
+          console.log('Got last4 from invoice.default_payment_method', {
+            last4,
+          });
         }
       }
     }
 
     // 方法3: invoice.payments.data[0].payment.payment_intent.payment_method から取得
-    if (paymentMethodLast4 === '****' && invoiceAny.payments?.data?.length > 0) {
+    if (
+      paymentMethodLast4 === '****' &&
+      invoiceAny.payments?.data?.length > 0
+    ) {
       const firstPayment = invoiceAny.payments.data[0];
       if (firstPayment?.payment?.payment_intent) {
         const paymentIntentId = extractId(firstPayment.payment.payment_intent);
         if (paymentIntentId) {
           try {
-            const paymentIntent = await stripe.paymentIntents.retrieve(paymentIntentId);
+            const paymentIntent =
+              await stripe.paymentIntents.retrieve(paymentIntentId);
             const pmId = extractId(paymentIntent.payment_method);
             if (pmId) {
               const last4 = await getPaymentMethodLast4(customerId, pmId);
               if (last4) {
                 paymentMethodLast4 = `****${last4}`;
-                console.log('Got last4 from invoice.payments.payment.payment_intent.payment_method', { last4 });
+                console.log(
+                  'Got last4 from invoice.payments.payment.payment_intent.payment_method',
+                  { last4 }
+                );
               }
             }
           } catch (error) {
-            console.warn('Failed to retrieve payment intent', { paymentIntentId, error });
+            console.warn('Failed to retrieve payment intent', {
+              paymentIntentId,
+              error,
+            });
           }
         }
       }
@@ -330,18 +365,29 @@ export async function buildReceiptDataFromInvoice(
           type: 'card',
           limit: 1,
         });
-        if (paymentMethods.data.length > 0 && paymentMethods.data[0].card?.last4) {
+        if (
+          paymentMethods.data.length > 0 &&
+          paymentMethods.data[0].card?.last4
+        ) {
           paymentMethodLast4 = `****${paymentMethods.data[0].card.last4}`;
-          console.log('Got last4 from customer payment method list', { last4: paymentMethods.data[0].card.last4 });
+          console.log('Got last4 from customer payment method list', {
+            last4: paymentMethods.data[0].card.last4,
+          });
         }
       } catch (error) {
-        console.warn('Failed to list customer payment methods', { customerId, error });
+        console.warn('Failed to list customer payment methods', {
+          customerId,
+          error,
+        });
       }
     }
   }
 
   if (paymentMethodLast4 === '****') {
-    console.warn('Could not extract payment method last4 from any source', { invoiceId, customerId });
+    console.warn('Could not extract payment method last4 from any source', {
+      invoiceId,
+      customerId,
+    });
   }
 
   return {
@@ -364,12 +410,17 @@ export async function buildReceiptDataFromInvoice(
  * 1. planId - 新規購入時に設定されるプランID
  * 2. newPlanId - プラン変更時に設定される新しいプランID
  */
-async function extractPlanIdFromInvoice(stripe: Stripe, invoice: Stripe.Invoice): Promise<string | null> {
+async function extractPlanIdFromInvoice(
+  stripe: Stripe,
+  invoice: Stripe.Invoice
+): Promise<string | null> {
   // サブスクリプションIDを取得してメタデータを確認
-  const subscriptionField = (invoice as unknown as Record<string, unknown>).subscription;
-  const subscriptionId = typeof subscriptionField === 'string'
-    ? subscriptionField
-    : (subscriptionField as { id: string } | null)?.id;
+  const subscriptionField = (invoice as unknown as Record<string, unknown>)
+    .subscription;
+  const subscriptionId =
+    typeof subscriptionField === 'string'
+      ? subscriptionField
+      : (subscriptionField as { id: string } | null)?.id;
 
   if (subscriptionId) {
     try {
@@ -389,7 +440,10 @@ async function extractPlanIdFromInvoice(stripe: Stripe, invoice: Stripe.Invoice)
         return subscription.metadata.newPlanId;
       }
     } catch (error) {
-      console.warn('Failed to fetch subscription for planId extraction', { subscriptionId, error });
+      console.warn('Failed to fetch subscription for planId extraction', {
+        subscriptionId,
+        error,
+      });
     }
   }
 
@@ -411,21 +465,26 @@ export async function getReceiptRecipient(
   childEmail?: string;
 }> {
   try {
-    const subscription = await stripe.subscriptions.retrieve(platformSubscriptionId);
+    const subscription = await stripe.subscriptions.retrieve(
+      platformSubscriptionId
+    );
 
-    const isParentalControl = subscription.metadata?.isParentalControl === 'true';
+    const isParentalControl =
+      subscription.metadata?.isParentalControl === 'true';
     const childEmail = subscription.metadata?.childEmail;
 
     // カスタマーIDを取得
-    const customerId = typeof subscription.customer === 'string'
-      ? subscription.customer
-      : subscription.customer.id;
+    const customerId =
+      typeof subscription.customer === 'string'
+        ? subscription.customer
+        : subscription.customer.id;
 
     // Stripeカスタマーからメールアドレスを取得
     const customer = await stripe.customers.retrieve(customerId);
-    const customerEmail = (typeof customer !== 'string' && !customer.deleted && customer.email)
-      ? customer.email
-      : null;
+    const customerEmail =
+      typeof customer !== 'string' && !customer.deleted && customer.email
+        ? customer.email
+        : null;
 
     if (isParentalControl) {
       // ペアレンタルコントロール: Stripeカスタマーのメールアドレス（保護者）
@@ -449,7 +508,10 @@ export async function getReceiptRecipient(
 
     throw new Error('Unable to determine receipt recipient email');
   } catch (error) {
-    console.error('Failed to get receipt recipient', { platformSubscriptionId, error });
+    console.error('Failed to get receipt recipient', {
+      platformSubscriptionId,
+      error,
+    });
 
     // フォールバックメールがあれば使用
     if (fallbackEmail) {
@@ -474,6 +536,8 @@ export async function getUserEmail(
 ): Promise<string | null> {
   // Note: UserStripeMappingテーブルへのアクセスはAPI Gateway経由でのみ可能
   // orchestration flowでは直接アクセスできないため、nullを返してStripe Customerメールを使用
-  console.log('getUserEmail: Returning null, will use Stripe Customer email as fallback');
+  console.log(
+    'getUserEmail: Returning null, will use Stripe Customer email as fallback'
+  );
   return null;
 }

--- a/packages/cdk/lambda/billing/payment-gateway/verification/stripeVerifier.ts
+++ b/packages/cdk/lambda/billing/payment-gateway/verification/stripeVerifier.ts
@@ -28,6 +28,10 @@ export class StripeVerifier {
       // Stripe API Clover系では、current_period_start/endはSubscriptionItemレベルに移行
       const subscriptionItem = subscription.items.data[0];
 
+      const periodEnd = new Date(
+        subscriptionItem.current_period_end * 1000
+      ).toISOString();
+
       return {
         success: isActive,
         data: {
@@ -40,9 +44,8 @@ export class StripeVerifier {
           currentPeriodStart: new Date(
             subscriptionItem.current_period_start * 1000
           ).toISOString(),
-          currentPeriodEnd: new Date(
-            subscriptionItem.current_period_end * 1000
-          ).toISOString(),
+          currentPeriodEnd: periodEnd,
+          expiresAt: periodEnd,
           productId: subscriptionItem?.price?.id,
           cancelAtPeriodEnd: subscription.cancel_at_period_end,
           canceledAt: subscription.canceled_at
@@ -81,14 +84,31 @@ export class StripeVerifier {
 
       const isComplete = session.status === 'complete';
 
+      // サブスクリプション情報を取得
+      const subscription = session.subscription;
+      if (typeof subscription === 'string' || !subscription) {
+        throw new Error(
+          'Subscription not expanded or not available. Cannot retrieve expiration date.'
+        );
+      }
+
+      // Stripe API Clover系では、current_period_endはSubscriptionItemレベルに移行
+      const subscriptionItem = subscription.items.data[0];
+      if (!subscriptionItem?.current_period_end) {
+        throw new Error(
+          'Subscription period end not found. Cannot retrieve expiration date.'
+        );
+      }
+
+      const expiresAt = new Date(
+        subscriptionItem.current_period_end * 1000
+      ).toISOString();
+
       return {
         success: isComplete,
         data: {
           sessionId: session.id,
-          subscriptionId:
-            typeof session.subscription === 'string'
-              ? session.subscription
-              : session.subscription?.id,
+          subscriptionId: subscription.id,
           customerId:
             typeof session.customer === 'string'
               ? session.customer
@@ -97,6 +117,7 @@ export class StripeVerifier {
           amountTotal: session.amount_total,
           currency: session.currency,
           paymentStatus: session.payment_status,
+          expiresAt,
         },
       };
     } catch (error) {


### PR DESCRIPTION
## 変更の概要
stripeVerifierで正しく契約の終了日時を取得できていないという潜在的な問題が存在していた
そのエラーを握りつぶす形でのフォールバック処理として、契約日時の30日後を契約終了日時として適用する実装が存在していた
潜在的な問題の解消とフォールバック処理を削除し、正常な契約日時が適用されるように修正した


## 申し送り事項

<!-- レビュワーに伝えておきたい事柄等を書く（Draftの理由など） -->

## Checklist（レビュワー用）

- [ ] `npm run lint`でエラーが出ない
- [ ] TypeScriptのビルドで型エラーが出ない
- [ ] 手元でフォーマットした際に差分が出ない
