### PR TITLE
🔧 fix(eslint): .github と mkdocs.yml をESLint対象外に追加

### DIFF
--- a/packages/eslint-config-shared/base.cjs
+++ b/packages/eslint-config-shared/base.cjs
@@ -36,6 +36,7 @@ const commonIgnores = {
     '**/*.config.cjs',
     '**/*.config.mjs',
     '**/*.config.ts',
+    '.github',
   ],
 };
 

--- a/packages/eslint-config-shared/yaml.cjs
+++ b/packages/eslint-config-shared/yaml.cjs
@@ -16,6 +16,11 @@ const yamlConfig = {
   },
 };
 
+const yamlIgnores = {
+  ignores: ['mkdocs.yml'],
+};
+
 module.exports = {
   yamlConfig,
+  yamlIgnores,
 };


### PR DESCRIPTION
## Summary
- ESLintの共通ignores設定に`.github`ディレクトリを追加
- YAML設定に`mkdocs.yml`用のignoresを追加・エクスポート

## Test plan
- [ ] `npm run lint` が正常に完了することを確認
- [ ] `.github`配下のファイルがESLint対象外になることを確認
- [ ] `mkdocs.yml`がYAML lintの対象外になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)