### PR TITLE
:bug: fix(billing): サブスクリプション決済完了メールの重複送信を修正

### DIFF
--- a/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
+++ b/packages/cdk/lambda/billing/orchestration/flows/webhookEventFlow.ts
@@ -677,38 +677,31 @@ async function handlePaymentSucceeded(
           const invoiceId: string = rawInvoiceId;
 
           // インボイス番号を取得（重複チェック用）
+          // invoiceNumberがない場合はinvoiceIdをフォールバックとして使用
           const invoiceNumber = invoiceObject?.number as string | undefined;
-          if (!invoiceNumber) {
-            console.warn(
-              'Invoice number not found in event data, skipping deduplication',
-              {
-                eventId,
-                invoiceId,
-              }
-            );
-          }
+          const idempotencyIdentifier = invoiceNumber || invoiceId;
 
           // 冪等性チェック: 同一インボイスへの重複送信を防止
-          if (invoiceNumber) {
-            const idempotencyRepo = new IdempotencyRepository(tenantId);
-            const idempotencyKey = IdempotencyRepository.generateReceiptKey(
-              tenantId,
-              invoiceNumber
-            );
+          // invoiceNumberがなくてもinvoiceIdで重複チェックを行う
+          const idempotencyRepo = new IdempotencyRepository(tenantId);
+          const idempotencyKey = IdempotencyRepository.generateReceiptKey(
+            tenantId,
+            idempotencyIdentifier
+          );
 
-            const alreadySent =
-              await idempotencyRepo.isReceiptAlreadySent(idempotencyKey);
-            if (alreadySent) {
-              console.log('Receipt already sent for this invoice, skipping', {
-                invoiceNumber,
-                idempotencyKey,
-              });
-              return {
-                success: true,
-                emailSent: false,
-                reason: 'already_sent',
-              };
-            }
+          const alreadySent =
+            await idempotencyRepo.isReceiptAlreadySent(idempotencyKey);
+          if (alreadySent) {
+            console.log('Receipt already sent for this invoice, skipping', {
+              invoiceNumber,
+              invoiceId,
+              idempotencyKey,
+            });
+            return {
+              success: true,
+              emailSent: false,
+              reason: 'already_sent',
+            };
           }
 
           // platformSubscriptionIdは関数スコープで既に定義済み
@@ -752,20 +745,14 @@ async function handlePaymentSucceeded(
           // 領収書メール送信
           await sendPaymentReceipt(receiptData);
 
-          // 送信完了を記録
-          if (invoiceNumber) {
-            const idempotencyRepo = new IdempotencyRepository(tenantId);
-            const idempotencyKey = IdempotencyRepository.generateReceiptKey(
-              tenantId,
-              invoiceNumber
-            );
-            await idempotencyRepo.markReceiptSent(idempotencyKey);
-          }
+          // 送信完了を記録（idempotencyRepoとidempotencyKeyは上で定義済み）
+          await idempotencyRepo.markReceiptSent(idempotencyKey);
 
           console.log('Payment receipt email sent successfully', {
             recipientEmail: recipient.email,
             isParentalControl: recipient.isParentalControl,
             invoiceNumber,
+            idempotencyKey,
           });
 
           return { success: true, emailSent: true };
@@ -1893,27 +1880,28 @@ async function handleSubscriptionUpdated(
           const invoice = invoices.data[0];
 
           // 冪等性チェック: 同一インボイスへの重複送信を防止
+          // invoiceNumberがない場合はinvoice.idをフォールバックとして使用
           const invoiceNumber = invoice.number;
-          if (invoiceNumber) {
-            const idempotencyRepo = new IdempotencyRepository(tenantId);
-            const idempotencyKey = IdempotencyRepository.generateReceiptKey(
-              tenantId,
-              invoiceNumber
-            );
+          const idempotencyIdentifier = invoiceNumber || invoice.id;
+          const idempotencyRepo = new IdempotencyRepository(tenantId);
+          const idempotencyKey = IdempotencyRepository.generateReceiptKey(
+            tenantId,
+            idempotencyIdentifier
+          );
 
-            const alreadySent =
-              await idempotencyRepo.isReceiptAlreadySent(idempotencyKey);
-            if (alreadySent) {
-              console.log('Receipt already sent for this invoice, skipping', {
-                invoiceNumber,
-                idempotencyKey,
-              });
-              return {
-                success: true,
-                emailSent: false,
-                reason: 'already_sent',
-              };
-            }
+          const alreadySent =
+            await idempotencyRepo.isReceiptAlreadySent(idempotencyKey);
+          if (alreadySent) {
+            console.log('Receipt already sent for this invoice, skipping', {
+              invoiceNumber,
+              invoiceId: invoice.id,
+              idempotencyKey,
+            });
+            return {
+              success: true,
+              emailSent: false,
+              reason: 'already_sent',
+            };
           }
 
           // 領収書データを構築
@@ -1945,19 +1933,13 @@ async function handleSubscriptionUpdated(
           await sendPaymentReceipt(receiptData);
 
           // 送信完了を記録
-          if (invoiceNumber) {
-            const idempotencyRepo = new IdempotencyRepository(tenantId);
-            const idempotencyKey = IdempotencyRepository.generateReceiptKey(
-              tenantId,
-              invoiceNumber
-            );
-            await idempotencyRepo.markReceiptSent(idempotencyKey);
-          }
+          await idempotencyRepo.markReceiptSent(idempotencyKey);
 
           console.log('Plan change receipt email sent successfully', {
             recipientEmail: recipient.email,
             isParentalControl: recipient.isParentalControl,
             invoiceNumber,
+            idempotencyKey,
           });
 
           return { success: true, emailSent: true };
@@ -2798,27 +2780,28 @@ async function handleParentalControlActivation(
           }
 
           // 冪等性チェック: 同一インボイスへの重複送信を防止
+          // invoiceNumberがない場合はinvoice.idをフォールバックとして使用
           const invoiceNumber = invoice.number;
-          if (invoiceNumber) {
-            const idempotencyRepo = new IdempotencyRepository(tenantId);
-            const idempotencyKey = IdempotencyRepository.generateReceiptKey(
-              tenantId,
-              invoiceNumber
-            );
+          const idempotencyIdentifier = invoiceNumber || invoice.id;
+          const idempotencyRepo = new IdempotencyRepository(tenantId);
+          const idempotencyKey = IdempotencyRepository.generateReceiptKey(
+            tenantId,
+            idempotencyIdentifier
+          );
 
-            const alreadySent =
-              await idempotencyRepo.isReceiptAlreadySent(idempotencyKey);
-            if (alreadySent) {
-              console.log('Receipt already sent for this invoice, skipping', {
-                invoiceNumber,
-                idempotencyKey,
-              });
-              return {
-                success: true,
-                emailSent: false,
-                reason: 'already_sent',
-              };
-            }
+          const alreadySent =
+            await idempotencyRepo.isReceiptAlreadySent(idempotencyKey);
+          if (alreadySent) {
+            console.log('Receipt already sent for this invoice, skipping', {
+              invoiceNumber,
+              invoiceId: invoice.id,
+              idempotencyKey,
+            });
+            return {
+              success: true,
+              emailSent: false,
+              reason: 'already_sent',
+            };
           }
 
           // 領収書データを構築
@@ -2846,19 +2829,13 @@ async function handleParentalControlActivation(
           await sendPaymentReceipt(receiptData);
 
           // 送信完了を記録
-          if (invoiceNumber) {
-            const idempotencyRepo = new IdempotencyRepository(tenantId);
-            const idempotencyKey = IdempotencyRepository.generateReceiptKey(
-              tenantId,
-              invoiceNumber
-            );
-            await idempotencyRepo.markReceiptSent(idempotencyKey);
-          }
+          await idempotencyRepo.markReceiptSent(idempotencyKey);
 
           console.log('Parental control receipt email sent successfully', {
             recipientEmail: recipient.email,
             childEmail,
             invoiceNumber,
+            idempotencyKey,
           });
 
           return { success: true, emailSent: true };
@@ -3216,27 +3193,28 @@ async function handlePlanChangeCompleted(
           const invoice = invoices.data[0];
 
           // 冪等性チェック: 同一インボイスへの重複送信を防止
+          // invoiceNumberがない場合はinvoice.idをフォールバックとして使用
           const invoiceNumber = invoice.number;
-          if (invoiceNumber) {
-            const idempotencyRepo = new IdempotencyRepository(tenantId);
-            const idempotencyKey = IdempotencyRepository.generateReceiptKey(
-              tenantId,
-              invoiceNumber
-            );
+          const idempotencyIdentifier = invoiceNumber || invoice.id;
+          const idempotencyRepo = new IdempotencyRepository(tenantId);
+          const idempotencyKey = IdempotencyRepository.generateReceiptKey(
+            tenantId,
+            idempotencyIdentifier
+          );
 
-            const alreadySent =
-              await idempotencyRepo.isReceiptAlreadySent(idempotencyKey);
-            if (alreadySent) {
-              console.log('Receipt already sent for this invoice, skipping', {
-                invoiceNumber,
-                idempotencyKey,
-              });
-              return {
-                success: true,
-                emailSent: false,
-                reason: 'already_sent',
-              };
-            }
+          const alreadySent =
+            await idempotencyRepo.isReceiptAlreadySent(idempotencyKey);
+          if (alreadySent) {
+            console.log('Receipt already sent for this invoice, skipping', {
+              invoiceNumber,
+              invoiceId: invoice.id,
+              idempotencyKey,
+            });
+            return {
+              success: true,
+              emailSent: false,
+              reason: 'already_sent',
+            };
           }
 
           // 領収書データを構築
@@ -3266,19 +3244,13 @@ async function handlePlanChangeCompleted(
           await sendPaymentReceipt(receiptData);
 
           // 送信完了を記録
-          if (invoiceNumber) {
-            const idempotencyRepo = new IdempotencyRepository(tenantId);
-            const idempotencyKey = IdempotencyRepository.generateReceiptKey(
-              tenantId,
-              invoiceNumber
-            );
-            await idempotencyRepo.markReceiptSent(idempotencyKey);
-          }
+          await idempotencyRepo.markReceiptSent(idempotencyKey);
 
           console.log('Checkout plan change receipt email sent successfully', {
             recipientEmail: recipient.email,
             isParentalControl: recipient.isParentalControl,
             invoiceNumber,
+            idempotencyKey,
           });
 
           return { success: true, emailSent: true };

--- a/packages/cdk/lambda/billing/payment-gateway/webhook/stripe/eventMapper.ts
+++ b/packages/cdk/lambda/billing/payment-gateway/webhook/stripe/eventMapper.ts
@@ -33,7 +33,8 @@ const STRIPE_TO_BUSINESS_EVENT_MAP: Record<
   BusinessEventType | EventMapper
 > = {
   'invoice.payment_succeeded': 'payment.succeeded',
-  'invoice.paid': 'payment.succeeded', // 補助的なマッピング
+  // Note: 'invoice.paid' は削除。invoice.payment_succeeded と重複して
+  // 同一決済に対して複数回のビジネスイベントが発火し、重複メール送信の原因となるため。
   'invoice.payment_failed': 'payment.failed',
   'customer.subscription.deleted': 'subscription.canceled',
   'charge.refunded': 'payment.refunded',


### PR DESCRIPTION
## 概要
サブスクリプション決済完了時に領収書メールが5通重複送信される問題を修正しました。

## 原因
1. **重複イベントマッピング**: `invoice.paid` と `invoice.payment_succeeded` が両方とも `payment.succeeded` にマッピングされていた。Stripeは同一決済に対して両方のイベントを送信するため、`handlePaymentSucceeded` が2回実行されていた。

2. **冪等性チェックのスキップ**: `invoiceNumber` が存在しない場合、冪等性チェックがスキップされ、重複送信を防げなかった。

## 修正内容
1. `eventMapper.ts`: 冗長な `invoice.paid` マッピングを削除
2. `webhookEventFlow.ts`: 4箇所の領収書送信処理で冪等性チェックを必須化
   - `invoiceNumber` がない場合は `invoiceId` をフォールバックとして使用
   - 条件分岐を削除し、常に冪等性チェックを実行

## 影響範囲
- `send_payment_receipt` (通常の決済完了)
- `send_plan_change_receipt` (プラン変更)
- `send_parental_control_receipt` (ペアレンタルコントロール)
- `send_checkout_plan_change_receipt` (Checkout経由のプラン変更)

## テスト計画
- [ ] 新規サブスクリプション登録時に領収書メールが1通のみ送信されることを確認
- [ ] プラン変更時に領収書メールが1通のみ送信されることを確認
- [ ] ペアレンタルコントロール経由の登録時に領収書メールが1通のみ送信されることを確認