### PR TITLE
♻️ refactor: ESLint設定を各パッケージに分離

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -1,127 +1,13 @@
 const { defineConfig } = require('eslint/config');
-const js = require('@eslint/js');
-const globals = require('globals');
-const typescriptPlugin = require('@typescript-eslint/eslint-plugin');
-const typescriptParser = require('@typescript-eslint/parser');
-const reactHooksPlugin = require('eslint-plugin-react-hooks');
-const reactRefreshPlugin = require('eslint-plugin-react-refresh');
-const tailwindcssPlugin = require('eslint-plugin-tailwindcss');
-const ymlPlugin = require('eslint-plugin-yml');
-const yamlParser = require('yaml-eslint-parser');
-const i18nhelperPlugin = require('eslint-plugin-i18nhelper');
-const shopifyPlugin = require('@shopify/eslint-plugin');
+const { yamlConfig, commonIgnores } = require('eslint-config-shared');
 
+// Root-level YAML files only (packages have their own ESLint configs)
 module.exports = defineConfig([
-  js.configs.recommended,
-  // For cdk, common
   {
-    files: ['packages/{cdk,common}/**/*.{ts,tsx}'],
-    plugins: {
-      '@typescript-eslint': typescriptPlugin,
-      i18nhelper: i18nhelperPlugin,
-    },
-    languageOptions: {
-      parser: typescriptParser,
-      parserOptions: {
-        ecmaVersion: 'latest',
-        sourceType: 'module',
-        project: './tsconfig.json',
-      },
-    },
-    rules: {
-      ...typescriptPlugin.configs['eslint-recommended'].rules,
-      ...typescriptPlugin.configs.recommended.rules,
-      '@typescript-eslint/no-namespace': 'off',
-      'i18nhelper/no-jp-string': 'warn',
-      'i18nhelper/no-jp-comment': 'warn',
-    },
-  },
-  // For web
-  {
-    files: ['packages/web/**/*.{js,jsx,ts,tsx}'],
-    plugins: {
-      '@typescript-eslint': typescriptPlugin,
-      'react-hooks': reactHooksPlugin,
-      'react-refresh': reactRefreshPlugin,
-      tailwindcss: tailwindcssPlugin,
-      i18nhelper: i18nhelperPlugin,
-      '@shopify': shopifyPlugin,
-    },
-    languageOptions: {
-      parser: typescriptParser,
-      parserOptions: {
-        ecmaVersion: 2020,
-        sourceType: 'module',
-        ecmaFeatures: {
-          jsx: true,
-        },
-      },
-      globals: {
-        ...globals.browser,
-        ...globals.es2020,
-      },
-    },
-    settings: {
-      'import/resolver': {
-        typescript: true,
-        node: true,
-      },
-      tailwindcss: {
-        whitelist: ['w-', 'h-'],
-      },
-    },
-    rules: {
-      ...js.configs.recommended.rules,
-      ...typescriptPlugin.configs.recommended.rules,
-      ...reactHooksPlugin.configs.recommended.rules,
-      ...tailwindcssPlugin.configs.recommended.rules,
-      'react-refresh/only-export-components': [
-        'warn',
-        { allowConstantExport: true },
-      ],
-      'tailwindcss/classnames-order': 'off',
-      'tailwindcss/enforces-shorthand': 'off',
-      'i18nhelper/no-jp-string': 'warn',
-      'i18nhelper/no-jp-comment': 'warn',
-      '@shopify/jsx-no-hardcoded-content': 'warn',
-    },
-  },
-  // For yaml files
-  {
-    files: ['**/*.{yaml,yml}'],
-    plugins: {
-      yml: ymlPlugin,
-    },
-    languageOptions: {
-      parser: yamlParser,
-    },
-    rules: {
-      ...ymlPlugin.configs.standard.rules,
-      'yml/sort-keys': 'error',
-      'yml/quotes': ['error', { prefer: 'single', avoidEscape: true }],
-    },
-  },
-  // General rules
-  {
-    files: ['**/*.{js,jsx,ts,tsx}'],
-    plugins: {
-      '@typescript-eslint': typescriptPlugin,
-    },
-    rules: {
-      '@typescript-eslint/no-unused-vars': 'off',
-    },
+    ...yamlConfig,
+    files: ['.github/**/*.{yaml,yml}', 'mkdocs.yml'],
   },
   {
-    ignores: [
-      'packages/cdk/cdk.out/**',
-      'packages/{cdk,common}/*.config.cjs',
-      '**/dist/**',
-      '**/build/**',
-      '**/node_modules/**',
-      '**/*.config.js',
-      '**/*.config.cjs',
-      '**/*.config.mjs',
-      '**/*.config.ts',
-    ],
+    ignores: [...commonIgnores.ignores, 'packages/**'],
   },
 ]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -39707,6 +39707,7 @@
         "autoprefixer": "^10.4.19",
         "eslint": "9.35.0",
         "eslint-config-shared": "file:../eslint-config-shared",
+        "eslint-import-resolver-typescript": "^4.4.4",
         "eslint-plugin-react-hooks": "5.2.0",
         "eslint-plugin-react-refresh": "0.4.20",
         "eslint-plugin-tailwindcss": "3.18.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,16 +12,9 @@
         "dagger"
       ],
       "devDependencies": {
-        "@shopify/eslint-plugin": "50.0.0",
-        "@typescript-eslint/eslint-plugin": "8.44.0",
-        "@typescript-eslint/parser": "8.44.0",
         "eslint": "9.35.0",
-        "eslint-import-resolver-typescript": "^4.4.4",
+        "eslint-config-shared": "file:packages/eslint-config-shared",
         "eslint-plugin-i18nhelper": "1.0.0",
-        "eslint-plugin-react-hooks": "5.2.0",
-        "eslint-plugin-react-refresh": "0.4.20",
-        "eslint-plugin-tailwindcss": "3.18.2",
-        "eslint-plugin-yml": "1.18.0",
         "npm-run-all": "^4.1.5",
         "prettier": "3.6.2",
         "prettier-plugin-tailwindcss": "0.6.14"
@@ -12319,7 +12312,6 @@
       "os": [
         "aix"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12336,7 +12328,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12353,7 +12344,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12370,7 +12360,6 @@
       "os": [
         "android"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12387,7 +12376,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12404,7 +12392,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12421,7 +12408,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12438,7 +12424,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12455,7 +12440,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12472,7 +12456,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12489,7 +12472,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12506,7 +12488,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12523,7 +12504,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12540,7 +12520,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12557,7 +12536,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12574,7 +12552,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12591,7 +12568,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12608,7 +12584,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12625,7 +12600,6 @@
       "os": [
         "netbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12642,7 +12616,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12659,7 +12632,6 @@
       "os": [
         "openbsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12676,7 +12648,6 @@
       "os": [
         "openharmony"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12693,7 +12664,6 @@
       "os": [
         "sunos"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12710,7 +12680,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12727,7 +12696,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12744,7 +12712,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -12753,7 +12720,6 @@
       "version": "4.9.0",
       "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
       "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
@@ -12772,7 +12738,6 @@
       "version": "4.12.1",
       "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
       "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -12782,7 +12747,6 @@
       "version": "0.21.0",
       "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
       "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^2.1.6",
@@ -12797,7 +12761,6 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -12808,7 +12771,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -12821,7 +12783,6 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.1.tgz",
       "integrity": "sha512-xR93k9WhrDYpXHORXpxVL5oHj3Era7wo6k/Wd8/IsQNnZUTzkGS29lyn3nAT05v6ltUuTFVCCYDEGfy2Or/sPA==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -12831,7 +12792,6 @@
       "version": "0.15.2",
       "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.2.tgz",
       "integrity": "sha512-78Md3/Rrxh83gCxoUc0EiciuOHsIITzLy53m3d9UyiW8y9Dj2D29FeETqyKA+BRK76tnTp6RXWb3pCay8Oyomg==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
@@ -12844,7 +12804,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
       "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^6.12.4",
@@ -12868,7 +12827,6 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -12879,7 +12837,6 @@
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
       "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -12892,7 +12849,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -12905,7 +12861,6 @@
       "version": "9.35.0",
       "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.35.0.tgz",
       "integrity": "sha512-30iXE9whjlILfWobBkNerJo+TXYsgVM5ERQwMcMKCHckHflCmf7wXDAHlARoWnh0s1U72WqlbeyE7iAcCzuCPw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -12918,7 +12873,6 @@
       "version": "2.1.6",
       "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
       "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -12928,7 +12882,6 @@
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.5.tgz",
       "integrity": "sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^0.15.2",
@@ -13041,7 +12994,6 @@
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
       "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
@@ -13051,7 +13003,6 @@
       "version": "0.16.7",
       "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
       "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@humanfs/core": "^0.19.1",
@@ -13065,7 +13016,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
       "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
@@ -13079,7 +13029,6 @@
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
       "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
@@ -15228,7 +15177,6 @@
       "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
       "license": "MIT",
       "optional": true,
-      "peer": true,
       "engines": {
         "node": ">=14"
       }
@@ -19428,7 +19376,6 @@
       "version": "8.44.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.44.0.tgz",
       "integrity": "sha512-EGDAOGX+uwwekcS0iyxVDmRV9HX6FLSM5kzrAToLTsr9OWCIKG/y3lQheCq18yZ5Xh78rRKJiEpP0ZaCs4ryOQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
@@ -19458,7 +19405,6 @@
       "version": "7.0.5",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -19468,7 +19414,6 @@
       "version": "8.44.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.44.0.tgz",
       "integrity": "sha512-VGMpFQGUQWYT9LfnPcX8ouFojyrZ/2w3K5BucvxL/spdNehccKhB4jUyB1yBCXpr2XFm0jkECxgrpXBW2ipoAw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.44.0",
@@ -19493,7 +19438,6 @@
       "version": "8.44.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.44.0.tgz",
       "integrity": "sha512-ZeaGNraRsq10GuEohKTo4295Z/SuGcSq2LzfGlqiuEvfArzo/VRrT0ZaJsVPuKZ55lVbNk8U6FcL+ZMH8CoyVA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/tsconfig-utils": "^8.44.0",
@@ -19515,7 +19459,6 @@
       "version": "8.44.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.44.0.tgz",
       "integrity": "sha512-87Jv3E+al8wpD+rIdVJm/ItDBe/Im09zXIjFoipOjr5gHUhJmTzfFLuTJ/nPTMc2Srsroy4IBXwcTCHyRR7KzA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.44.0",
@@ -19533,7 +19476,6 @@
       "version": "8.44.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.44.0.tgz",
       "integrity": "sha512-x5Y0+AuEPqAInc6yd0n5DAcvtoQ/vyaGwuX5HE9n6qAefk1GaedqrLQF8kQGylLUb9pnZyLf+iEiL9fr8APDtQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -19550,7 +19492,6 @@
       "version": "8.44.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.44.0.tgz",
       "integrity": "sha512-9cwsoSxJ8Sak67Be/hD2RNt/fsqmWnNE1iHohG8lxqLSNY8xNfyY7wloo5zpW3Nu9hxVgURevqfcH6vvKCt6yg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.44.0",
@@ -19575,7 +19516,6 @@
       "version": "8.44.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.44.0.tgz",
       "integrity": "sha512-ZSl2efn44VsYM0MfDQe68RKzBz75NPgLQXuGypmym6QVOWL5kegTZuZ02xRAT9T+onqvM6T8CdQk0OwYMB6ZvA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -19589,7 +19529,6 @@
       "version": "8.44.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.44.0.tgz",
       "integrity": "sha512-lqNj6SgnGcQZwL4/SBJ3xdPEfcBuhCG8zdcwCPgYcmiPLgokiNDKlbPzCwEwu7m279J/lBYWtDYL+87OEfn8Jw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/project-service": "8.44.0",
@@ -19618,7 +19557,6 @@
       "version": "8.44.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.44.0.tgz",
       "integrity": "sha512-nktOlVcg3ALo0mYlV+L7sWUD58KG4CMj1rb2HUVOO4aL3K/6wcD+NERqd0rrA5Vg06b42YhF6cFxeixsp9Riqg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.7.0",
@@ -19642,7 +19580,6 @@
       "version": "8.44.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.44.0.tgz",
       "integrity": "sha512-zaz9u8EJ4GBmnehlrpoKvj/E3dNbuQ7q0ucyZImm3cLqJ8INTc970B1qEqDX/Rzq65r3TvVTN7kHWPBoyW7DWw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.44.0",
@@ -19660,7 +19597,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -20342,7 +20278,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
@@ -20387,7 +20322,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
@@ -21881,7 +21815,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -23509,7 +23442,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/deepmerge": {
@@ -24273,7 +24205,6 @@
       "version": "9.35.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.35.0.tgz",
       "integrity": "sha512-QePbBFMJFjgmlE+cXAlbHZbHpdFVS2E/6vzCy7aKlebddvl1vadiC4JFV5u/wqTkNUwEV8WrQi257jf5f06hrg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
@@ -24358,6 +24289,10 @@
       "peerDependencies": {
         "eslint": ">=7.0.0"
       }
+    },
+    "node_modules/eslint-config-shared": {
+      "resolved": "packages/eslint-config-shared",
+      "link": true
     },
     "node_modules/eslint-import-context": {
       "version": "0.1.9",
@@ -24834,7 +24769,6 @@
       "version": "1.18.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-yml/-/eslint-plugin-yml-1.18.0.tgz",
       "integrity": "sha512-9NtbhHRN2NJa/s3uHchO3qVVZw0vyOIvWlXWGaKCr/6l3Go62wsvJK5byiI6ZoYztDsow4GnS69BZD3GnqH3hA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.2",
@@ -24857,7 +24791,6 @@
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.6.5.tgz",
       "integrity": "sha512-vAUHYzue4YAa2hNACjB8HvUQj5yehAZgiClyFVVom9cP8z5NSFq3PwB/TtJslN2zAMgRX6FCFCjYBbQh71g5RQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "semver": "^7.5.4"
@@ -24873,7 +24806,6 @@
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
       "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "esrecurse": "^4.3.0",
@@ -24890,7 +24822,6 @@
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
       "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -24903,7 +24834,6 @@
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
       "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0",
@@ -24914,7 +24844,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -24927,7 +24856,6 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "brace-expansion": "^1.1.7"
@@ -24940,7 +24868,6 @@
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
       "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.15.0",
@@ -24958,7 +24885,6 @@
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
       "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-      "dev": true,
       "license": "Apache-2.0",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -24985,7 +24911,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
       "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
@@ -24998,7 +24923,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
       "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
@@ -25011,7 +24935,6 @@
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
@@ -25240,7 +25163,6 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-uri": {
@@ -25351,7 +25273,6 @@
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
       "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flat-cache": "^4.0.0"
@@ -25427,7 +25348,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
       "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
@@ -25453,7 +25373,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
       "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
@@ -25467,7 +25386,6 @@
       "version": "3.3.3",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
@@ -25925,7 +25843,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/graphql": {
@@ -26813,7 +26730,6 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
       "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -26860,7 +26776,6 @@
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
       "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
@@ -26978,7 +26893,6 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
       "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
@@ -28717,7 +28631,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
       "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-parse-better-errors": {
@@ -28744,14 +28657,12 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/json11": {
@@ -28953,7 +28864,6 @@
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
       "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
@@ -29197,7 +29107,6 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
       "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1",
@@ -29286,7 +29195,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
       "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
@@ -29375,7 +29283,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.once": {
@@ -30754,7 +30661,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/neo-async": {
@@ -31616,7 +31522,6 @@
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
       "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
@@ -31682,7 +31587,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
@@ -31698,7 +31602,6 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
       "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
@@ -31793,7 +31696,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
@@ -32454,7 +32356,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
@@ -34458,7 +34359,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"
@@ -35696,7 +35596,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
       "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -36466,7 +36365,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
       "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18.12"
@@ -36695,7 +36593,6 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
       "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
@@ -37434,7 +37331,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
       "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
@@ -38269,7 +38165,6 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
       "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -38902,7 +38797,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/yaml-eslint-parser/-/yaml-eslint-parser-1.3.0.tgz",
       "integrity": "sha512-E/+VitOorXSLiAqtTd7Yqax0/pAS3xaYMP+AUUJGOK1OZG3rhcj9fcJOM5HJ2VrP1FrStVCWr1muTfQCdj4tAA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.0.0",
@@ -38997,7 +38891,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
       "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -39139,6 +39032,8 @@
         "@types/pdf-parse": "^1.1.5",
         "@types/sanitize-html": "^2.13.0",
         "aws-cdk": "^2.154.1",
+        "eslint": "9.35.0",
+        "eslint-config-shared": "file:../eslint-config-shared",
         "jest": "^29.7.0",
         "ts-jest": "^29.2.5",
         "ts-node": "^10.9.2",
@@ -39688,6 +39583,21 @@
         "aws-jwt-verify": "^4.0.0"
       }
     },
+    "packages/eslint-config-shared": {
+      "version": "1.0.0",
+      "dependencies": {
+        "@eslint/js": "^9.35.0",
+        "@typescript-eslint/eslint-plugin": "8.44.0",
+        "@typescript-eslint/parser": "8.44.0",
+        "eslint-plugin-i18nhelper": "1.0.0",
+        "eslint-plugin-yml": "1.18.0",
+        "globals": "^15.15.0",
+        "yaml-eslint-parser": "^1.2.3"
+      },
+      "peerDependencies": {
+        "eslint": "^9.0.0"
+      }
+    },
     "packages/eslint-plugin-i18nhelper": {
       "version": "1.0.0",
       "license": "MIT",
@@ -39782,6 +39692,7 @@
         "zustand": "^4.5.2"
       },
       "devDependencies": {
+        "@shopify/eslint-plugin": "50.0.0",
         "@tailwindcss/forms": "^0.5.7",
         "@tailwindcss/typography": "^0.5.12",
         "@types/diff-match-patch": "^1.0.5",
@@ -39794,6 +39705,12 @@
         "@types/react-syntax-highlighter": "^15.5.11",
         "@vitejs/plugin-react": "^4.3.4",
         "autoprefixer": "^10.4.19",
+        "eslint": "9.35.0",
+        "eslint-config-shared": "file:../eslint-config-shared",
+        "eslint-plugin-react-hooks": "5.2.0",
+        "eslint-plugin-react-refresh": "0.4.20",
+        "eslint-plugin-tailwindcss": "3.18.2",
+        "globals": "^15.15.0",
         "postcss": "^8.4.38",
         "rollup-plugin-visualizer": "^5.10.0",
         "tailwind-scrollbar": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -3,8 +3,10 @@
   "private": true,
   "version": "4.3.2",
   "scripts": {
-    "lint": "run-s custom-lint:build web:lint cdk:lint cdk:lambda-build-dryrun",
-    "lint:fix": "run-s custom-lint:build web:lint:fix cdk:lint cdk:lambda-build-dryrun",
+    "lint": "run-s custom-lint:build lint:root web:lint cdk:lint cdk:lambda-build-dryrun",
+    "lint:fix": "run-s custom-lint:build lint:root:fix web:lint:fix cdk:lint cdk:lambda-build-dryrun",
+    "lint:root": "eslint . --report-unused-disable-directives --max-warnings 0",
+    "lint:root:fix": "eslint . --report-unused-disable-directives --max-warnings 0 --fix",
     "test": "run-s web:test",
     "format": "npx prettier --write .",
     "web:devw": "source ./setup-env.sh ${npm_config_env} && VITE_APP_VERSION=${npm_package_version} npm -w packages/web run dev",
@@ -44,16 +46,9 @@
     "pipeline:ci": "npm -w dagger run ci"
   },
   "devDependencies": {
-    "@shopify/eslint-plugin": "50.0.0",
-    "@typescript-eslint/eslint-plugin": "8.44.0",
-    "@typescript-eslint/parser": "8.44.0",
     "eslint": "9.35.0",
-    "eslint-import-resolver-typescript": "^4.4.4",
+    "eslint-config-shared": "file:packages/eslint-config-shared",
     "eslint-plugin-i18nhelper": "1.0.0",
-    "eslint-plugin-react-hooks": "5.2.0",
-    "eslint-plugin-react-refresh": "0.4.20",
-    "eslint-plugin-tailwindcss": "3.18.2",
-    "eslint-plugin-yml": "1.18.0",
     "npm-run-all": "^4.1.5",
     "prettier": "3.6.2",
     "prettier-plugin-tailwindcss": "0.6.14"

--- a/packages/cdk/eslint.config.cjs
+++ b/packages/cdk/eslint.config.cjs
@@ -1,0 +1,33 @@
+const { defineConfig } = require('eslint/config');
+const {
+  baseConfig,
+  typescriptConfig,
+  commonIgnores,
+  globals,
+} = require('eslint-config-shared/base');
+
+module.exports = defineConfig([
+  baseConfig,
+  {
+    files: ['**/*.{ts,tsx}', '../common/**/*.{ts,tsx}'],
+    ...typescriptConfig,
+    languageOptions: {
+      ...typescriptConfig.languageOptions,
+      globals: {
+        ...globals.node,
+      },
+    },
+    rules: {
+      ...typescriptConfig.rules,
+      '@typescript-eslint/no-namespace': 'off',
+    },
+  },
+  {
+    ignores: [
+      ...commonIgnores.ignores,
+      'cdk.out/**',
+      'cloudfront-functions/**',
+      'custom-resources/**',
+    ],
+  },
+]);

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -22,7 +22,9 @@
     "jest": "^29.7.0",
     "ts-jest": "^29.2.5",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "eslint": "9.35.0",
+    "eslint-config-shared": "file:../eslint-config-shared"
   },
   "dependencies": {
     "@aws-cdk/aws-glue-alpha": "^2.189.0-alpha.0",

--- a/packages/eslint-config-shared/base.cjs
+++ b/packages/eslint-config-shared/base.cjs
@@ -1,0 +1,47 @@
+const js = require('@eslint/js');
+const globals = require('globals');
+const typescriptPlugin = require('@typescript-eslint/eslint-plugin');
+const typescriptParser = require('@typescript-eslint/parser');
+const i18nhelperPlugin = require('eslint-plugin-i18nhelper');
+
+const baseConfig = js.configs.recommended;
+
+const typescriptConfig = {
+  plugins: {
+    '@typescript-eslint': typescriptPlugin,
+    i18nhelper: i18nhelperPlugin,
+  },
+  languageOptions: {
+    parser: typescriptParser,
+    parserOptions: {
+      ecmaVersion: 'latest',
+      sourceType: 'module',
+    },
+  },
+  rules: {
+    ...typescriptPlugin.configs['eslint-recommended'].rules,
+    ...typescriptPlugin.configs.recommended.rules,
+    '@typescript-eslint/no-unused-vars': 'off',
+    'i18nhelper/no-jp-string': 'warn',
+    'i18nhelper/no-jp-comment': 'warn',
+  },
+};
+
+const commonIgnores = {
+  ignores: [
+    '**/dist/**',
+    '**/build/**',
+    '**/node_modules/**',
+    '**/*.config.js',
+    '**/*.config.cjs',
+    '**/*.config.mjs',
+    '**/*.config.ts',
+  ],
+};
+
+module.exports = {
+  baseConfig,
+  typescriptConfig,
+  commonIgnores,
+  globals,
+};

--- a/packages/eslint-config-shared/index.cjs
+++ b/packages/eslint-config-shared/index.cjs
@@ -1,0 +1,7 @@
+const base = require('./base.cjs');
+const yaml = require('./yaml.cjs');
+
+module.exports = {
+  ...base,
+  ...yaml,
+};

--- a/packages/eslint-config-shared/package.json
+++ b/packages/eslint-config-shared/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "eslint-config-shared",
+  "version": "1.0.0",
+  "private": true,
+  "main": "index.cjs",
+  "exports": {
+    ".": "./index.cjs",
+    "./base": "./base.cjs",
+    "./yaml": "./yaml.cjs"
+  },
+  "dependencies": {
+    "@eslint/js": "^9.35.0",
+    "@typescript-eslint/eslint-plugin": "8.44.0",
+    "@typescript-eslint/parser": "8.44.0",
+    "eslint-plugin-i18nhelper": "1.0.0",
+    "eslint-plugin-yml": "1.18.0",
+    "globals": "^15.15.0",
+    "yaml-eslint-parser": "^1.2.3"
+  },
+  "peerDependencies": {
+    "eslint": "^9.0.0"
+  }
+}

--- a/packages/eslint-config-shared/yaml.cjs
+++ b/packages/eslint-config-shared/yaml.cjs
@@ -1,0 +1,21 @@
+const ymlPlugin = require('eslint-plugin-yml');
+const yamlParser = require('yaml-eslint-parser');
+
+const yamlConfig = {
+  files: ['**/*.{yaml,yml}'],
+  plugins: {
+    yml: ymlPlugin,
+  },
+  languageOptions: {
+    parser: yamlParser,
+  },
+  rules: {
+    ...ymlPlugin.configs.standard.rules,
+    'yml/sort-keys': 'error',
+    'yml/quotes': ['error', { prefer: 'single', avoidEscape: true }],
+  },
+};
+
+module.exports = {
+  yamlConfig,
+};

--- a/packages/web/eslint.config.cjs
+++ b/packages/web/eslint.config.cjs
@@ -15,6 +15,7 @@ module.exports = defineConfig([
   baseConfig,
   {
     files: ['**/*.{js,jsx,ts,tsx}'],
+    ignores: ['node_modules', 'dist', 'dist-ssr', 'dev-dist'],
     plugins: {
       ...typescriptConfig.plugins,
       'react-hooks': reactHooksPlugin,
@@ -37,6 +38,10 @@ module.exports = defineConfig([
       },
     },
     settings: {
+      'import/resolver': {
+        typescript: true,
+        node: true,
+      },
       tailwindcss: {
         whitelist: ['w-', 'h-'],
       },

--- a/packages/web/eslint.config.cjs
+++ b/packages/web/eslint.config.cjs
@@ -1,0 +1,59 @@
+const { defineConfig } = require('eslint/config');
+const globals = require('globals');
+const {
+  baseConfig,
+  typescriptConfig,
+  commonIgnores,
+} = require('eslint-config-shared/base');
+const { yamlConfig } = require('eslint-config-shared/yaml');
+const reactHooksPlugin = require('eslint-plugin-react-hooks');
+const reactRefreshPlugin = require('eslint-plugin-react-refresh');
+const tailwindcssPlugin = require('eslint-plugin-tailwindcss');
+const shopifyPlugin = require('@shopify/eslint-plugin');
+
+module.exports = defineConfig([
+  baseConfig,
+  {
+    files: ['**/*.{js,jsx,ts,tsx}'],
+    plugins: {
+      ...typescriptConfig.plugins,
+      'react-hooks': reactHooksPlugin,
+      'react-refresh': reactRefreshPlugin,
+      tailwindcss: tailwindcssPlugin,
+      '@shopify': shopifyPlugin,
+    },
+    languageOptions: {
+      ...typescriptConfig.languageOptions,
+      parserOptions: {
+        ecmaVersion: 2020,
+        sourceType: 'module',
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
+      globals: {
+        ...globals.browser,
+        ...globals.es2020,
+      },
+    },
+    settings: {
+      tailwindcss: {
+        whitelist: ['w-', 'h-'],
+      },
+    },
+    rules: {
+      ...typescriptConfig.rules,
+      ...reactHooksPlugin.configs.recommended.rules,
+      ...tailwindcssPlugin.configs.recommended.rules,
+      'react-refresh/only-export-components': [
+        'warn',
+        { allowConstantExport: true },
+      ],
+      'tailwindcss/classnames-order': 'off',
+      'tailwindcss/enforces-shorthand': 'off',
+      '@shopify/jsx-no-hardcoded-content': 'warn',
+    },
+  },
+  yamlConfig,
+  commonIgnores,
+]);

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -92,6 +92,13 @@
     "@types/react-syntax-highlighter": "^15.5.11",
     "@vitejs/plugin-react": "^4.3.4",
     "autoprefixer": "^10.4.19",
+    "eslint": "9.35.0",
+    "eslint-config-shared": "file:../eslint-config-shared",
+    "eslint-import-resolver-typescript": "^4.4.4",
+    "eslint-plugin-react-hooks": "5.2.0",
+    "eslint-plugin-react-refresh": "0.4.20",
+    "eslint-plugin-tailwindcss": "3.18.2",
+    "globals": "^15.15.0",
     "postcss": "^8.4.38",
     "rollup-plugin-visualizer": "^5.10.0",
     "tailwind-scrollbar": "^3.1.0",
@@ -100,12 +107,6 @@
     "vite": "^6.3.4",
     "vite-plugin-node-polyfills": "^0.23.0",
     "vite-plugin-svgr": "^4.2.0",
-    "vitest": "^3.0.7",
-    "eslint": "9.35.0",
-    "eslint-config-shared": "file:../eslint-config-shared",
-    "eslint-plugin-react-hooks": "5.2.0",
-    "eslint-plugin-react-refresh": "0.4.20",
-    "eslint-plugin-tailwindcss": "3.18.2",
-    "globals": "^15.15.0"
+    "vitest": "^3.0.7"
   }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -79,6 +79,7 @@
     "zustand": "^4.5.2"
   },
   "devDependencies": {
+    "@shopify/eslint-plugin": "50.0.0",
     "@tailwindcss/forms": "^0.5.7",
     "@tailwindcss/typography": "^0.5.12",
     "@types/diff-match-patch": "^1.0.5",
@@ -99,6 +100,12 @@
     "vite": "^6.3.4",
     "vite-plugin-node-polyfills": "^0.23.0",
     "vite-plugin-svgr": "^4.2.0",
-    "vitest": "^3.0.7"
+    "vitest": "^3.0.7",
+    "eslint": "9.35.0",
+    "eslint-config-shared": "file:../eslint-config-shared",
+    "eslint-plugin-react-hooks": "5.2.0",
+    "eslint-plugin-react-refresh": "0.4.20",
+    "eslint-plugin-tailwindcss": "3.18.2",
+    "globals": "^15.15.0"
   }
 }


### PR DESCRIPTION
## Summary
- ESLint設定をプロジェクトルートから各パッケージに分離
- 共有設定パッケージ `packages/eslint-config-shared` を新規作成
- web/cdk パッケージにそれぞれ専用の `eslint.config.cjs` を配置
- ルートの設定をYAMLファイル専用に最小化

## Test plan
- [ ] `npm run custom-lint:build` でi18nhelperプラグインをビルド
- [ ] `npm run web:lint` でwebパッケージのlintが動作することを確認
- [ ] `npm run cdk:lint` でcdkパッケージのlintが動作することを確認
- [ ] `npm run lint` で全体lintが正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)