### PR TITLE
✨ feat: PDFのcitations設定を有効化して画像ベースPDFのビジョン処理に対応

### DIFF
--- a/packages/cdk/lambda/utils/models.ts
+++ b/packages/cdk/lambda/utils/models.ts
@@ -386,6 +386,8 @@ const createConverseCommandInput = (
             },
           } as ContentBlock.ImageMember);
         } else if (extra.type === 'file' && extra.source.type === 'base64') {
+          // PDFの場合はcitationsを有効にして画像ベースPDFのビジョン処理を有効化
+          const isPdf = mimeType === 'application/pdf';
           contentBlocks.push({
             document: {
               format,
@@ -395,6 +397,11 @@ const createConverseCommandInput = (
               source: {
                 bytes: Buffer.from(extra.source.data, 'base64'),
               },
+              ...(isPdf && {
+                citations: {
+                  enabled: true,
+                },
+              }),
             },
           } as ContentBlock.DocumentMember);
         } else if (extra.type === 'video' && extra.source.type === 'base64') {


### PR DESCRIPTION
## Summary
- Bedrock Converse APIでPDFを送信する際に`citations`設定を有効化
- 画像ベースPDF（スキャン文書など）をClaudeが読み取れるようになる
- DocumentBlockにcitations: { enabled: true }を追加（PDFファイルの場合のみ）

## Test plan
- [ ] 画像ベースPDF（スキャン文書）をアップロードし、Claudeが内容を正しく読み取れることを確認
- [ ] テキストベースPDFが引き続き正常に動作することを確認
- [ ] 複数ページの画像ベースPDFで動作確認

## Note
- トークン使用量が増加します（約7倍: 1,000→7,000トークン/3ページ）
- 一部のリージョンではビジョン機能がまだ展開されていない可能性あり

🤖 Generated with [Claude Code](https://claude.com/claude-code)