### PR TITLE
:sparkles: feat(user): ユーザーメタデータAPI（GET/PUT /user/metadata）の追加

### DIFF
--- a/packages/cdk/lambda/getUserMetadata.ts
+++ b/packages/cdk/lambda/getUserMetadata.ts
@@ -1,0 +1,69 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
+import { verifyToken } from './utils/auth';
+import {
+  internalServerError500Response,
+  ok200Response,
+  unauthorized401Response,
+} from './utils/apiResponse';
+
+const dynamoClient = new DynamoDBClient({
+  region: process.env.AWS_REGION!,
+});
+const docClient = DynamoDBDocumentClient.from(dynamoClient);
+
+const USER_REGISTRATION_METADATA_TABLE_NAME =
+  process.env.USER_REGISTRATION_METADATA_TABLE_NAME!;
+
+interface GetUserMetadataResponse {
+  metadata: Record<string, string>;
+}
+
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    const authHeader =
+      event.headers.Authorization || event.headers.authorization;
+    if (!authHeader) {
+      return unauthorized401Response({
+        message: 'Authorization header is required',
+      });
+    }
+
+    const token = authHeader.startsWith('Bearer ')
+      ? authHeader.slice(7)
+      : authHeader;
+
+    const claims = await verifyToken(token);
+    if (!claims) {
+      return unauthorized401Response({ message: 'Invalid or expired token' });
+    }
+
+    const userId = claims.sub;
+    if (!userId) {
+      return unauthorized401Response({
+        message: 'User ID not found in token',
+      });
+    }
+
+    const result = await docClient.send(
+      new GetCommand({
+        TableName: USER_REGISTRATION_METADATA_TABLE_NAME,
+        Key: { userId },
+        ProjectionExpression: 'metadata',
+      })
+    );
+
+    const metadata = (result.Item?.metadata as Record<string, string>) || {};
+
+    return ok200Response<GetUserMetadataResponse>({ metadata });
+  } catch (error) {
+    console.error('Error getting user metadata:', error);
+    return internalServerError500Response({
+      message: 'Failed to get user metadata',
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+};

--- a/packages/cdk/lambda/getUserMetadata.ts
+++ b/packages/cdk/lambda/getUserMetadata.ts
@@ -63,7 +63,6 @@ export const handler = async (
     console.error('Error getting user metadata:', error);
     return internalServerError500Response({
       message: 'Failed to get user metadata',
-      error: error instanceof Error ? error.message : 'Unknown error',
     });
   }
 };

--- a/packages/cdk/lambda/putUserMetadata.ts
+++ b/packages/cdk/lambda/putUserMetadata.ts
@@ -1,0 +1,168 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  UpdateCommand,
+} from '@aws-sdk/lib-dynamodb';
+import { verifyToken } from './utils/auth';
+import {
+  badRequest400Response,
+  internalServerError500Response,
+  ok200Response,
+  unauthorized401Response,
+} from './utils/apiResponse';
+
+const dynamoClient = new DynamoDBClient({
+  region: process.env.AWS_REGION!,
+});
+const docClient = DynamoDBDocumentClient.from(dynamoClient);
+
+const USER_REGISTRATION_METADATA_TABLE_NAME =
+  process.env.USER_REGISTRATION_METADATA_TABLE_NAME!;
+
+const MAX_METADATA_SIZE_BYTES = 100 * 1024; // 100KB
+
+interface PutUserMetadataRequest {
+  metadata: Record<string, string>;
+  mode?: 'merge' | 'replace';
+}
+
+interface PutUserMetadataResponse {
+  message: string;
+  metadata: Record<string, string>;
+}
+
+function validateMetadata(metadata: unknown): string | null {
+  if (metadata === null || metadata === undefined) {
+    return 'metadata is required';
+  }
+  if (typeof metadata !== 'object' || Array.isArray(metadata)) {
+    return 'metadata must be an object';
+  }
+
+  for (const [key, value] of Object.entries(metadata)) {
+    if (typeof key !== 'string' || key.length === 0) {
+      return 'metadata keys must be non-empty strings';
+    }
+    if (typeof value !== 'string') {
+      return `metadata value for key "${key}" must be a string`;
+    }
+  }
+
+  const size = Buffer.byteLength(JSON.stringify(metadata), 'utf8');
+  if (size > MAX_METADATA_SIZE_BYTES) {
+    return `metadata exceeds maximum size of ${MAX_METADATA_SIZE_BYTES} bytes`;
+  }
+
+  return null;
+}
+
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    const authHeader =
+      event.headers.Authorization || event.headers.authorization;
+    if (!authHeader) {
+      return unauthorized401Response({
+        message: 'Authorization header is required',
+      });
+    }
+
+    const token = authHeader.startsWith('Bearer ')
+      ? authHeader.slice(7)
+      : authHeader;
+
+    const claims = await verifyToken(token);
+    if (!claims) {
+      return unauthorized401Response({ message: 'Invalid or expired token' });
+    }
+
+    const userId = claims.sub;
+    if (!userId) {
+      return unauthorized401Response({
+        message: 'User ID not found in token',
+      });
+    }
+
+    let requestBody: PutUserMetadataRequest;
+    try {
+      requestBody = JSON.parse(event.body || '{}');
+    } catch {
+      return badRequest400Response({ message: 'Invalid JSON in request body' });
+    }
+
+    const validationError = validateMetadata(requestBody.metadata);
+    if (validationError) {
+      return badRequest400Response({ message: validationError });
+    }
+
+    const mode = requestBody.mode || 'merge';
+    const newMetadata = requestBody.metadata;
+
+    let finalMetadata: Record<string, string>;
+
+    if (mode === 'replace') {
+      await docClient.send(
+        new UpdateCommand({
+          TableName: USER_REGISTRATION_METADATA_TABLE_NAME,
+          Key: { userId },
+          UpdateExpression:
+            'SET metadata = :metadata, metadataUpdatedAt = :updatedAt',
+          ExpressionAttributeValues: {
+            ':metadata': newMetadata,
+            ':updatedAt': new Date().toISOString(),
+          },
+        })
+      );
+      finalMetadata = newMetadata;
+    } else {
+      const existingResult = await docClient.send(
+        new GetCommand({
+          TableName: USER_REGISTRATION_METADATA_TABLE_NAME,
+          Key: { userId },
+          ProjectionExpression: 'metadata',
+        })
+      );
+
+      const existingMetadata =
+        (existingResult.Item?.metadata as Record<string, string>) || {};
+      finalMetadata = { ...existingMetadata, ...newMetadata };
+
+      const mergedSize = Buffer.byteLength(
+        JSON.stringify(finalMetadata),
+        'utf8'
+      );
+      if (mergedSize > MAX_METADATA_SIZE_BYTES) {
+        return badRequest400Response({
+          message: `merged metadata exceeds maximum size of ${MAX_METADATA_SIZE_BYTES} bytes`,
+        });
+      }
+
+      await docClient.send(
+        new UpdateCommand({
+          TableName: USER_REGISTRATION_METADATA_TABLE_NAME,
+          Key: { userId },
+          UpdateExpression:
+            'SET metadata = :metadata, metadataUpdatedAt = :updatedAt',
+          ExpressionAttributeValues: {
+            ':metadata': finalMetadata,
+            ':updatedAt': new Date().toISOString(),
+          },
+        })
+      );
+    }
+
+    return ok200Response<PutUserMetadataResponse>({
+      message: 'Metadata updated successfully',
+      metadata: finalMetadata,
+    });
+  } catch (error) {
+    console.error('Error updating user metadata:', error);
+    return internalServerError500Response({
+      message: 'Failed to update user metadata',
+      error: error instanceof Error ? error.message : 'Unknown error',
+    });
+  }
+};

