### PR TITLE
:sparkles: feat(billing): Stripeのsubscription.updatedでサブスクリプションステータスを同期

### DIFF
--- a/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
+++ b/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
@@ -1184,6 +1184,10 @@ async function handleSubscriptionUpdated(
 
   // イベントデータから抽出情報を取得
   // NOTE: _extracted はプラットフォーム固有のデータ構造（現在はStripeのみ対応）
+  // TODO: プラットフォーム共通の抽出データ型（ExtractedEventData）を定義し、
+  //       各プラットフォーム（Stripe/Apple/Google）のEventDataに統一的な_extractedを持たせる
+  // TODO: platformに応じた型ガード関数を実装し、型安全にイベントデータを取得する
+  //       例: isStripeEvent(eventData) / isAppleEvent(eventData) / isGoogleEvent(eventData)
   const stripeEventData = eventData as StripeEventData;
   const extracted = stripeEventData._extracted ?? {};
   const {

--- a/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
+++ b/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
@@ -1198,6 +1198,8 @@ async function handleSubscriptionUpdated(
     isPlanChange,
     isParentalControlPlanChange,
     status: platformStatus,
+    currentPeriodStart,
+    currentPeriodEnd,
   } = extracted;
 
   console.log('Extracted subscription update data', {
@@ -1208,6 +1210,8 @@ async function handleSubscriptionUpdated(
     previousPriceId,
     isPlanChange,
     platformStatus,
+    currentPeriodStart,
+    currentPeriodEnd,
   });
 
   // プラットフォームステータスから内部ステータスへのマッピング
@@ -1296,12 +1300,75 @@ async function handleSubscriptionUpdated(
     }
   }
 
+  // 期間同期処理（Stripeのみ、プラン変更の有無に関わらず実行）
+  // NOTE: 期間変更はStripeで手動調整や日割り計算などで発生する可能性がある
+  let periodSynced = false;
+  if (platform === 'stripe' && platformSubscriptionId && currentPeriodStart && currentPeriodEnd) {
+    try {
+      // 内部サブスクリプションを検索
+      const subscription = await invokeDataAccessFunctionByTenantId<{
+        subscription_id: string;
+        current_period_start: string;
+        current_period_end: string;
+      } | null>(tenantId, 'subscription', 'findByPlatformSubscriptionId', {
+        platformSubscriptionId,
+      });
+
+      if (subscription) {
+        // Stripeのタイムスタンプ（秒）をISO 8601形式に変換
+        const newPeriodStart = new Date(currentPeriodStart * 1000).toISOString();
+        const newPeriodEnd = new Date(currentPeriodEnd * 1000).toISOString();
+        const existingPeriodEnd = new Date(subscription.current_period_end).toISOString();
+
+        // 期間が変更されている場合のみ更新
+        if (existingPeriodEnd !== newPeriodEnd) {
+          console.log('Syncing subscription period from platform', {
+            platformSubscriptionId,
+            internalSubscriptionId: subscription.subscription_id,
+            existingPeriodEnd,
+            newPeriodStart,
+            newPeriodEnd,
+          });
+
+          const periodParams: ExtendSubscriptionPeriodParams = {
+            tenantId,
+            subscriptionId: subscription.subscription_id,
+            newPeriodStart,
+            newPeriodEnd,
+          };
+
+          await subscriptionClient.extendSubscriptionPeriod(periodParams);
+          periodSynced = true;
+
+          console.log('Subscription period synced successfully', {
+            subscriptionId: subscription.subscription_id,
+            newPeriodEnd,
+          });
+        } else {
+          console.log('Subscription period already in sync', {
+            platformSubscriptionId,
+            currentPeriodEnd: existingPeriodEnd,
+          });
+        }
+      }
+    } catch (error) {
+      // 期間同期エラーはログに記録するが、プラン変更処理は続行
+      console.error('Failed to sync subscription period', {
+        platformSubscriptionId,
+        currentPeriodStart,
+        currentPeriodEnd,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  }
+
   // プラン変更がない場合は処理をスキップ
   if (!isPlanChange) {
     console.log('No plan change detected, skipping plan change processing', {
       eventId,
       platformSubscriptionId,
       statusSynced: !!internalStatus,
+      periodSynced,
     });
 
     return {
@@ -1310,7 +1377,7 @@ async function handleSubscriptionUpdated(
       eventId,
       errorDetails: {
         errorCode: 'NO_PLAN_CHANGE',
-        errorMessage: 'Subscription updated but no plan change detected (status sync completed if applicable)',
+        errorMessage: 'Subscription updated but no plan change detected (status/period sync completed if applicable)',
       },
     };
   }

--- a/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
+++ b/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
@@ -1183,8 +1183,8 @@ async function handleSubscriptionUpdated(
   });
 
   // イベントデータから抽出情報を取得
-  const stripeData = eventData as StripeEventData;
-  const extracted = stripeData._extracted ?? {};
+  // NOTE: _extracted はプラットフォーム固有のデータ構造（現在はStripeのみ対応）
+  const extracted = (eventData as any)?._extracted ?? {};
   const {
     subscriptionId: platformSubscriptionId,
     userId,
@@ -1192,43 +1192,54 @@ async function handleSubscriptionUpdated(
     previousPriceId,
     isPlanChange,
     isParentalControlPlanChange,
-    status: stripeStatus,
+    status: platformStatus,
   } = extracted;
 
   console.log('Extracted subscription update data', {
+    platform,
     platformSubscriptionId,
     userId,
     currentPriceId,
     previousPriceId,
     isPlanChange,
-    stripeStatus,
+    platformStatus,
   });
 
-  // Stripeステータスから内部ステータスへのマッピング
+  // プラットフォームステータスから内部ステータスへのマッピング
+  // NOTE: 現在はStripeのみ対応。Apple/Googleは別のWebhookイベントでステータス管理される
   // TODO: 内部ステータスに 'trialing' を追加し、トライアル期間を明示的に管理する
-  const mapStripeStatusToInternal = (
+  const mapPlatformStatusToInternal = (
+    platformType: string,
     status: string | undefined
   ): 'active' | 'past_due' | 'canceled' | 'expired' | undefined => {
     if (!status) return undefined;
-    switch (status) {
-      case 'active':
-      case 'trialing': // TODO: 'trialing' 内部ステータス実装後は分離する
-        return 'active';
-      case 'past_due':
-      case 'unpaid': // unpaid: Smart Retriesが全て失敗した後の最終状態
-        return 'past_due';
-      case 'canceled':
-        return 'canceled';
-      case 'incomplete_expired':
-        return 'expired';
-      default:
-        // incomplete, paused などは変換しない（状態遷移が複雑なため）
-        return undefined;
+
+    // Stripeの場合のみステータスマッピングを行う
+    if (platformType === 'stripe') {
+      switch (status) {
+        case 'active':
+        case 'trialing': // TODO: 'trialing' 内部ステータス実装後は分離する
+          return 'active';
+        case 'past_due':
+        case 'unpaid': // unpaid: Smart Retriesが全て失敗した後の最終状態
+          return 'past_due';
+        case 'canceled':
+          return 'canceled';
+        case 'incomplete_expired':
+          return 'expired';
+        default:
+          // incomplete, paused などは変換しない（状態遷移が複雑なため）
+          return undefined;
+      }
     }
+
+    // Apple/Googleの場合は subscription.updated では同期しない
+    // （各プラットフォーム固有のWebhookで処理される）
+    return undefined;
   };
 
-  // ステータス同期処理（プラン変更の有無に関わらず実行）
-  const internalStatus = mapStripeStatusToInternal(stripeStatus as string);
+  // ステータス同期処理（Stripeのみ、プラン変更の有無に関わらず実行）
+  const internalStatus = mapPlatformStatusToInternal(platform, platformStatus as string);
   if (platformSubscriptionId && internalStatus) {
     try {
       // 内部サブスクリプションを検索
@@ -1240,12 +1251,12 @@ async function handleSubscriptionUpdated(
       });
 
       if (subscription && subscription.subscription_status !== internalStatus) {
-        console.log('Syncing subscription status from Stripe', {
+        console.log('Syncing subscription status from platform', {
           platformSubscriptionId,
           internalSubscriptionId: subscription.subscription_id,
           currentStatus: subscription.subscription_status,
           newStatus: internalStatus,
-          stripeStatus,
+          platformStatus,
         });
 
         const statusUpdateParams: UpdateSubscriptionStatusParams = {
@@ -1266,14 +1277,14 @@ async function handleSubscriptionUpdated(
         console.log('Subscription status already in sync', {
           platformSubscriptionId,
           currentStatus: subscription.subscription_status,
-          stripeStatus,
+          platformStatus,
         });
       }
     } catch (error) {
       // ステータス同期エラーはログに記録するが、プラン変更処理は続行
       console.error('Failed to sync subscription status', {
         platformSubscriptionId,
-        stripeStatus,
+        platformStatus,
         internalStatus,
         error: error instanceof Error ? error.message : 'Unknown error',
       });

--- a/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
+++ b/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
@@ -1192,6 +1192,7 @@ async function handleSubscriptionUpdated(
     previousPriceId,
     isPlanChange,
     isParentalControlPlanChange,
+    status: stripeStatus,
   } = extracted;
 
   console.log('Extracted subscription update data', {
@@ -1200,13 +1201,90 @@ async function handleSubscriptionUpdated(
     currentPriceId,
     previousPriceId,
     isPlanChange,
+    stripeStatus,
   });
+
+  // Stripeステータスから内部ステータスへのマッピング
+  const mapStripeStatusToInternal = (
+    status: string | undefined
+  ): 'active' | 'past_due' | 'canceled' | 'expired' | undefined => {
+    if (!status) return undefined;
+    switch (status) {
+      case 'active':
+      case 'trialing':
+        return 'active';
+      case 'past_due':
+      case 'unpaid':
+        return 'past_due';
+      case 'canceled':
+        return 'canceled';
+      case 'incomplete_expired':
+        return 'expired';
+      default:
+        // incomplete, paused などは変換しない（状態遷移が複雑なため）
+        return undefined;
+    }
+  };
+
+  // ステータス同期処理（プラン変更の有無に関わらず実行）
+  const internalStatus = mapStripeStatusToInternal(stripeStatus as string);
+  if (platformSubscriptionId && internalStatus) {
+    try {
+      // 内部サブスクリプションを検索
+      const subscription = await invokeDataAccessFunctionByTenantId<{
+        subscription_id: string;
+        subscription_status: string;
+      } | null>(tenantId, 'subscription', 'findByPlatformSubscriptionId', {
+        platformSubscriptionId,
+      });
+
+      if (subscription && subscription.subscription_status !== internalStatus) {
+        console.log('Syncing subscription status from Stripe', {
+          platformSubscriptionId,
+          internalSubscriptionId: subscription.subscription_id,
+          currentStatus: subscription.subscription_status,
+          newStatus: internalStatus,
+          stripeStatus,
+        });
+
+        const statusUpdateParams: UpdateSubscriptionStatusParams = {
+          tenantId,
+          subscriptionId: subscription.subscription_id,
+          newStatus: internalStatus,
+        };
+
+        const statusResult =
+          await subscriptionClient.updateSubscriptionStatus(statusUpdateParams);
+
+        console.log('Subscription status synced successfully', {
+          subscriptionId: subscription.subscription_id,
+          previousStatus: statusResult.previousStatus,
+          newStatus: statusResult.newStatus,
+        });
+      } else if (subscription) {
+        console.log('Subscription status already in sync', {
+          platformSubscriptionId,
+          currentStatus: subscription.subscription_status,
+          stripeStatus,
+        });
+      }
+    } catch (error) {
+      // ステータス同期エラーはログに記録するが、プラン変更処理は続行
+      console.error('Failed to sync subscription status', {
+        platformSubscriptionId,
+        stripeStatus,
+        internalStatus,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  }
 
   // プラン変更がない場合は処理をスキップ
   if (!isPlanChange) {
-    console.log('No plan change detected, skipping processing', {
+    console.log('No plan change detected, skipping plan change processing', {
       eventId,
       platformSubscriptionId,
+      statusSynced: !!internalStatus,
     });
 
     return {
@@ -1215,7 +1293,7 @@ async function handleSubscriptionUpdated(
       eventId,
       errorDetails: {
         errorCode: 'NO_PLAN_CHANGE',
-        errorMessage: 'Subscription updated but no plan change detected',
+        errorMessage: 'Subscription updated but no plan change detected (status sync completed if applicable)',
       },
     };
   }

--- a/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
+++ b/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
@@ -1205,16 +1205,17 @@ async function handleSubscriptionUpdated(
   });
 
   // Stripeステータスから内部ステータスへのマッピング
+  // TODO: 内部ステータスに 'trialing' を追加し、トライアル期間を明示的に管理する
   const mapStripeStatusToInternal = (
     status: string | undefined
   ): 'active' | 'past_due' | 'canceled' | 'expired' | undefined => {
     if (!status) return undefined;
     switch (status) {
       case 'active':
-      case 'trialing':
+      case 'trialing': // TODO: 'trialing' 内部ステータス実装後は分離する
         return 'active';
       case 'past_due':
-      case 'unpaid':
+      case 'unpaid': // unpaid: Smart Retriesが全て失敗した後の最終状態
         return 'past_due';
       case 'canceled':
         return 'canceled';

--- a/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
+++ b/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
@@ -150,6 +150,10 @@ interface EventDetailPayload {
   subscriptionId?: string;
   /** プラットフォームサブスクリプションID（Stripe等のサブスクリプションID） */
   platformSubscriptionId?: string;
+  /** 請求期間開始日時（Unixタイムスタンプ、秒） */
+  periodStart?: number;
+  /** 請求期間終了日時（Unixタイムスタンプ、秒） */
+  periodEnd?: number;
 }
 
 /**
@@ -413,7 +417,13 @@ async function handlePaymentSucceeded(
   const userId = input.userId || extractUserId(platform, eventData);
 
   // periodStart/periodEndの抽出（Stripeから取得）
-  const { periodStart, periodEnd } = extractPeriodDates(platform, eventData);
+  // NOTE: input.periodStart/periodEndはEventDetailPayloadで直接渡される（eventExtractorで抽出済み）
+  const { periodStart, periodEnd } = extractPeriodDates(
+    platform,
+    eventData,
+    input.periodStart,
+    input.periodEnd
+  );
 
   // 前のステップの結果を保持する変数
   const previousStepResults: Record<string, unknown> = {};
@@ -2163,11 +2173,15 @@ function extractExpirationDate(
  *
  * @param platform 決済プラットフォーム
  * @param eventData イベントデータ
+ * @param inputPeriodStart EventDetailPayloadから直接取得した期間開始（優先）
+ * @param inputPeriodEnd EventDetailPayloadから直接取得した期間終了（優先）
  * @returns { periodStart, periodEnd } ISO 8601形式
  */
 function extractPeriodDates(
   platform: PlatformType,
-  eventData: Record<string, unknown>
+  eventData: Record<string, unknown>,
+  inputPeriodStart?: number,
+  inputPeriodEnd?: number
 ): { periodStart: string; periodEnd: string } {
   const now = new Date();
   const defaultEnd = new Date(now);
@@ -2176,12 +2190,14 @@ function extractPeriodDates(
   if (platform === 'stripe') {
     const stripeData = eventData as StripeEventData;
 
-    // periodStart/periodEndがeventDataのトップレベルにある場合（eventExtractorで抽出済み）
-    const rawPeriodStart = (eventData as Record<string, unknown>)
-      .periodStart as number | undefined;
-    const rawPeriodEnd = (eventData as Record<string, unknown>).periodEnd as
-      | number
-      | undefined;
+    // 優先順位: 1. input直接 → 2. eventData → 3. stripeData → 4. デフォルト
+    // NOTE: EventDetailPayloadのperiodStart/periodEndはeventExtractorで抽出済み
+    const rawPeriodStart =
+      inputPeriodStart ??
+      ((eventData as Record<string, unknown>).periodStart as number | undefined);
+    const rawPeriodEnd =
+      inputPeriodEnd ??
+      ((eventData as Record<string, unknown>).periodEnd as number | undefined);
 
     const periodStart = rawPeriodStart
       ? new Date(rawPeriodStart * 1000).toISOString()

--- a/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
+++ b/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
@@ -1184,7 +1184,8 @@ async function handleSubscriptionUpdated(
 
   // イベントデータから抽出情報を取得
   // NOTE: _extracted はプラットフォーム固有のデータ構造（現在はStripeのみ対応）
-  const extracted = (eventData as any)?._extracted ?? {};
+  const stripeEventData = eventData as StripeEventData;
+  const extracted = stripeEventData._extracted ?? {};
   const {
     subscriptionId: platformSubscriptionId,
     userId,

--- a/packages/cdk/lambda/billing/orchestration/types/eventTypes.ts
+++ b/packages/cdk/lambda/billing/orchestration/types/eventTypes.ts
@@ -117,6 +117,9 @@ export interface StripeEventData {
     isPlanChange?: boolean;
     isParentalControlPlanChange?: boolean;
     status?: string;
+    // 期間情報（Unixタイムスタンプ、秒）
+    currentPeriodStart?: number;
+    currentPeriodEnd?: number;
     // Checkoutベースのプラン変更用フィールド
     newPlanId?: string;
     previousPlanId?: string;

--- a/packages/cdk/lambda/billing/payment-gateway/webhook/stripe/eventExtractor.ts
+++ b/packages/cdk/lambda/billing/payment-gateway/webhook/stripe/eventExtractor.ts
@@ -298,6 +298,10 @@ function extractFromSubscriptionUpdated(
     });
   }
 
+  // 期間情報の抽出（Unixタイムスタンプ、秒）
+  const currentPeriodStart = subscription.current_period_start;
+  const currentPeriodEnd = subscription.current_period_end;
+
   console.log('Subscription updated event details', {
     subscriptionId,
     userId,
@@ -305,6 +309,9 @@ function extractFromSubscriptionUpdated(
     previousPriceId,
     isPlanChange,
     isParentalControlPlanChange,
+    status: subscription.status,
+    currentPeriodStart,
+    currentPeriodEnd,
     previousAttributesKeys: Object.keys(previousAttributes),
   });
 
@@ -329,6 +336,8 @@ function extractFromSubscriptionUpdated(
         isPlanChange,
         isParentalControlPlanChange,
         status: subscription.status,
+        currentPeriodStart,
+        currentPeriodEnd,
       },
     },
   };


### PR DESCRIPTION
## 概要

Stripeの`customer.subscription.updated` Webhookイベントを利用して、内部サブスクリプションのステータスをStripeのステータスと自動同期する機能を実装しました。

## 背景・課題

自動課金（auto-billing）のリトライが成功した場合など、Stripeでサブスクリプションステータスが変更されても、内部DBのステータスが更新されない問題がありました。

例：
- 支払い失敗で `past_due` になった後、リトライ成功で Stripe側は `active` に戻る
- しかし内部DBは `past_due` のまま残ってしまう

## 変更内容

### `webhookEventFlow.ts`

- `handleSubscriptionUpdated` 関数にステータス同期処理を追加
- Stripeステータスから内部ステータスへのマッピング関数を実装
- プラン変更の有無に関わらず、ステータス同期を実行

### ステータスマッピング

| Stripeステータス | 内部ステータス |
|-----------------|---------------|
| `active` | `active` |
| `trialing` | `active` (TODO: 将来的に分離) |
| `past_due` | `past_due` |
| `unpaid` | `past_due` |
| `canceled` | `canceled` |
| `incomplete_expired` | `expired` |
| その他 | 同期しない |

## 処理フロー

```
customer.subscription.updated (Stripe Webhook)
       ↓
ステータス抽出
       ↓
内部ステータスへマッピング
       ↓
内部サブスクリプション検索
       ↓
ステータス変更あり → updateSubscriptionStatus() 呼び出し
       ↓
プラン変更処理（該当する場合）
```

## TODO

- [ ] 内部ステータスに `trialing` を追加し、トライアル期間を明示的に管理する

## テスト計画

- [ ] `past_due` → `active` のステータス遷移が正しく同期されることを確認
- [ ] プラン変更と同時にステータス変更があった場合、両方が処理されることを確認
- [ ] ステータス同期エラー時もプラン変更処理が続行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)