### PR TITLE
feat(web): モデルセレクタに対応入力タイプのアイコンを表示

### DIFF
--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -915,6 +915,9 @@ model:
   parameters:
     reasoning: Reasoning
     reasoning_budget: Reasoning Budget
+  supports_document: Supports documents
+  supports_image: Supports images
+  supports_video: Supports videos
 navigation:
   agentChat: Agent Chat
   chat: Chat

--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -912,6 +912,7 @@ meetingMinutes:
   title: Meeting Minutes Generator
   transcript: Transcript
 model:
+  otherModels: Other Models
   parameters:
     reasoning: Reasoning
     reasoning_budget: Reasoning Budget

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -773,6 +773,7 @@ meetingMinutes:
   title: 議事録生成
   transcript: 文字起こし
 model:
+  otherModels: その他モデル
   parameters:
     reasoning: Reasoning
     reasoning_budget: Reasoning Budget

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -776,6 +776,9 @@ model:
   parameters:
     reasoning: Reasoning
     reasoning_budget: Reasoning Budget
+  supports_document: ドキュメント対応
+  supports_image: 画像対応
+  supports_video: 動画対応
 navigation:
   agentChat: Agent チャット
   chat: チャット

--- a/packages/web/public/locales/translation/th.yaml
+++ b/packages/web/public/locales/translation/th.yaml
@@ -669,6 +669,9 @@ model:
   parameters:
     reasoning: การให้เหตุผล
     reasoning_budget: งบประมาณการให้เหตุผล
+  supports_document: รองรับเอกสาร
+  supports_image: รองรับรูปภาพ
+  supports_video: รองรับวิดีโอ
 navigation:
   agentChat: Agent Chat
   chat: Chat

--- a/packages/web/public/locales/translation/th.yaml
+++ b/packages/web/public/locales/translation/th.yaml
@@ -666,6 +666,7 @@ meetingMinutes:
   title: ตัวสร้างรายงานการประชุม
   transcript: บันทึกการถอดความ
 model:
+  otherModels: โมเดลอื่นๆ
   parameters:
     reasoning: การให้เหตุผล
     reasoning_budget: งบประมาณการให้เหตุผล

--- a/packages/web/public/locales/translation/vi.yaml
+++ b/packages/web/public/locales/translation/vi.yaml
@@ -653,6 +653,9 @@ model:
   parameters:
     reasoning: Reasoning
     reasoning_budget: Reasoning Budget
+  supports_document: Hỗ trợ tài liệu
+  supports_image: Hỗ trợ hình ảnh
+  supports_video: Hỗ trợ video
 navigation:
   agentChat: Agent Chat
   chat: Chat

--- a/packages/web/public/locales/translation/vi.yaml
+++ b/packages/web/public/locales/translation/vi.yaml
@@ -650,6 +650,7 @@ meetingMinutes:
   title: Trình tạo biên bản cuộc họp
   transcript: Bản chuyển đổi
 model:
+  otherModels: Các mô hình khác
   parameters:
     reasoning: Reasoning
     reasoning_budget: Reasoning Budget

--- a/packages/web/public/locales/translation/zh.yaml
+++ b/packages/web/public/locales/translation/zh.yaml
@@ -559,6 +559,9 @@ model:
   parameters:
     reasoning: 推理
     reasoning_budget: 推理预算
+  supports_document: 支持文档
+  supports_image: 支持图像
+  supports_video: 支持视频
 navigation:
   agentChat: Agent聊天
   chat: 聊天

--- a/packages/web/public/locales/translation/zh.yaml
+++ b/packages/web/public/locales/translation/zh.yaml
@@ -556,6 +556,7 @@ meetingMinutes:
   title: 会议纪要生成器
   transcript: 转录文本
 model:
+  otherModels: 其他模型
   parameters:
     reasoning: 推理
     reasoning_budget: 推理预算

