### PR TITLE
🐛 fix: LiteLLM無効時にフロントエンドでモデルを非表示にする

### DIFF
--- a/packages/cdk/lib/construct/web.ts
+++ b/packages/cdk/lib/construct/web.ts
@@ -61,6 +61,7 @@ export interface WebProps {
   readonly mcpEndpoint: string | null;
   readonly pptxEnabled: boolean;
   readonly webSearchEnabled: boolean;
+  readonly litellmProxyEnabled: boolean;
 }
 
 export class Web extends Construct {
@@ -272,6 +273,7 @@ export class Web extends Construct {
         VITE_APP_MCP_ENDPOINT: props.mcpEndpoint ?? '',
         VITE_APP_PPTX_ENABLED: props.pptxEnabled.toString(),
         VITE_APP_WEB_SEARCH_ENABLED: props.webSearchEnabled.toString(),
+        VITE_APP_LITELLM_PROXY_ENABLED: props.litellmProxyEnabled.toString(),
       },
     });
     // Enhance computing resources

--- a/packages/cdk/lib/stacks/common/web-stack.ts
+++ b/packages/cdk/lib/stacks/common/web-stack.ts
@@ -79,6 +79,7 @@ class WebStack extends NestedStack {
       mcpEndpoint,
       pptxEnabled: params.pptxEnabled,
       webSearchEnabled: !!params.searchApiKey && !!params.searchEngine,
+      litellmProxyEnabled: params.litellmProxyEnabled,
       // Frontend
       // Custom Domain
       cert: cert,

--- a/packages/web/src/hooks/useModel.ts
+++ b/packages/web/src/hooks/useModel.ts
@@ -101,8 +101,14 @@ const getFlows = () => {
 
 const flows = getFlows();
 
-// List of LangChain model IDs (configured to match config.yaml)
-const liteLlmModelIds = ['gemini-2.5-flash', 'gemini-2.5-pro'];
+// LiteLLM proxy enabled flag from CDK configuration
+const litellmProxyEnabled =
+  import.meta.env.VITE_APP_LITELLM_PROXY_ENABLED === 'true';
+
+// List of LiteLLM model IDs (only available when litellmProxyEnabled is true)
+const liteLlmModelIds = litellmProxyEnabled
+  ? ['gemini-2.5-flash', 'gemini-2.5-pro']
+  : [];
 
 // List of LangChain model IDs
 const langchainModelIds = [

--- a/packages/web/src/hooks/useModel.ts
+++ b/packages/web/src/hooks/useModel.ts
@@ -271,7 +271,7 @@ const featuredModelIds: string[] = [
   // Find Claude Sonnet 4 model (pattern: anthropic.claude-sonnet-4*)
   bedrockModelIds.find((id) => id.includes('claude-sonnet-4')) || '',
   'openai:gpt-5',
-  'gemini-2.5-pro',
+  ...(litellmProxyEnabled ? ['gemini-2.5-pro'] : []),
 ].filter((id) => id !== '');
 
 export const MODELS = {

--- a/packages/web/src/vite-env.d.ts
+++ b/packages/web/src/vite-env.d.ts
@@ -35,6 +35,7 @@ interface ImportMetaEnv {
   readonly VITE_APP_MCP_ENABLED: string;
   readonly VITE_APP_MCP_ENDPOINT: string;
   readonly VITE_APP_PPTX_ENABLED: string;
+  readonly VITE_APP_LITELLM_PROXY_ENABLED: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## Summary
- cdk.jsonで`litellmProxyEnabled: false`の場合、フロントエンドのモデルセレクタにLiteLLMモデル（Gemini 2.5 Flash, Gemini 2.5 Pro）が表示されないように修正
- CDKからフロントエンドに`VITE_APP_LITELLM_PROXY_ENABLED`環境変数を渡し、useModel.tsで条件分岐

## Test plan
- [ ] `cdk.json`で`litellmProxyEnabled: false`を設定してデプロイし、LiteLLMモデルが表示されないことを確認
- [ ] `litellmProxyEnabled: true`に変更して再デプロイし、モデルが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)