### PR TITLE
🚨 🔧 `Resolve error: unable to load resolver "node"`のエラーを修正

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -62,6 +62,10 @@ module.exports = defineConfig([
       },
     },
     settings: {
+      'import/resolver': {
+        typescript: true,
+        node: true,
+      },
       tailwindcss: {
         whitelist: ['w-', 'h-'],
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@typescript-eslint/eslint-plugin": "8.44.0",
         "@typescript-eslint/parser": "8.44.0",
         "eslint": "9.35.0",
+        "eslint-import-resolver-typescript": "^4.4.4",
         "eslint-plugin-i18nhelper": "1.0.0",
         "eslint-plugin-react-hooks": "5.2.0",
         "eslint-plugin-react-refresh": "0.4.20",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@typescript-eslint/eslint-plugin": "8.44.0",
     "@typescript-eslint/parser": "8.44.0",
     "eslint": "9.35.0",
+    "eslint-import-resolver-typescript": "^4.4.4",
     "eslint-plugin-i18nhelper": "1.0.0",
     "eslint-plugin-react-hooks": "5.2.0",
     "eslint-plugin-react-refresh": "0.4.20",


### PR DESCRIPTION
## Summary

フロントエンドのファイルに対し、`Resolve error: unable to load resolver "node"`というESLintのwarnが出ていたのを修正しました。