--- a/packages/web/src/components/ModelSelector.tsx
+++ b/packages/web/src/components/ModelSelector.tsx
@@ -1,11 +1,20 @@
 import React, { Fragment, useState, useMemo } from 'react';
 import { Menu, Transition } from '@headlessui/react';
-import { PiCaretDown, PiCheck, PiCaretRight } from 'react-icons/pi';
+import {
+  PiCaretDown,
+  PiCheck,
+  PiCaretRight,
+  PiFile,
+  PiImage,
+  PiVideo,
+} from 'react-icons/pi';
+import { FeatureFlags } from 'generative-ai-use-cases-jp';
 
 export type ModelOption = {
   value: string;
   label: string;
   description?: string;
+  flags?: FeatureFlags;
 };
 
 type Props = {
@@ -14,6 +23,26 @@ type Props = {
   models: ModelOption[];
   featuredModelIds: string[];
   className?: string;
+};
+
+const AttachmentIcons: React.FC<{ flags?: FeatureFlags }> = ({ flags }) => {
+  if (!flags) return null;
+  const hasAny = flags.doc || flags.image || flags.video;
+  if (!hasAny) return null;
+
+  return (
+    <span className="ml-2 flex items-center gap-1">
+      {flags.doc && (
+        <PiFile className="h-4 w-4 text-blue-500" title="ドキュメント対応" />
+      )}
+      {flags.image && (
+        <PiImage className="h-4 w-4 text-green-500" title="画像対応" />
+      )}
+      {flags.video && (
+        <PiVideo className="h-4 w-4 text-purple-500" title="動画対応" />
+      )}
+    </span>
+  );
 };
 
 const ModelSelector: React.FC<Props> = ({
@@ -74,10 +103,11 @@ const ModelSelector: React.FC<Props> = ({
         <>
           <Menu.Button className="relative h-10 w-full cursor-pointer rounded-lg px-4 py-2 text-left focus:outline-none">
             <span className="flex items-center justify-between">
-              <span className="block truncate font-medium">
+              <span className="flex items-center truncate font-medium">
                 {currentModel?.label || value}
+                <AttachmentIcons flags={currentModel?.flags} />
               </span>
-              <PiCaretDown className="ml-2 h-5 w-5 text-gray-400" />
+              <PiCaretDown className="ml-2 h-5 w-5 shrink-0 text-gray-400" />
             </span>
           </Menu.Button>
 
@@ -112,8 +142,9 @@ const ModelSelector: React.FC<Props> = ({
                           )}
                         </span>
                         <div className="ml-3 flex-1">
-                          <div className="font-medium text-gray-900">
+                          <div className="flex items-center font-medium text-gray-900">
                             {model.label}
+                            <AttachmentIcons flags={model.flags} />
                           </div>
                           {model.description && (
                             <div className="mt-0.5 text-sm text-gray-500">
@@ -170,8 +201,9 @@ const ModelSelector: React.FC<Props> = ({
                                 )}
                               </span>
                               <div className="ml-3 flex-1">
-                                <div className="font-medium text-gray-900">
+                                <div className="flex items-center font-medium text-gray-900">
                                   {model.label}
+                                  <AttachmentIcons flags={model.flags} />
                                 </div>
                                 {model.description && (
                                   <div className="mt-0.5 text-sm text-gray-500">

--- a/packages/web/src/components/ModelSelector.tsx
+++ b/packages/web/src/components/ModelSelector.tsx
@@ -101,7 +101,7 @@ const ModelSelector: React.FC<Props> = ({
     <Menu as="div" className={`relative ${className}`}>
       {({ open, close }) => (
         <>
-          <Menu.Button className="relative h-10 w-full cursor-pointer rounded-lg px-4 py-2 text-left focus:outline-none">
+          <Menu.Button className="relative h-10 w-full cursor-pointer rounded-lg border border-gray-300 bg-white px-4 py-2 text-left hover:border-gray-400 focus:outline-none">
             <span className="flex items-center justify-between">
               <span className="flex items-center truncate font-medium">
                 {currentModel?.label || value}

--- a/packages/web/src/components/ModelSelector.tsx
+++ b/packages/web/src/components/ModelSelector.tsx
@@ -8,6 +8,7 @@ import {
   PiImage,
   PiVideo,
 } from 'react-icons/pi';
+import { useTranslation } from 'react-i18next';
 import { FeatureFlags } from 'generative-ai-use-cases';
 
 export type ModelOption = {
@@ -26,6 +27,7 @@ type Props = {
 };
 
 const AttachmentIcons: React.FC<{ flags?: FeatureFlags }> = ({ flags }) => {
+  const { t } = useTranslation();
   if (!flags) return null;
   const hasAny = flags.doc || flags.image || flags.video;
   if (!hasAny) return null;
@@ -33,13 +35,22 @@ const AttachmentIcons: React.FC<{ flags?: FeatureFlags }> = ({ flags }) => {
   return (
     <span className="ml-2 flex items-center gap-1">
       {flags.doc && (
-        <PiFile className="h-4 w-4 text-blue-500" title="ドキュメント対応" />
+        <PiFile
+          className="h-4 w-4 text-blue-500"
+          title={t('model.supports_document')}
+        />
       )}
       {flags.image && (
-        <PiImage className="h-4 w-4 text-green-500" title="画像対応" />
+        <PiImage
+          className="h-4 w-4 text-green-500"
+          title={t('model.supports_image')}
+        />
       )}
       {flags.video && (
-        <PiVideo className="h-4 w-4 text-purple-500" title="動画対応" />
+        <PiVideo
+          className="h-4 w-4 text-purple-500"
+          title={t('model.supports_video')}
+        />
       )}
     </span>
   );

--- a/packages/web/src/components/ModelSelector.tsx
+++ b/packages/web/src/components/ModelSelector.tsx
@@ -8,7 +8,7 @@ import {
   PiImage,
   PiVideo,
 } from 'react-icons/pi';
-import { FeatureFlags } from 'generative-ai-use-cases-jp';
+import { FeatureFlags } from 'generative-ai-use-cases';
 
 export type ModelOption = {
   value: string;

--- a/packages/web/src/components/ModelSelector.tsx
+++ b/packages/web/src/components/ModelSelector.tsx
@@ -63,6 +63,7 @@ const ModelSelector: React.FC<Props> = ({
   featuredModelIds,
   className = '',
 }) => {
+  const { t } = useTranslation();
   const [isSubMenuOpen, setIsSubMenuOpen] = useState(false);
 
   // Get current model display info
@@ -180,7 +181,7 @@ const ModelSelector: React.FC<Props> = ({
                       onClick={handleSubMenuToggle}
                       className="group flex w-full cursor-pointer items-center justify-between px-4 py-3 text-left hover:bg-gray-100">
                       <span className="font-medium text-gray-900">
-                        その他モデル
+                        {t('model.otherModels')}
                       </span>
                       <PiCaretRight className="h-5 w-5 text-gray-400" />
                     </button>

--- a/packages/web/src/pages/ChatPage.tsx
+++ b/packages/web/src/pages/ChatPage.tsx
@@ -433,6 +433,7 @@ ${baseContext}
                 value: m,
                 label: modelDisplayName(m),
                 description: modelMetadata[m]?.description,
+                flags: modelMetadata[m]?.flags,
               };
             })}
             featuredModelIds={featuredModelIds}


### PR DESCRIPTION
## Summary
- モデルセレクタの各モデル名の横に、対応している入力タイプ（ドキュメント、画像、動画）をアイコンで表示
- メインボタン、フィーチャーモデルリスト、その他モデルサブメニューの3箇所にアイコンを表示
- 各アイコンに異なる色を設定（ドキュメント: 青、画像: 緑、動画: 紫）

## Test plan
- [ ] `npm run web:devw` でローカル開発サーバーを起動
- [ ] チャットページを開き、モデルセレクタをクリック
- [ ] 各モデルの横に対応アイコンが表示されることを確認
- [ ] 「その他モデル」サブメニューでも同様にアイコンが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)