--- a/packages/cdk/lambda/putUserMetadata.ts
+++ b/packages/cdk/lambda/putUserMetadata.ts
@@ -1,4 +1,5 @@
 import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { ConditionalCheckFailedException } from '@aws-sdk/client-dynamodb';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import {
   DynamoDBDocumentClient,
@@ -8,6 +9,7 @@ import {
 import { verifyToken } from './utils/auth';
 import {
   badRequest400Response,
+  conflict409Response,
   internalServerError500Response,
   ok200Response,
   unauthorized401Response,
@@ -98,6 +100,15 @@ export const handler = async (
       return badRequest400Response({ message: validationError });
     }
 
+    if (
+      requestBody.mode !== undefined &&
+      !['merge', 'replace'].includes(requestBody.mode)
+    ) {
+      return badRequest400Response({
+        message: 'mode must be merge or replace',
+      });
+    }
+
     const mode = requestBody.mode || 'merge';
     const newMetadata = requestBody.metadata;
 
@@ -122,12 +133,14 @@ export const handler = async (
         new GetCommand({
           TableName: USER_REGISTRATION_METADATA_TABLE_NAME,
           Key: { userId },
-          ProjectionExpression: 'metadata',
+          ProjectionExpression: 'metadata, metadataUpdatedAt',
         })
       );
 
       const existingMetadata =
         (existingResult.Item?.metadata as Record<string, string>) || {};
+      const prevUpdatedAt =
+        (existingResult.Item?.metadataUpdatedAt as string | undefined) ?? null;
       finalMetadata = { ...existingMetadata, ...newMetadata };
 
       const mergedSize = Buffer.byteLength(
@@ -140,18 +153,31 @@ export const handler = async (
         });
       }
 
-      await docClient.send(
-        new UpdateCommand({
-          TableName: USER_REGISTRATION_METADATA_TABLE_NAME,
-          Key: { userId },
-          UpdateExpression:
-            'SET metadata = :metadata, metadataUpdatedAt = :updatedAt',
-          ExpressionAttributeValues: {
-            ':metadata': finalMetadata,
-            ':updatedAt': new Date().toISOString(),
-          },
-        })
-      );
+      try {
+        await docClient.send(
+          new UpdateCommand({
+            TableName: USER_REGISTRATION_METADATA_TABLE_NAME,
+            Key: { userId },
+            UpdateExpression:
+              'SET metadata = :metadata, metadataUpdatedAt = :updatedAt',
+            ConditionExpression:
+              'attribute_not_exists(metadataUpdatedAt) OR metadataUpdatedAt = :prevUpdatedAt',
+            ExpressionAttributeValues: {
+              ':metadata': finalMetadata,
+              ':updatedAt': new Date().toISOString(),
+              ':prevUpdatedAt': prevUpdatedAt,
+            },
+          })
+        );
+      } catch (error) {
+        if (error instanceof ConditionalCheckFailedException) {
+          return conflict409Response({
+            message:
+              'Metadata was modified by another request. Please retry the operation.',
+          });
+        }
+        throw error;
+      }
     }
 
     return ok200Response<PutUserMetadataResponse>({
@@ -162,7 +188,6 @@ export const handler = async (
     console.error('Error updating user metadata:', error);
     return internalServerError500Response({
       message: 'Failed to update user metadata',
-      error: error instanceof Error ? error.message : 'Unknown error',
     });
   }
 };

--- a/packages/cdk/lib/construct/api/user.ts
+++ b/packages/cdk/lib/construct/api/user.ts
@@ -57,28 +57,26 @@ class UserApi extends Construct {
 
     // Lambda function for setting birthdate
     // テーブル名を環境変数から構築（auth.tsと同じ命名規則）
-    const userRegistrationMetadataTableName = props.userRegistrationMetadataTable
-      ? props.userRegistrationMetadataTable.tableName
-      : props.environment
-        ? `UserRegistrationMetadata-${props.environment}`
-        : 'UserRegistrationMetadata';
+    const userRegistrationMetadataTableName =
+      props.userRegistrationMetadataTable
+        ? props.userRegistrationMetadataTable.tableName
+        : props.environment
+          ? `UserRegistrationMetadata-${props.environment}`
+          : 'UserRegistrationMetadata';
 
-    const setBirthdateFunction = new NodejsFunction(
-      this,
-      'SetBirthdate',
-      {
-        runtime: LAMBDA_RUNTIME_NODEJS,
-        entry: './lambda/setBirthdate.ts',
-        timeout: Duration.minutes(1),
-        bundling: {
-          nodeModules: ['aws-jwt-verify'],
-        },
-        environment: getBaseEnvironment(this, props, {
-          USER_POOL_CLIENT_ID: userPoolClient.userPoolClientId,
-          USER_REGISTRATION_METADATA_TABLE_NAME: userRegistrationMetadataTableName,
-        }),
-      }
-    );
+    const setBirthdateFunction = new NodejsFunction(this, 'SetBirthdate', {
+      runtime: LAMBDA_RUNTIME_NODEJS,
+      entry: './lambda/setBirthdate.ts',
+      timeout: Duration.minutes(1),
+      bundling: {
+        nodeModules: ['aws-jwt-verify'],
+      },
+      environment: getBaseEnvironment(this, props, {
+        USER_POOL_CLIENT_ID: userPoolClient.userPoolClientId,
+        USER_REGISTRATION_METADATA_TABLE_NAME:
+          userRegistrationMetadataTableName,
+      }),
+    });
 
     // Grant DynamoDB write permission
     if (props.userRegistrationMetadataTable) {
@@ -89,10 +87,7 @@ class UserApi extends Construct {
       setBirthdateFunction.addToRolePolicy(
         new PolicyStatement({
           effect: Effect.ALLOW,
-          actions: [
-            'dynamodb:UpdateItem',
-            'dynamodb:PutItem',
-          ],
+          actions: ['dynamodb:UpdateItem', 'dynamodb:PutItem'],
           resources: [
             `arn:aws:dynamodb:${stack.region}:${stack.account}:table/${userRegistrationMetadataTableName}`,
           ],
@@ -114,6 +109,101 @@ class UserApi extends Construct {
     birthdateResource.addMethod(
       'PUT',
       new LambdaIntegration(setBirthdateFunction),
+      commonAuthorizerProps
+    );
+
+    // Lambda function for getting user metadata
+    const getUserMetadataFunction = new NodejsFunction(
+      this,
+      'GetUserMetadata',
+      {
+        runtime: LAMBDA_RUNTIME_NODEJS,
+        entry: './lambda/getUserMetadata.ts',
+        timeout: Duration.minutes(1),
+        bundling: {
+          nodeModules: ['aws-jwt-verify'],
+        },
+        environment: getBaseEnvironment(this, props, {
+          USER_POOL_CLIENT_ID: userPoolClient.userPoolClientId,
+          USER_REGISTRATION_METADATA_TABLE_NAME:
+            userRegistrationMetadataTableName,
+        }),
+      }
+    );
+
+    // Grant DynamoDB read permission for getUserMetadata
+    if (props.userRegistrationMetadataTable) {
+      props.userRegistrationMetadataTable.grantReadData(
+        getUserMetadataFunction
+      );
+    } else {
+      const stack = Stack.of(this);
+      getUserMetadataFunction.addToRolePolicy(
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: ['dynamodb:GetItem'],
+          resources: [
+            `arn:aws:dynamodb:${stack.region}:${stack.account}:table/${userRegistrationMetadataTableName}`,
+          ],
+        })
+      );
+    }
+
+    // Lambda function for updating user metadata
+    const putUserMetadataFunction = new NodejsFunction(
+      this,
+      'PutUserMetadata',
+      {
+        runtime: LAMBDA_RUNTIME_NODEJS,
+        entry: './lambda/putUserMetadata.ts',
+        timeout: Duration.minutes(1),
+        bundling: {
+          nodeModules: ['aws-jwt-verify'],
+        },
+        environment: getBaseEnvironment(this, props, {
+          USER_POOL_CLIENT_ID: userPoolClient.userPoolClientId,
+          USER_REGISTRATION_METADATA_TABLE_NAME:
+            userRegistrationMetadataTableName,
+        }),
+      }
+    );
+
+    // Grant DynamoDB read/write permission for putUserMetadata
+    if (props.userRegistrationMetadataTable) {
+      props.userRegistrationMetadataTable.grantReadWriteData(
+        putUserMetadataFunction
+      );
+    } else {
+      const stack = Stack.of(this);
+      putUserMetadataFunction.addToRolePolicy(
+        new PolicyStatement({
+          effect: Effect.ALLOW,
+          actions: [
+            'dynamodb:GetItem',
+            'dynamodb:UpdateItem',
+            'dynamodb:PutItem',
+          ],
+          resources: [
+            `arn:aws:dynamodb:${stack.region}:${stack.account}:table/${userRegistrationMetadataTableName}`,
+          ],
+        })
+      );
+    }
+
+    // API routes for metadata
+    const metadataResource = userResource.addResource('metadata');
+
+    // GET /user/metadata - Get user metadata
+    metadataResource.addMethod(
+      'GET',
+      new LambdaIntegration(getUserMetadataFunction),
+      commonAuthorizerProps
+    );
+
+    // PUT /user/metadata - Update user metadata
+    metadataResource.addMethod(
+      'PUT',
+      new LambdaIntegration(putUserMetadataFunction),
       commonAuthorizerProps
     );
   }

--- a/packages/web/src/hooks/useUserMetadata.ts
+++ b/packages/web/src/hooks/useUserMetadata.ts
@@ -1,0 +1,146 @@
+import { create } from 'zustand';
+import { useCallback, useEffect, useRef } from 'react';
+import useHttp from './useHttp';
+
+export type UserMetadata = Record<string, string>;
+
+interface UserMetadataState {
+  metadata: UserMetadata;
+  isLoading: boolean;
+  isInitialized: boolean;
+  error: string | null;
+  setMetadata: (metadata: UserMetadata) => void;
+  setLoading: (loading: boolean) => void;
+  setInitialized: (initialized: boolean) => void;
+  setError: (error: string | null) => void;
+  reset: () => void;
+}
+
+const useUserMetadataStore = create<UserMetadataState>((set) => ({
+  metadata: {},
+  isLoading: false,
+  isInitialized: false,
+  error: null,
+  setMetadata: (metadata) => set({ metadata }),
+  setLoading: (isLoading) => set({ isLoading }),
+  setInitialized: (isInitialized) => set({ isInitialized }),
+  setError: (error) => set({ error }),
+  reset: () =>
+    set({
+      metadata: {},
+      isLoading: false,
+      isInitialized: false,
+      error: null,
+    }),
+}));
+
+interface GetUserMetadataResponse {
+  metadata: UserMetadata;
+}
+
+interface PutUserMetadataResponse {
+  message: string;
+  metadata: UserMetadata;
+}
+
+interface UseUserMetadataOptions {
+  syncOnMount?: boolean;
+}
+
+export const useUserMetadata = (options: UseUserMetadataOptions = {}) => {
+  const { syncOnMount = true } = options;
+  const { api } = useHttp();
+  const {
+    metadata,
+    isLoading,
+    isInitialized,
+    error,
+    setMetadata,
+    setLoading,
+    setInitialized,
+    setError,
+    reset,
+  } = useUserMetadataStore();
+
+  const fetchInProgress = useRef(false);
+
+  const fetchMetadata = useCallback(async () => {
+    if (fetchInProgress.current) return;
+    fetchInProgress.current = true;
+
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await api.get<GetUserMetadataResponse>('/user/metadata');
+      setMetadata(response.data.metadata);
+      setInitialized(true);
+    } catch (err) {
+      console.error('Failed to fetch user metadata:', err);
+      setError('Failed to fetch user metadata');
+    } finally {
+      setLoading(false);
+      fetchInProgress.current = false;
+    }
+  }, [api, setMetadata, setLoading, setInitialized, setError]);
+
+  const saveMetadata = useCallback(
+    async (
+      updates: UserMetadata,
+      mode: 'merge' | 'replace' = 'merge'
+    ): Promise<UserMetadata> => {
+      setLoading(true);
+      setError(null);
+
+      try {
+        const response = await api.put<PutUserMetadataResponse>(
+          '/user/metadata',
+          { metadata: updates, mode }
+        );
+        setMetadata(response.data.metadata);
+        return response.data.metadata;
+      } catch (err) {
+        console.error('Failed to save user metadata:', err);
+        setError('Failed to save user metadata');
+        throw err;
+      } finally {
+        setLoading(false);
+      }
+    },
+    [api, setMetadata, setLoading, setError]
+  );
+
+  const updateMetadataKey = useCallback(
+    async (key: string, value: string): Promise<UserMetadata> => {
+      return saveMetadata({ [key]: value }, 'merge');
+    },
+    [saveMetadata]
+  );
+
+  const getMetadataKey = useCallback(
+    (key: string): string | undefined => {
+      return metadata[key];
+    },
+    [metadata]
+  );
+
+  useEffect(() => {
+    if (syncOnMount && !isInitialized && !isLoading) {
+      fetchMetadata();
+    }
+  }, [syncOnMount, isInitialized, isLoading, fetchMetadata]);
+
+  return {
+    metadata,
+    isLoading,
+    isInitialized,
+    error,
+    fetchMetadata,
+    saveMetadata,
+    updateMetadataKey,
+    getMetadataKey,
+    reset,
+  };
+};
+
+export default useUserMetadata;


### PR DESCRIPTION
## Summary
- ユーザーごとのカスタムメタデータを保存・取得できるAPIエンドポイントを追加
- `GET /user/metadata`: ユーザーのメタデータを取得
- `PUT /user/metadata`: メタデータを更新（merge/replaceモード対応、100KB制限）
- フロントエンド用の `useUserMetadata` hook を追加（Zustandで状態管理）

## Changes
- `packages/cdk/lambda/getUserMetadata.ts`: メタデータ取得Lambda
- `packages/cdk/lambda/putUserMetadata.ts`: メタデータ更新Lambda
- `packages/cdk/lib/construct/api/user.ts`: API Gatewayエンドポイント追加
- `packages/web/src/hooks/useUserMetadata.ts`: React hook追加

## Test plan
- [ ] `GET /user/metadata` で空のメタデータが取得できること
- [ ] `PUT /user/metadata` でメタデータが保存できること
- [ ] mergeモードで既存のメタデータとマージされること
- [ ] replaceモードで既存のメタデータが置換されること
- [ ] 100KB超のメタデータで400エラーが返ること
- [ ] 未認証リクエストで401エラーが返ること

🤖 Generated with [Claude Code](https://claude.ai/code)