### PR TITLE
fix(web): LangChainモデルの添付ファイルを画像のみに制限

### DIFF
--- a/packages/web/src/hooks/useModel.ts
+++ b/packages/web/src/hooks/useModel.ts
@@ -204,27 +204,27 @@ const liteLlmModelMetadata: Record<string, ModelMetadata> = {
 
 const langchainModelMetadata: Record<string, ModelMetadata> = {
   'openai:gpt-4o': {
-    flags: { text: true, doc: true, image: true, video: false },
+    flags: { text: true, doc: false, image: true, video: false },
     displayName: 'GPT 4o',
     description: 'レガシー モデル',
   },
   'openai:gpt-4o-mini': {
-    flags: { text: true, doc: true, image: true, video: false },
+    flags: { text: true, doc: false, image: true, video: false },
     displayName: 'GPT 4o mini',
     description: '高速な処理が可能な軽量モデル',
   },
   'openai:o3': {
-    flags: { text: true, doc: true, image: true, video: false },
+    flags: { text: true, doc: false, image: true, video: false },
     displayName: 'o3',
     description: '高度な推論を使用する',
   },
   'openai:gpt-4.1': {
-    flags: { text: true, doc: true, image: true, video: false },
+    flags: { text: true, doc: false, image: true, video: false },
     displayName: 'GPT 4.1',
     description: '迅速なコーディングと分析に最適',
   },
   'openai:gpt-5': {
-    flags: { text: true, doc: true, image: true, video: false },
+    flags: { text: true, doc: false, image: true, video: false },
     displayName: 'GPT 5',
     description: '高速な推論能力モデル',
   },


### PR DESCRIPTION
## Summary
- LangChainプロバイダを使用するOpenAIモデルで、添付可能なファイルを画像のみに制限
- 対象モデル: GPT-4o, GPT-4o-mini, o3, GPT-4.1, GPT-5
- `flags.doc`を`false`に変更し、ドキュメントファイル(PDF, CSV, DOCなど)の添付を無効化

## Test plan
- [ ] LangChainモデル(例: GPT 4o)を選択した際に、ファイル添付で画像のみが選択可能であることを確認
- [ ] PDFなどのドキュメントファイルが添付できないことを確認
- [ ] Bedrockモデルでは従来通りドキュメントファイルも添付可能であることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)