### PR TITLE
:lock: fix(billing): 支払い方法更新メールのオープンリダイレクト脆弱性対策

### DIFF
--- a/packages/cdk/cdk.example.json
+++ b/packages/cdk/cdk.example.json
@@ -102,6 +102,7 @@
     "emailServiceName": "GenU",
     "sendgridApiKey": "SG.xxxxxxxxxx",
     "sendgridFromEmail": "noreply@example.com",
+    "allowedRedirectDomains": ["https://your-app.example.com"],
     "@aws-cdk/aws-lambda:recognizeLayerVersion": true,
     "@aws-cdk/core:checkSecretUsage": true,
     "@aws-cdk/core:target-partitions": ["aws", "aws-cn"],

--- a/packages/cdk/lambda/billing/user-api/subscriptions/sendPaymentMethodUpdateToParent.ts
+++ b/packages/cdk/lambda/billing/user-api/subscriptions/sendPaymentMethodUpdateToParent.ts
@@ -35,6 +35,17 @@ const SENDGRID_FROM_EMAIL = process.env.SENDGRID_FROM_EMAIL || '';
 const SENDGRID_API_URL = 'https://api.sendgrid.com/v3/mail/send';
 
 /**
+ * フロントエンドURL設定
+ * FRONTEND_URL: 本番用フロントエンドURL（オプション）
+ * ALLOWED_ORIGINS: 許可されたOriginのカンマ区切りリスト（オプション、開発環境用）
+ */
+const FRONTEND_URL = process.env.FRONTEND_URL || '';
+const ALLOWED_ORIGINS = (process.env.ALLOWED_ORIGINS || '')
+  .split(',')
+  .map((origin) => origin.trim())
+  .filter(Boolean);
+
+/**
  * カラーテーマ（既存のメールテンプレートと統一）
  */
 const COLORS = {
@@ -100,11 +111,32 @@ async function getStripeApiKey(tenantId: string): Promise<string> {
 
 /**
  * リクエストヘッダーからフロントエンドのベースURLを取得する
+ *
+ * セキュリティ対策：
+ * - Originヘッダーは許可リスト（ALLOWED_ORIGINS）に含まれている場合のみ使用
+ * - 許可リストに含まれていない場合はFRONTEND_URL（環境変数）を使用
+ * - FRONTEND_URLも設定されていない場合は、従来通りOriginヘッダーを使用（後方互換性）
+ * - これにより、攻撃者がOriginヘッダーを偽装しても悪意のあるURLにリダイレクトされない
  */
 function getBaseUrlFromRequest(event: APIGatewayProxyEvent): string {
   const headers = event.headers;
-
   const origin = headers['origin'] || headers['Origin'];
+
+  // Originが許可リストに含まれている場合は使用
+  if (
+    origin &&
+    ALLOWED_ORIGINS.length > 0 &&
+    ALLOWED_ORIGINS.includes(origin)
+  ) {
+    return origin;
+  }
+
+  // 許可リストにない場合は環境変数のFRONTEND_URLを使用
+  if (FRONTEND_URL) {
+    return FRONTEND_URL;
+  }
+
+  // 後方互換性のため、環境変数が設定されていない場合は従来のロジックを使用
   if (origin) {
     return origin;
   }
@@ -335,6 +367,25 @@ export const handler = async (
   console.log(
     'User API: Send Payment Method Update Link to Parent request received'
   );
+
+  // 必須環境変数のバリデーション
+  if (!SENDGRID_API_KEY) {
+    console.error('SENDGRID_API_KEY environment variable is not configured');
+    return internalServerError500Response({
+      message: 'メール送信の設定が正しく構成されていません',
+      code: 'CONFIGURATION_ERROR',
+      details: 'SENDGRID_API_KEY is missing',
+    });
+  }
+
+  if (!SENDGRID_FROM_EMAIL) {
+    console.error('SENDGRID_FROM_EMAIL environment variable is not configured');
+    return internalServerError500Response({
+      message: 'メール送信の設定が正しく構成されていません',
+      code: 'CONFIGURATION_ERROR',
+      details: 'SENDGRID_FROM_EMAIL is missing',
+    });
+  }
 
   try {
     // 1. 認証情報からユーザID、テナントID、子供のメールを取得

--- a/packages/cdk/lib/construct/api/user-billing-api.ts
+++ b/packages/cdk/lib/construct/api/user-billing-api.ts
@@ -96,6 +96,19 @@ export interface UserBillingApiProps {
    * DynamoDB table for user registration metadata (birthdate, parental consent, etc.)
    */
   readonly userRegistrationMetadataTable?: ITable;
+
+  /**
+   * Frontend URL for secure redirects (required for parental control APIs)
+   * This is used as the default redirect URL to prevent open redirect attacks.
+   */
+  readonly frontendUrl?: string;
+
+  /**
+   * Allowed origins for redirect URLs (optional, comma-separated)
+   * If provided, Origin header will be validated against this list.
+   * Use for development/staging environments with multiple frontend URLs.
+   */
+  readonly allowedOrigins?: string;
 }
 
 class UserBillingApi extends Construct {
@@ -1037,7 +1050,9 @@ class UserBillingApi extends Construct {
       );
 
       // API Gatewayエンドポイント
-      const previewPlanChangeResource = subscriptionsResource.addResource('preview-plan-change');
+      const previewPlanChangeResource = subscriptionsResource.addResource(
+        'preview-plan-change'
+      );
       previewPlanChangeResource.addMethod(
         'POST',
         new LambdaIntegration(this.previewPlanChangeFunction),
@@ -1299,6 +1314,10 @@ class UserBillingApi extends Construct {
           SERVICE_NAME: props.emailServiceName,
           SENDGRID_API_KEY: props.sendgridApiKey,
           SENDGRID_FROM_EMAIL: props.sendgridFromEmail,
+          ...(props.frontendUrl && { FRONTEND_URL: props.frontendUrl }),
+          ...(props.allowedOrigins && {
+            ALLOWED_ORIGINS: props.allowedOrigins,
+          }),
         },
       }
     );

--- a/packages/cdk/lib/stack-input.ts
+++ b/packages/cdk/lib/stack-input.ts
@@ -213,6 +213,24 @@ const baseStackInputSchema = z.object({
       apiKey: z.string(),
     })
     .optional(),
+
+  // Redirect URL Security
+  // Allowed domains for redirect URLs (e.g., payment method update emails)
+  // Must be in origin format: protocol + host (e.g., "https://example.com")
+  // If not specified, custom domain (hostName + domainName) will be used if available
+  // WARNING: If no custom domain and no allowedRedirectDomains, open redirect vulnerability may exist
+  allowedRedirectDomains: z
+    .array(
+      z
+        .string()
+        .url('allowedRedirectDomains must contain valid URLs')
+        .transform((u) => {
+          // Normalize to origin format (protocol + host only, remove path/query)
+          const url = new URL(u);
+          return `${url.protocol}//${url.host}`;
+        })
+    )
+    .nullish(),
 });
 
 // Common Validator with refine
@@ -243,7 +261,21 @@ export const stackInputSchema = baseStackInputSchema
         'AWS account ID is required. Set CDK_DEFAULT_ACCOUNT environment variable.',
       path: ['account'],
     }
-  );
+  )
+  .superRefine((data, ctx) => {
+    // SECURITY WARNING: When no custom domain is configured and allowedRedirectDomains is empty,
+    // there's a risk of open redirect vulnerability
+    const hasCustomDomain = !!(data.hostName && data.domainName);
+    const hasAllowedDomains = (data.allowedRedirectDomains ?? []).length > 0;
+    if (!hasCustomDomain && !hasAllowedDomains) {
+      // eslint-disable-next-line no-undef
+      console.warn(
+        '\x1b[33m⚠️  WARNING: allowedRedirectDomains is empty and no custom domain is configured.\n' +
+          '   This may allow open redirect vulnerabilities in billing redirect URLs.\n' +
+          '   Please configure allowedRedirectDomains in cdk.json.\x1b[0m'
+      );
+    }
+  });
 
 // schema after conversion
 export const processedStackInputSchema = baseStackInputSchema.extend({

--- a/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/stacks/common/generative-ai-use-cases-stack.ts
@@ -107,7 +107,8 @@ export class GenerativeAiUseCasesStack extends Stack {
     const backgroundJobRole = new iam.Role(this, 'BackgroundJobRole', {
       roleName: `${params.env}-billing-background-job-role`,
       assumedBy: new iam.ServicePrincipal('lambda.amazonaws.com'),
-      description: 'Shared IAM role for background job Lambda functions that need cross-tenant access',
+      description:
+        'Shared IAM role for background job Lambda functions that need cross-tenant access',
       managedPolicies: [
         iam.ManagedPolicy.fromAwsManagedPolicyName(
           'service-role/AWSLambdaBasicExecutionRole'
@@ -361,6 +362,22 @@ export class GenerativeAiUseCasesStack extends Stack {
     // Billing Management (as Nested Stack with independent API)
     // Uses IAM authentication for RDS access via tenant-specific credentials
     // Separated from main API to avoid CloudFormation 500 resource limit
+
+    // Build redirect URL security settings
+    // Custom domain takes priority if configured
+    const customDomain =
+      params.hostName && params.domainName
+        ? `${params.hostName}.${params.domainName}`
+        : undefined;
+    const frontendUrl = customDomain ? `https://${customDomain}` : undefined;
+
+    // Build allowed redirect domains list
+    // Include custom domain (if configured) and any additional domains from cdk.json
+    const allowedRedirectDomains = [
+      ...(customDomain ? [`https://${customDomain}`] : []),
+      ...(params.allowedRedirectDomains || []),
+    ].filter(Boolean);
+
     const billingManagementStack = new BillingManagementStack(
       this,
       `BillingManagementStack${params.env}`,
@@ -377,6 +394,12 @@ export class GenerativeAiUseCasesStack extends Stack {
         sendgridFromEmail: params.sendgridFromEmail,
         emailServiceName: params.emailServiceName,
         userRegistrationMetadataTable: auth.userRegistrationMetadataTable,
+        // Redirect URL security settings
+        frontendUrl: frontendUrl,
+        allowedRedirectDomains:
+          allowedRedirectDomains.length > 0
+            ? allowedRedirectDomains
+            : undefined,
       }
     );
 
@@ -390,7 +413,8 @@ export class GenerativeAiUseCasesStack extends Stack {
     // This ARN should be set as controlPlaneLambdaRoleArn in cdk.tenant.json
     new CfnOutput(this, 'BackgroundJobRoleArn', {
       value: backgroundJobRole.roleArn,
-      description: 'ARN of the shared background job IAM role. Set this as controlPlaneLambdaRoleArn in cdk.tenant.json for cross-tenant access.',
+      description:
+        'ARN of the shared background job IAM role. Set this as controlPlaneLambdaRoleArn in cdk.tenant.json for cross-tenant access.',
       exportName: `${this.stackName}-BackgroundJobRoleArn`,
     });
 

--- a/packages/cdk/lib/stacks/nested/billing-management-stack.ts
+++ b/packages/cdk/lib/stacks/nested/billing-management-stack.ts
@@ -85,6 +85,18 @@ export interface BillingManagementStackProps extends NestedStackProps {
    * DynamoDB table for user registration metadata (birthdate, parental consent, etc.)
    */
   readonly userRegistrationMetadataTable?: ITable;
+
+  /**
+   * Frontend URL for secure redirects (e.g., custom domain or CloudFront URL)
+   * Used as the default redirect URL to prevent open redirect attacks.
+   */
+  readonly frontendUrl?: string;
+
+  /**
+   * Allowed domains for redirect URLs (comma-separated or array)
+   * Used for validating Origin header in redirect URL generation.
+   */
+  readonly allowedRedirectDomains?: string[];
 }
 
 /**
@@ -338,6 +350,9 @@ export class BillingManagementStack extends NestedStack {
       pendingPlanChangesTable: pendingPlanChangesTable,
       pendingParentalCheckoutsTable: pendingParentalCheckoutsTable,
       userRegistrationMetadataTable: props.userRegistrationMetadataTable,
+      // Redirect URL security settings
+      frontendUrl: props.frontendUrl,
+      allowedOrigins: props.allowedRedirectDomains?.join(','),
     });
 
     // ========================================


### PR DESCRIPTION
## Summary
- 親権者向け支払い方法更新メールのリダイレクトURLにおけるオープンリダイレクト脆弱性を修正
- Originヘッダーの許可リスト検証機能を追加
- 必須環境変数（SendGrid設定）のバリデーションを追加
- `allowedRedirectDomains`設定をcdk.jsonで外部化

## Changes
### セキュリティ強化
- `FRONTEND_URL`: 信頼できるリダイレクト先URLを環境変数で指定可能に
- `ALLOWED_ORIGINS`: 開発/ステージング環境用に複数のOriginを許可リストで管理
- Originヘッダーが許可リストに含まれない場合は`FRONTEND_URL`を使用し、攻撃者によるOriginヘッダー偽装を防止
- カスタムドメイン（hostName + domainName）設定時は自動的に許可リストに追加

### CDK設定の外部化
- `allowedRedirectDomains`: cdk.jsonで許可ドメインを配列形式で設定可能に
- カスタムドメイン未設定かつ`allowedRedirectDomains`未設定時に警告を表示

### バリデーション追加
- `SENDGRID_API_KEY`と`SENDGRID_FROM_EMAIL`の存在チェックを追加
- 設定不備時に適切なエラーメッセージを返却

## Test plan
- [ ] `FRONTEND_URL`設定時、許可リスト外のOriginヘッダーでも`FRONTEND_URL`へリダイレクトされることを確認
- [ ] `ALLOWED_ORIGINS`に含まれるOriginからのリクエストが正しく処理されることを確認
- [ ] SendGrid環境変数未設定時に500エラーが返ることを確認
- [ ] cdk.jsonに`allowedRedirectDomains`を設定してデプロイが成功することを確認
- [ ] カスタムドメイン・allowedRedirectDomains両方未設定時に警告が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
