### PR TITLE
:bug: fix(billing): 解約予定サブスクリプションのプラン変更を修正

### DIFF
--- a/packages/cdk/lambda/billing/data-access/repositories/subscriptionRepository.ts
+++ b/packages/cdk/lambda/billing/data-access/repositories/subscriptionRepository.ts
@@ -180,6 +180,11 @@ export class SubscriptionRepository extends BaseRepository {
       params.push(updates.plan_id);
     }
 
+    if (updates.platform_subscription_id !== undefined) {
+      fields.push(`platform_subscription_id = $${paramIndex++}`);
+      params.push(updates.platform_subscription_id);
+    }
+
     if (fields.length === 0) {
       return this.findById(subscriptionId);
     }

--- a/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
+++ b/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
@@ -911,6 +911,7 @@ async function handleSubscriptionCanceled(
         const subscription = await invokeDataAccessFunctionByTenantId<{
           subscription_id: string;
           user_id: string;
+          platform_subscription_id: string;
         } | null>(tenantId, 'subscription', 'findByPlatformSubscriptionId', {
           platformSubscriptionId,
         });
@@ -943,6 +944,44 @@ async function handleSubscriptionCanceled(
           return {
             skipped: true,
             reason: 'no_internal_subscription_found_and_no_user_id',
+          };
+        }
+
+        // Race condition guard: 更新前にサブスクリプションを再取得して
+        // platform_subscription_idが変更されていないか確認
+        // （プラン変更フローで新しいサブスクリプションIDに切り替わっている可能性がある）
+        const currentSubscription = await invokeDataAccessFunctionByTenantId<{
+          subscription_id: string;
+          platform_subscription_id: string;
+        } | null>(tenantId, 'subscription', 'findById', {
+          subscriptionId: subscription.subscription_id,
+        });
+
+        if (
+          currentSubscription &&
+          currentSubscription.platform_subscription_id !== platformSubscriptionId
+        ) {
+          console.log(
+            'Skipping cancellation: subscription platform_subscription_id has changed (likely plan change)',
+            {
+              subscriptionId: subscription.subscription_id,
+              originalPlatformSubscriptionId: platformSubscriptionId,
+              currentPlatformSubscriptionId:
+                currentSubscription.platform_subscription_id,
+            }
+          );
+          // サブスクリプションが別のプラットフォームIDに切り替わっている場合は
+          // キャンセル処理をスキップ（プラン変更で新しいサブスクリプションが作成された）
+          previousStepResults['subscription_info'] = {
+            internalSubscriptionId: subscription.subscription_id,
+            userId: subscription.user_id,
+            skippedDueToPlanChange: true,
+          };
+          return {
+            skipped: true,
+            reason: 'platform_subscription_id_changed',
+            subscriptionId: subscription.subscription_id,
+            userId: subscription.user_id,
           };
         }
 
@@ -993,6 +1032,7 @@ async function handleSubscriptionCanceled(
           | {
               internalSubscriptionId: string | undefined;
               userId: string;
+              skippedDueToPlanChange?: boolean;
             }
           | undefined;
 
@@ -1003,6 +1043,18 @@ async function handleSubscriptionCanceled(
           return {
             skipped: true,
             reason: 'no_subscription_info',
+          };
+        }
+
+        // プラン変更によりキャンセルがスキップされた場合は、プラン終了もスキップ
+        // （プラン変更フローで新しいプランが適用される）
+        if (subscriptionInfo.skippedDueToPlanChange) {
+          console.log(
+            'Skipping plan termination (cancellation was skipped due to plan change)'
+          );
+          return {
+            skipped: true,
+            reason: 'skipped_due_to_plan_change',
           };
         }
 
@@ -1078,6 +1130,7 @@ async function handleSubscriptionCanceled(
           | {
               internalSubscriptionId: string | undefined;
               userId: string;
+              skippedDueToPlanChange?: boolean;
             }
           | undefined;
 
@@ -1088,6 +1141,18 @@ async function handleSubscriptionCanceled(
           return {
             skipped: true,
             reason: 'no_subscription_info_or_user_id',
+          };
+        }
+
+        // プラン変更によりキャンセルがスキップされた場合は、デフォルトプラン適用もスキップ
+        // （プラン変更フローで新しいプランが適用される）
+        if (subscriptionInfo.skippedDueToPlanChange) {
+          console.log(
+            'Skipping default plan application (cancellation was skipped due to plan change)'
+          );
+          return {
+            skipped: true,
+            reason: 'skipped_due_to_plan_change',
           };
         }
 
@@ -3004,6 +3069,8 @@ async function handlePlanChangeCompleted(
     },
 
     // ステップ2: 内部DBサブスクリプションを更新
+    // プラン変更時は新しいサブスクリプションが作成されるため、
+    // subscription_statusをactiveに、cancel_at_period_endをfalseにリセット
     {
       stepName: 'update_internal_subscription',
       stepType: 'api_call',
@@ -3028,6 +3095,10 @@ async function handlePlanChangeCompleted(
             updates: {
               platform_subscription_id: validatedNewPlatformSubscriptionId,
               plan_id: validatedNewPlanId,
+              // プラン変更により新しいサブスクリプションが作成されるため、
+              // ステータスをactiveに更新し、解約予定フラグをリセット
+              subscription_status: 'active',
+              cancel_at_period_end: false,
             },
           }
         );

--- a/packages/cdk/lambda/billing/payment-gateway/operations/updateSubscription.ts
+++ b/packages/cdk/lambda/billing/payment-gateway/operations/updateSubscription.ts
@@ -230,6 +230,8 @@ async function updateStripeSubscription(
       // アップグレードの場合は即座に変更し、日割り請求
       // ダウングレードの場合は次回更新時に変更
       proration_behavior: isUpgrade ? 'always_invoice' : 'none',
+      // プラン変更時は解約予定をキャンセル（ユーザーが継続を選択したことを意味する）
+      cancel_at_period_end: false,
     }
   );
 

--- a/packages/cdk/lambda/billing/subscription-management/internal/updateSubscriptionStatus.ts
+++ b/packages/cdk/lambda/billing/subscription-management/internal/updateSubscriptionStatus.ts
@@ -129,6 +129,7 @@ export const handler = async (
 
     // ステータスを更新（データアクセス層Lambda関数を呼び出し）
     // scheduled_cancellation への遷移時は cancel_at_period_end も true に設定
+    // active への遷移時は cancel_at_period_end を false にリセット
     const updates: Partial<Subscription> = {
       subscription_status:
         input.newStatus as Subscription['subscription_status'],
@@ -136,6 +137,9 @@ export const handler = async (
 
     if (input.newStatus === 'scheduled_cancellation') {
       updates.cancel_at_period_end = true;
+    } else if (input.newStatus === 'active') {
+      // activeに戻る場合は解約予定フラグをリセット
+      updates.cancel_at_period_end = false;
     }
 
     const updatedSubscription =

--- a/packages/cdk/lambda/billing/user-api/subscriptions/previewPlanChange.ts
+++ b/packages/cdk/lambda/billing/user-api/subscriptions/previewPlanChange.ts
@@ -344,6 +344,82 @@ export const handler = async (
       ? stripeSubscription.customer
       : stripeSubscription.customer.id;
 
+    // 残り日数を計算（subscription objectから期間終了日を取得）
+    const subscriptionData = stripeSubscription as unknown as {
+      current_period_end: number;
+      items: { data: Array<{ current_period_end?: number }> };
+    };
+    const currentPeriodEnd = subscriptionData.items.data[0]?.current_period_end
+      ?? subscriptionData.current_period_end;
+    const periodEnd = new Date(currentPeriodEnd * 1000);
+    const daysRemaining = Math.ceil((periodEnd.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
+
+    // Stripeサブスクリプションの状態をログ出力（デバッグ用）
+    console.log('Stripe subscription state:', {
+      subscriptionId: subscription.subscription_id,
+      platformSubscriptionId: subscription.platform_subscription_id,
+      stripeStatus: stripeSubscription.status,
+      cancelAtPeriodEnd: stripeSubscription.cancel_at_period_end,
+    });
+
+    // サブスクリプションが完全にキャンセル済みの場合はエラー
+    // （完全キャンセル済みの場合は新規サブスクリプション作成が必要）
+    if (stripeSubscription.status === 'canceled') {
+      return badRequest400Response({
+        message: 'サブスクリプションは既にキャンセル済みです。新規でサブスクリプションを作成してください。',
+        code: 'SUBSCRIPTION_CANCELED',
+      });
+    }
+
+    // キャンセル予定のサブスクリプションの場合、まずStripeで解約予定を解除する
+    // （ユーザーがプラン変更を検討している＝継続する意思がある）
+    // これにより、invoices.createPreviewが正常に動作するようになる
+    if (stripeSubscription.cancel_at_period_end) {
+      console.log('Subscription is scheduled for cancellation, reactivating on Stripe before preview', {
+        subscriptionId: subscription.subscription_id,
+        platformSubscriptionId: subscription.platform_subscription_id,
+      });
+
+      // Stripeで解約予定を解除
+      await stripe.subscriptions.update(subscription.platform_subscription_id, {
+        cancel_at_period_end: false,
+      });
+
+      // 内部DBも同期更新（Stripeと整合性を保つ）
+      await invokeDataAccessFunction(
+        event,
+        'subscription',
+        'update',
+        {
+          subscriptionId: subscription.subscription_id,
+          updates: {
+            subscription_status: 'active',
+            cancel_at_period_end: false,
+          },
+        }
+      );
+
+      // プラン適用のステータスも更新（scheduled_termination → active）
+      if (highestPriorityApplication.application_status === 'scheduled_termination') {
+        await invokeDataAccessFunction(
+          event,
+          'user-plan-application',
+          'update',
+          {
+            applicationId: highestPriorityApplication.application_id,
+            updates: {
+              application_status: 'active',
+            },
+          }
+        );
+      }
+
+      console.log('Subscription reactivated on Stripe and internal DB', {
+        subscriptionId: subscription.subscription_id,
+        platformSubscriptionId: subscription.platform_subscription_id,
+      });
+    }
+
     // Stripeで次回インボイスをプレビュー
     const upcomingInvoice = await stripe.invoices.createPreview({
       customer: customerId,
@@ -369,16 +445,6 @@ export const handler = async (
           line.description?.toLowerCase().includes('remaining');
       })
       .reduce((sum: number, line: Stripe.InvoiceLineItem) => sum + line.amount, 0);
-
-    // 残り日数を計算（subscription objectから期間終了日を取得）
-    const subscriptionData = stripeSubscription as unknown as {
-      current_period_end: number;
-      items: { data: Array<{ current_period_end?: number }> };
-    };
-    const currentPeriodEnd = subscriptionData.items.data[0]?.current_period_end
-      ?? subscriptionData.current_period_end;
-    const periodEnd = new Date(currentPeriodEnd * 1000);
-    const daysRemaining = Math.ceil((periodEnd.getTime() - now.getTime()) / (1000 * 60 * 60 * 24));
 
     // アップグレードかダウングレードかを判定
     const currentAmount = currentPrice.unit_amount || 0;
@@ -419,7 +485,7 @@ export const handler = async (
       },
       proration: {
         amount: prorationAmount,
-        currency: upcomingInvoice.currency || 'jpy',
+        currency: newPrice.currency || 'jpy',
         daysRemaining,
         periodEnd: periodEnd.toISOString(),
       },


### PR DESCRIPTION
## 概要
解約予定（scheduled_cancellation）状態のサブスクリプションでプラン変更ができない問題を修正。

## 変更内容
- previewPlanChange: 解約予定サブスクリプションの場合、Stripeで解約予定を解除してからプレビューを実行
- webhookEventFlow: プラン変更完了時にsubscription_statusをactive、cancel_at_period_endをfalseにリセット
- updateSubscriptionStatus: ステータスがactiveになる際にcancel_at_period_endをfalseにリセット

## テスト計画
- [ ] 解約予定サブスクリプションでプラン変更プレビューが成功することを確認
- [ ] プラン変更後、サブスクリプションがactive状態になることを確認
- [ ] cancel_at_period_endがfalseにリセットされることを確認