### PR TITLE
fix(assistant): WebサイトRAGのナレッジソース同期問題を修正

### DIFF
--- a/packages/cdk/lambda/utils/documentLoader.ts
+++ b/packages/cdk/lambda/utils/documentLoader.ts
@@ -417,8 +417,22 @@ async function fetchWebContent(
 ): Promise<{ content: Buffer; contentType: string }> {
   return new Promise((resolve, reject) => {
     const client = url.startsWith('https:') ? https : http;
+    const parsedUrl = new URL(url);
 
-    const request = client.get(url, (response) => {
+    const options = {
+      hostname: parsedUrl.hostname,
+      port: parsedUrl.port || (url.startsWith('https:') ? 443 : 80),
+      path: parsedUrl.pathname + parsedUrl.search,
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (compatible; GenAIUseCases/1.0; +https://github.com/aws-samples/generative-ai-use-cases-jp)',
+        Accept:
+          'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+        'Accept-Language': 'en-US,en;q=0.5',
+      },
+    };
+
+    const request = client.get(options, (response) => {
       // Verify the actual connected socket address (prevent DNS rebinding)
       const remoteAddress = response.socket.remoteAddress;
       if (remoteAddress && isBlockedIP(remoteAddress)) {

--- a/packages/web/src/components/assistants/KnowledgeSection.tsx
+++ b/packages/web/src/components/assistants/KnowledgeSection.tsx
@@ -72,7 +72,9 @@ const KnowledgeSection: React.FC<KnowledgeSectionProps> = ({
                   key={actualIndex}
                   className="flex items-center gap-2 text-sm">
                   <PiGlobe className="text-gray-500" />
-                  <span className="flex-1">{source.url}</span>
+                  <span className="flex-1">
+                    {source.sourceUrl || source.url || source.name}
+                  </span>
                   {!disabled && (
                     <Button
                       outlined

--- a/packages/web/src/hooks/useAssistantForm.ts
+++ b/packages/web/src/hooks/useAssistantForm.ts
@@ -78,9 +78,12 @@ const useAssistantForm = (
   const addKnowledgeUrl = useCallback(() => {
     if (newUrl.trim()) {
       const newSource: KnowledgeSource = {
+        id: crypto.randomUUID(),
+        type: 'web',
         sourceType: 'url',
         name: newUrl,
-        url: newUrl,
+        displayName: newUrl,
+        sourceUrl: newUrl,
       };
       setFormData((prev) => ({
         ...prev,


### PR DESCRIPTION
## Summary
- フロントエンドのURL追加処理でバックエンドが期待するフィールド名（type, sourceUrl, id, displayName）に修正
- KnowledgeSectionでsourceUrl/url/nameのフォールバック表示を追加して後方互換性を確保
- fetchWebContentにUser-Agentヘッダーを追加してWikipedia等のWebサイトからの403 Forbiddenエラーを回避

## Test plan
- [ ] アシスタント作成画面でWebサイトURLを追加
- [ ] URLが正しく表示されることを確認
- [ ] ナレッジベースの同期が成功することを確認（SYNCING → SUCCEEDED）
- [ ] Wikipedia等のURLでも同期が成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)