### PR TITLE
🐛 fix: 議事録生成で長文テキストの出力が途中で切れる問題を修正

### DIFF
--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -888,6 +888,7 @@ meetingMinutes:
   generate_minutes_header: Generate Meeting Minutes
   generated_minutes: Generated Minutes
   generating: Generating minutes...
+  generating_continuation: Generating minutes (continuation {{current}}/{{max}})...
   generation_error: Failed to generate meeting minutes. Please try again.
   generation_success: Meeting minutes generated successfully
   language: Language

--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -891,6 +891,7 @@ meetingMinutes:
   generating_continuation: Generating minutes (continuation {{current}}/{{max}})...
   generation_error: Failed to generate meeting minutes. Please try again.
   generation_success: Meeting minutes generated successfully
+  output_may_be_incomplete: Output may be incomplete due to length limits. Consider splitting the transcript.
   language: Language
   language_auto: Auto Detect
   language_chinese: Chinese

--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -1095,6 +1095,7 @@ transcribe:
   result_placeholder: Speech recognition results will be displayed here
   screen_audio: Screen Audio
   screen_audio_error: 'Screen Audio Error:'
+  screen_audio_failed_fallback_mic: Failed to capture screen audio. Starting recording with microphone only.
   screen_audio_notice: 'For Windows: Select "Entire Screen" tab and turn ON "Share system audio".<br/>For Mac: Select "Chrome Tab" and turn ON "Also share tab audio".<br/>Chrome and Edge work. Firefox does not work.'
   select_input_method: Please select from microphone input or file upload
   speaker_names: Speaker names (comma separated)

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -752,6 +752,7 @@ meetingMinutes:
   generating_continuation: 議事録生成中（継続 {{current}}/{{max}} 回目）...
   generation_error: 議事録の生成に失敗しました。再試行してください。
   generation_success: 議事録が正常に生成されました
+  output_may_be_incomplete: 出力が長さの制限により不完全な可能性があります。文字起こしを分割することを検討してください。
   language: 言語
   language_auto: 自動検出
   language_chinese: 中国語

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -935,6 +935,7 @@ transcribe:
   result_placeholder: 音声認識結果がここに表示されます
   screen_audio: スクリーン音声
   screen_audio_error: 'スクリーン音声エラー:'
+  screen_audio_failed_fallback_mic: スクリーン音声の取得に失敗しました。マイクのみで録音を開始します。
   screen_audio_notice: 'Windows の場合:「画面全体」タブより、「システム音声も共有する」を ON にしてください。<br/>Mac の場合:「Chrome Tab」から、「Also share tab audio」を ON にしてください。<br/>Chrome と Edge は動作します。Firefox は動作しません。'
   select_input_method: マイク入力 or ファイルアップロードから選択してください
   speaker_names: 話し手の名前（カンマ区切り）

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -749,6 +749,7 @@ meetingMinutes:
   generate_minutes_header: 議事録を生成
   generated_minutes: 生成された議事録
   generating: 議事録生成中...
+  generating_continuation: 議事録生成中（継続 {{current}}/{{max}} 回目）...
   generation_error: 議事録の生成に失敗しました。再試行してください。
   generation_success: 議事録が正常に生成されました
   language: 言語

--- a/packages/web/public/locales/translation/th.yaml
+++ b/packages/web/public/locales/translation/th.yaml
@@ -645,6 +645,7 @@ meetingMinutes:
   generating_continuation: กำลังสร้างรายงานการประชุม (ต่อเนื่อง {{current}}/{{max}})...
   generation_error: ไม่สามารถสร้างรายงานการประชุมได้ กรุณาลองอีกครั้ง
   generation_success: สร้างรายงานการประชุมสำเร็จ
+  output_may_be_incomplete: ผลลัพธ์อาจไม่สมบูรณ์เนื่องจากข้อจำกัดด้านความยาว กรุณาพิจารณาแบ่งการถอดความ
   language: ภาษา
   language_auto: ตรวจจับอัตโนมัติ
   language_chinese: จีน

--- a/packages/web/public/locales/translation/th.yaml
+++ b/packages/web/public/locales/translation/th.yaml
@@ -642,6 +642,7 @@ meetingMinutes:
   generate_minutes_header: สร้างรายงานการประชุม
   generated_minutes: รายงานการประชุมที่สร้างแล้ว
   generating: กำลังสร้างรายงานการประชุม...
+  generating_continuation: กำลังสร้างรายงานการประชุม (ต่อเนื่อง {{current}}/{{max}})...
   generation_error: ไม่สามารถสร้างรายงานการประชุมได้ กรุณาลองอีกครั้ง
   generation_success: สร้างรายงานการประชุมสำเร็จ
   language: ภาษา

--- a/packages/web/public/locales/translation/th.yaml
+++ b/packages/web/public/locales/translation/th.yaml
@@ -798,6 +798,7 @@ transcribe:
   result_placeholder: ข้อความที่แปลงจากเสียงของคุณ
   screen_audio: เสียงหน้าจอ
   screen_audio_error: 'ข้อผิดพลาดเสียงหน้าจอ:'
+  screen_audio_failed_fallback_mic: การจับเสียงหน้าจอล้มเหลว เริ่มบันทึกด้วยไมโครโฟนเท่านั้น
   screen_audio_notice: 'สำหรับ Windows: เลือกแท็บ "หน้าจอทั้งหมด" และเปิด "แชร์เสียงระบบด้วย"<br/>สำหรับ Mac: เลือก "Chrome Tab" และเปิด "Also share tab audio"<br/>Chrome และ Edge ใช้งานได้ Firefox ใช้งานไม่ได้'
   select_input_method: โปรดเลือกจากอินพุตไมโครโฟนหรืออัปโหลดไฟล์
   speaker_names: ชื่อผู้พูด (คั่นด้วยเครื่องหมายจุลภาค)

--- a/packages/web/public/locales/translation/vi.yaml
+++ b/packages/web/public/locales/translation/vi.yaml
@@ -772,6 +772,7 @@ transcribe:
   result_placeholder: Kết quả nhận dạng giọng nói sẽ được hiển thị ở đây
   screen_audio: Âm thanh màn hình
   screen_audio_error: 'Lỗi âm thanh màn hình:'
+  screen_audio_failed_fallback_mic: Không thể thu âm thanh màn hình. Bắt đầu ghi âm chỉ với micro.
   screen_audio_notice: 'Đối với Windows: Chọn tab "Toàn bộ màn hình" và bật "Chia sẻ âm thanh hệ thống".<br/>Đối với Mac: Chọn "Chrome Tab" và bật "Also share tab audio".<br/>Chrome và Edge hoạt động. Firefox không hoạt động.'
   select_input_method: Vui lòng chọn từ đầu vào microphone hoặc tải lên tệp
   speaker_names: Tên người nói (phân cách bằng dấu phẩy)

--- a/packages/web/public/locales/translation/vi.yaml
+++ b/packages/web/public/locales/translation/vi.yaml
@@ -629,6 +629,7 @@ meetingMinutes:
   generating_continuation: Đang tạo biên bản (tiếp tục {{current}}/{{max}})...
   generation_error: Không thể tạo biên bản cuộc họp. Vui lòng thử lại.
   generation_success: Tạo biên bản cuộc họp thành công
+  output_may_be_incomplete: Kết quả có thể không đầy đủ do giới hạn độ dài. Hãy xem xét chia nhỏ bản ghi âm.
   language: Ngôn ngữ
   language_auto: Tự động phát hiện
   language_chinese: Tiếng Trung

--- a/packages/web/public/locales/translation/vi.yaml
+++ b/packages/web/public/locales/translation/vi.yaml
@@ -626,6 +626,7 @@ meetingMinutes:
   generate_minutes_header: Tạo biên bản
   generated_minutes: Biên bản đã được tạo
   generating: Đang tạo biên bản...
+  generating_continuation: Đang tạo biên bản (tiếp tục {{current}}/{{max}})...
   generation_error: Không thể tạo biên bản cuộc họp. Vui lòng thử lại.
   generation_success: Tạo biên bản cuộc họp thành công
   language: Ngôn ngữ

--- a/packages/web/public/locales/translation/zh.yaml
+++ b/packages/web/public/locales/translation/zh.yaml
@@ -532,6 +532,7 @@ meetingMinutes:
   generate_minutes_header: 生成会议纪要
   generated_minutes: 已生成的会议纪要
   generating: 正在生成会议纪要...
+  generating_continuation: 正在生成会议纪要（继续 {{current}}/{{max}} 次）...
   generation_error: 会议纪要生成失败。请重试。
   generation_success: 会议纪要生成成功
   language: 语言

--- a/packages/web/public/locales/translation/zh.yaml
+++ b/packages/web/public/locales/translation/zh.yaml
@@ -535,6 +535,7 @@ meetingMinutes:
   generating_continuation: 正在生成会议纪要（继续 {{current}}/{{max}} 次）...
   generation_error: 会议纪要生成失败。请重试。
   generation_success: 会议纪要生成成功
+  output_may_be_incomplete: 由于长度限制，输出可能不完整。请考虑分割转录文本。
   language: 语言
   language_auto: 自动检测
   language_chinese: 中文

--- a/packages/web/public/locales/translation/zh.yaml
+++ b/packages/web/public/locales/translation/zh.yaml
@@ -672,6 +672,7 @@ transcribe:
   result_placeholder: 语音识别结果将显示在这里
   screen_audio: 屏幕音频
   screen_audio_error: 屏幕音频错误：
+  screen_audio_failed_fallback_mic: 屏幕音频捕获失败。仅使用麦克风开始录音。
   screen_audio_notice: 'Windows 的情况:选择「整个屏幕」选项卡，并启用「共享系统音频」。<br/>Mac 的情况:选择「Chrome Tab」，并启用「Also share tab audio」。<br/>Chrome 和 Edge 可以使用。Firefox 无法使用。'
   select_input_method: 请选择麦克风输入或文件上传
   speaker_names: 发言人姓名（逗号分隔）

--- a/packages/web/src/hooks/useMeetingMinutes.ts
+++ b/packages/web/src/hooks/useMeetingMinutes.ts
@@ -122,7 +122,12 @@ export const useMeetingMinutes = (
                     // Only treat SyntaxError as JSON parse error
                     if (error instanceof SyntaxError) {
                       consecutiveParseErrors++;
-                      console.warn('Failed to parse JSON chunk:', c, error);
+                      // Avoid logging raw chunk data to prevent exposing sensitive content
+                      console.warn('Failed to parse JSON chunk:', {
+                        chunkLength: c.length,
+                        chunkPreview: c.substring(0, 50) + (c.length > 50 ? '...' : ''),
+                        error: error.message,
+                      });
 
                       if (
                         consecutiveParseErrors >= MAX_CONSECUTIVE_PARSE_ERRORS

--- a/packages/web/src/hooks/useMeetingMinutes.ts
+++ b/packages/web/src/hooks/useMeetingMinutes.ts
@@ -211,6 +211,7 @@ export const useMeetingMinutes = (
         setLastGeneratedTime(new Date());
         onGenerate?.('success', { minutes: fullResponse });
       } catch (error) {
+        console.error('Meeting minutes generation failed:', error);
         onGenerate?.('error', {
           message: error instanceof Error ? error.message : 'Unknown error',
         });

--- a/packages/web/src/hooks/useMeetingMinutes.ts
+++ b/packages/web/src/hooks/useMeetingMinutes.ts
@@ -13,6 +13,9 @@ export type MeetingMinutesStyle =
 // Maximum number of continuation attempts to prevent infinite loops
 const MAX_CONTINUATION_ATTEMPTS = 5;
 
+// Maximum consecutive parse errors before considering the stream corrupted
+const MAX_CONSECUTIVE_PARSE_ERRORS = 10;
+
 export const useMeetingMinutes = (
   minutesStyle: MeetingMinutesStyle,
   customPrompt: string,
@@ -68,11 +71,14 @@ export const useMeetingMinutes = (
         let continuationCount = 0;
         setGeneratedMinutes('');
 
-        // Helper function to process stream and return stopReason
+        // Helper function to process stream chunks, accumulate response text,
+        // update UI via setGeneratedMinutes, and return the final stopReason
         const processStream = async (
           stream: AsyncGenerator<string, void, unknown>
         ): Promise<string> => {
           let stopReason = '';
+          let consecutiveParseErrors = 0;
+          let successfulParses = 0;
 
           for await (const chunk of stream) {
             if (chunk) {
@@ -82,20 +88,52 @@ export const useMeetingMinutes = (
                 if (c && c.length > 0) {
                   try {
                     const payload = JSON.parse(c) as StreamingChunk;
+                    consecutiveParseErrors = 0; // Reset on successful parse
+                    successfulParses++;
+
                     if (payload.text && payload.text.length > 0) {
                       fullResponse += payload.text;
                       setGeneratedMinutes(fullResponse);
                     }
                     if (payload.stopReason) {
                       stopReason = payload.stopReason;
+
+                      // Handle explicit error responses from backend
+                      if (payload.stopReason === 'error') {
+                        throw new Error(
+                          payload.text || 'API returned an error during streaming'
+                        );
+                      }
                     }
                   } catch (error) {
-                    // Skip invalid JSON chunks
-                    console.debug('Skipping invalid JSON chunk:', c);
+                    // Re-throw if it's our explicit error
+                    if (
+                      error instanceof Error &&
+                      error.message.includes('API returned an error')
+                    ) {
+                      throw error;
+                    }
+
+                    // Track consecutive parse errors to detect stream corruption
+                    consecutiveParseErrors++;
+                    console.warn('Failed to parse JSON chunk:', c);
+
+                    if (consecutiveParseErrors >= MAX_CONSECUTIVE_PARSE_ERRORS) {
+                      throw new Error(
+                        'Stream processing failed: too many consecutive parse errors'
+                      );
+                    }
                   }
                 }
               }
             }
+          }
+
+          // Warn if we received no successful parses (possible complete stream failure)
+          if (successfulParses === 0 && consecutiveParseErrors > 0) {
+            console.error(
+              'No chunks were successfully parsed from stream, possible stream corruption'
+            );
           }
 
           return stopReason;

--- a/packages/web/src/hooks/useMeetingMinutes.ts
+++ b/packages/web/src/hooks/useMeetingMinutes.ts
@@ -2,7 +2,11 @@ import { useState, useCallback } from 'react';
 import useChatApi from './useChatApi';
 import { MODELS } from './useModel';
 import { getPrompter } from '../prompts';
-import { UnrecordedMessage, Model, StreamingChunk } from 'generative-ai-use-cases';
+import {
+  UnrecordedMessage,
+  Model,
+  StreamingChunk,
+} from 'generative-ai-use-cases';
 
 export type MeetingMinutesStyle =
   | 'faq'
@@ -101,7 +105,8 @@ export const useMeetingMinutes = (
                       // Handle explicit error responses from backend
                       if (payload.stopReason === 'error') {
                         throw new Error(
-                          payload.text || 'API returned an error during streaming'
+                          payload.text ||
+                            'API returned an error during streaming'
                         );
                       }
                     }
@@ -118,7 +123,9 @@ export const useMeetingMinutes = (
                     consecutiveParseErrors++;
                     console.warn('Failed to parse JSON chunk:', c);
 
-                    if (consecutiveParseErrors >= MAX_CONSECUTIVE_PARSE_ERRORS) {
+                    if (
+                      consecutiveParseErrors >= MAX_CONSECUTIVE_PARSE_ERRORS
+                    ) {
                       throw new Error(
                         'Stream processing failed: too many consecutive parse errors'
                       );

--- a/packages/web/src/hooks/useMeetingMinutes.ts
+++ b/packages/web/src/hooks/useMeetingMinutes.ts
@@ -187,8 +187,7 @@ export const useMeetingMinutes = (
             {
               role: 'user',
               content:
-                // eslint-disable-next-line i18nhelper/no-jp-string
-                '続きを出力してください。前回の出力の続きから始めてください。',
+                'Please continue from where you left off. Start from the end of the previous output.',
             },
           ];
 

--- a/packages/web/src/hooks/useMeetingMinutes.ts
+++ b/packages/web/src/hooks/useMeetingMinutes.ts
@@ -111,7 +111,7 @@ export const useMeetingMinutes = (
                       }
                     }
                   } catch (error) {
-                    // Re-throw if it's our explicit error
+                    // Re-throw explicit API errors
                     if (
                       error instanceof Error &&
                       error.message.includes('API returned an error')
@@ -119,16 +119,25 @@ export const useMeetingMinutes = (
                       throw error;
                     }
 
-                    // Track consecutive parse errors to detect stream corruption
-                    consecutiveParseErrors++;
-                    console.warn('Failed to parse JSON chunk:', c);
+                    // Only treat SyntaxError as JSON parse error
+                    if (error instanceof SyntaxError) {
+                      consecutiveParseErrors++;
+                      console.warn('Failed to parse JSON chunk:', c, error);
 
-                    if (
-                      consecutiveParseErrors >= MAX_CONSECUTIVE_PARSE_ERRORS
-                    ) {
-                      throw new Error(
-                        'Stream processing failed: too many consecutive parse errors'
+                      if (
+                        consecutiveParseErrors >= MAX_CONSECUTIVE_PARSE_ERRORS
+                      ) {
+                        throw new Error(
+                          'Stream processing failed: too many consecutive parse errors'
+                        );
+                      }
+                    } else {
+                      // Re-throw unexpected errors (TypeError, RangeError, etc.)
+                      console.error(
+                        'Unexpected error during stream processing:',
+                        error
                       );
+                      throw error;
                     }
                   }
                 }
@@ -137,7 +146,7 @@ export const useMeetingMinutes = (
           }
 
           // Throw error if we received no successful parses (complete stream failure)
-          if (successfulParses === 0 && consecutiveParseErrors > 0) {
+          if (successfulParses === 0) {
             throw new Error(
               'Stream processing failed: no data received from server'
             );
@@ -209,7 +218,23 @@ export const useMeetingMinutes = (
 
         setLastProcessedTranscript(transcript);
         setLastGeneratedTime(new Date());
-        onGenerate?.('success', { minutes: fullResponse });
+
+        // Check if we reached max continuation attempts with incomplete output
+        if (
+          lastStopReason === 'max_tokens' &&
+          continuationCount >= MAX_CONTINUATION_ATTEMPTS
+        ) {
+          console.warn(
+            `Meeting minutes generation reached maximum continuation attempts (${MAX_CONTINUATION_ATTEMPTS}). Output may be incomplete.`
+          );
+          onGenerate?.('success', {
+            minutes: fullResponse,
+            message:
+              'Output may be incomplete due to length limits. Consider splitting the transcript.',
+          });
+        } else {
+          onGenerate?.('success', { minutes: fullResponse });
+        }
       } catch (error) {
         console.error('Meeting minutes generation failed:', error);
         onGenerate?.('error', {

--- a/packages/web/src/hooks/useMeetingMinutes.ts
+++ b/packages/web/src/hooks/useMeetingMinutes.ts
@@ -2,13 +2,16 @@ import { useState, useCallback } from 'react';
 import useChatApi from './useChatApi';
 import { MODELS } from './useModel';
 import { getPrompter } from '../prompts';
-import { UnrecordedMessage, Model } from 'generative-ai-use-cases';
+import { UnrecordedMessage, Model, StreamingChunk } from 'generative-ai-use-cases';
 
 export type MeetingMinutesStyle =
   | 'faq'
   | 'newspaper'
   | 'transcription'
   | 'custom';
+
+// Maximum number of continuation attempts to prevent infinite loops
+const MAX_CONTINUATION_ATTEMPTS = 5;
 
 export const useMeetingMinutes = (
   minutesStyle: MeetingMinutesStyle,
@@ -29,8 +32,13 @@ export const useMeetingMinutes = (
       transcript: string,
       modelId: string,
       onGenerate?: (
-        status: 'generating' | 'success' | 'error',
-        data?: { message?: string; minutes?: string }
+        status: 'generating' | 'continuing' | 'success' | 'error',
+        data?: {
+          message?: string;
+          minutes?: string;
+          continuationAttempt?: number;
+          maxContinuationAttempts?: number;
+        }
       ) => void
     ) => {
       if (!transcript || transcript.trim() === '') return;
@@ -55,7 +63,46 @@ export const useMeetingMinutes = (
                 customPrompt,
               });
 
-        const messages: UnrecordedMessage[] = [
+        let fullResponse = '';
+        let lastStopReason = '';
+        let continuationCount = 0;
+        setGeneratedMinutes('');
+
+        // Helper function to process stream and return stopReason
+        const processStream = async (
+          stream: AsyncGenerator<string, void, unknown>
+        ): Promise<string> => {
+          let stopReason = '';
+
+          for await (const chunk of stream) {
+            if (chunk) {
+              const chunks = chunk.split('\n');
+
+              for (const c of chunks) {
+                if (c && c.length > 0) {
+                  try {
+                    const payload = JSON.parse(c) as StreamingChunk;
+                    if (payload.text && payload.text.length > 0) {
+                      fullResponse += payload.text;
+                      setGeneratedMinutes(fullResponse);
+                    }
+                    if (payload.stopReason) {
+                      stopReason = payload.stopReason;
+                    }
+                  } catch (error) {
+                    // Skip invalid JSON chunks
+                    console.debug('Skipping invalid JSON chunk:', c);
+                  }
+                }
+              }
+            }
+          }
+
+          return stopReason;
+        };
+
+        // Initial generation
+        const initialMessages: UnrecordedMessage[] = [
           {
             role: 'system',
             content: promptContent,
@@ -66,34 +113,54 @@ export const useMeetingMinutes = (
           },
         ];
 
-        const stream = predictStream({
+        const initialStream = predictStream({
           model: model as Model,
-          messages,
+          messages: initialMessages,
           id: `meeting-minutes-${autoGenerateSessionTimestamp || Date.now()}`,
         });
 
-        let fullResponse = '';
-        setGeneratedMinutes('');
+        lastStopReason = await processStream(initialStream);
 
-        for await (const chunk of stream) {
-          if (chunk) {
-            const chunks = chunk.split('\n');
+        // Continuation loop for max_tokens
+        while (
+          lastStopReason === 'max_tokens' &&
+          continuationCount < MAX_CONTINUATION_ATTEMPTS
+        ) {
+          continuationCount++;
+          onGenerate?.('continuing', {
+            continuationAttempt: continuationCount,
+            maxContinuationAttempts: MAX_CONTINUATION_ATTEMPTS,
+          });
 
-            for (const c of chunks) {
-              if (c && c.length > 0) {
-                try {
-                  const payload = JSON.parse(c) as { text: string };
-                  if (payload.text && payload.text.length > 0) {
-                    fullResponse += payload.text;
-                    setGeneratedMinutes(fullResponse);
-                  }
-                } catch (error) {
-                  // Skip invalid JSON chunks
-                  console.debug('Skipping invalid JSON chunk:', c);
-                }
-              }
-            }
-          }
+          // Build continuation messages with previous response
+          const continueMessages: UnrecordedMessage[] = [
+            {
+              role: 'system',
+              content: promptContent,
+            },
+            {
+              role: 'user',
+              content: transcript,
+            },
+            {
+              role: 'assistant',
+              content: fullResponse,
+            },
+            {
+              role: 'user',
+              content:
+                // eslint-disable-next-line i18nhelper/no-jp-string
+                '続きを出力してください。前回の出力の続きから始めてください。',
+            },
+          ];
+
+          const continueStream = predictStream({
+            model: model as Model,
+            messages: continueMessages,
+            id: `meeting-minutes-continue-${continuationCount}-${autoGenerateSessionTimestamp || Date.now()}`,
+          });
+
+          lastStopReason = await processStream(continueStream);
         }
 
         setLastProcessedTranscript(transcript);

--- a/packages/web/src/hooks/useMeetingMinutes.ts
+++ b/packages/web/src/hooks/useMeetingMinutes.ts
@@ -136,10 +136,10 @@ export const useMeetingMinutes = (
             }
           }
 
-          // Warn if we received no successful parses (possible complete stream failure)
+          // Throw error if we received no successful parses (complete stream failure)
           if (successfulParses === 0 && consecutiveParseErrors > 0) {
-            console.error(
-              'No chunks were successfully parsed from stream, possible stream corruption'
+            throw new Error(
+              'Stream processing failed: no data received from server'
             );
           }
 

--- a/packages/web/src/pages/MeetingMinutesPage.tsx
+++ b/packages/web/src/pages/MeetingMinutesPage.tsx
@@ -285,6 +285,12 @@ const MeetingMinutesPage: React.FC = () => {
   const { modelIds: availableModels, modelDisplayName } = MODELS;
   const [modelId, setModelId] = useState(availableModels[0] || '');
 
+  // Continuation state for long text generation
+  const [continuationInfo, setContinuationInfo] = useState<{
+    attempt: number;
+    maxAttempts: number;
+  } | null>(null);
+
   // Meeting minutes specific hook with external state
   const {
     loading: minutesLoading,
@@ -463,11 +469,19 @@ const MeetingMinutesPage: React.FC = () => {
     ) {
       if (realtimeText !== lastProcessedTranscript && !minutesLoading) {
         shouldGenerateRef.current = false; // Reset the flag
-        generateMinutes(realtimeText, modelId, (status) => {
+        setContinuationInfo(null);
+        generateMinutes(realtimeText, modelId, (status, data) => {
           if (status === 'success') {
+            setContinuationInfo(null);
             toast.success(t('meetingMinutes.generation_success'));
           } else if (status === 'error') {
+            setContinuationInfo(null);
             toast.error(t('meetingMinutes.generation_error'));
+          } else if (status === 'continuing') {
+            setContinuationInfo({
+              attempt: data?.continuationAttempt || 0,
+              maxAttempts: data?.maxContinuationAttempts || 5,
+            });
           }
         });
       } else {
@@ -625,11 +639,21 @@ const MeetingMinutesPage: React.FC = () => {
     }
 
     if (hasTranscriptText && !minutesLoading) {
-      generateMinutes(currentTranscriptText, modelId, (status) => {
+      // Reset continuation info at the start
+      setContinuationInfo(null);
+
+      generateMinutes(currentTranscriptText, modelId, (status, data) => {
         if (status === 'success') {
+          setContinuationInfo(null);
           toast.success(t('meetingMinutes.generation_success'));
         } else if (status === 'error') {
+          setContinuationInfo(null);
           toast.error(t('meetingMinutes.generation_error'));
+        } else if (status === 'continuing') {
+          setContinuationInfo({
+            attempt: data?.continuationAttempt || 0,
+            maxAttempts: data?.maxContinuationAttempts || 5,
+          });
         }
       });
     }
@@ -1085,7 +1109,12 @@ const MeetingMinutesPage: React.FC = () => {
                 <div className="flex items-center gap-2">
                   <div className="border-aws-sky size-5 animate-spin rounded-full border-4 border-t-transparent"></div>
                   <span className="text-sm text-gray-600">
-                    {t('meetingMinutes.generating')}
+                    {continuationInfo
+                      ? t('meetingMinutes.generating_continuation', {
+                          current: continuationInfo.attempt,
+                          max: continuationInfo.maxAttempts,
+                        })
+                      : t('meetingMinutes.generating')}
                   </span>
                 </div>
               )}

--- a/packages/web/src/pages/MeetingMinutesPage.tsx
+++ b/packages/web/src/pages/MeetingMinutesPage.tsx
@@ -305,6 +305,37 @@ const MeetingMinutesPage: React.FC = () => {
     setLastGeneratedTime
   );
 
+  // Common callback handler for generation status updates
+  const handleGenerationStatus = useCallback(
+    (
+      status: 'generating' | 'continuing' | 'success' | 'error',
+      data?: {
+        message?: string;
+        minutes?: string;
+        continuationAttempt?: number;
+        maxContinuationAttempts?: number;
+      }
+    ) => {
+      switch (status) {
+        case 'success':
+          setContinuationInfo(null);
+          toast.success(t('meetingMinutes.generation_success'));
+          break;
+        case 'error':
+          setContinuationInfo(null);
+          toast.error(t('meetingMinutes.generation_error'));
+          break;
+        case 'continuing':
+          setContinuationInfo({
+            attempt: data?.continuationAttempt || 0,
+            maxAttempts: data?.maxContinuationAttempts || 5,
+          });
+          break;
+      }
+    },
+    [t]
+  );
+
   const speakerMapping = useMemo(() => {
     return Object.fromEntries(
       speakers.split(',').map((speaker, idx) => [`spk_${idx}`, speaker.trim()])
@@ -470,20 +501,7 @@ const MeetingMinutesPage: React.FC = () => {
       if (realtimeText !== lastProcessedTranscript && !minutesLoading) {
         shouldGenerateRef.current = false; // Reset the flag
         setContinuationInfo(null);
-        generateMinutes(realtimeText, modelId, (status, data) => {
-          if (status === 'success') {
-            setContinuationInfo(null);
-            toast.success(t('meetingMinutes.generation_success'));
-          } else if (status === 'error') {
-            setContinuationInfo(null);
-            toast.error(t('meetingMinutes.generation_error'));
-          } else if (status === 'continuing') {
-            setContinuationInfo({
-              attempt: data?.continuationAttempt || 0,
-              maxAttempts: data?.maxContinuationAttempts || 5,
-            });
-          }
-        });
+        generateMinutes(realtimeText, modelId, handleGenerationStatus);
       } else {
         shouldGenerateRef.current = false; // Reset even if we don't generate
       }
@@ -496,7 +514,7 @@ const MeetingMinutesPage: React.FC = () => {
     minutesLoading,
     generateMinutes,
     modelId,
-    t,
+    handleGenerationStatus,
   ]);
 
   // Auto-generation countdown setup
@@ -612,6 +630,8 @@ const MeetingMinutesPage: React.FC = () => {
       startMicTranscription(langCode, speakerLabel);
     } catch (error) {
       console.error('Failed to start synchronized recording:', error);
+      // Notify user about the fallback
+      toast.warning(t('transcribe.screen_audio_failed_fallback_mic'));
       // Fallback to microphone only if screen preparation fails
       startMicTranscription(langCode, speakerLabel);
     }
@@ -625,6 +645,7 @@ const MeetingMinutesPage: React.FC = () => {
     startTranscriptionWithStream,
     clearMicTranscripts,
     clearScreenTranscripts,
+    t,
   ]);
 
   // Manual generation handler
@@ -641,21 +662,7 @@ const MeetingMinutesPage: React.FC = () => {
     if (hasTranscriptText && !minutesLoading) {
       // Reset continuation info at the start
       setContinuationInfo(null);
-
-      generateMinutes(currentTranscriptText, modelId, (status, data) => {
-        if (status === 'success') {
-          setContinuationInfo(null);
-          toast.success(t('meetingMinutes.generation_success'));
-        } else if (status === 'error') {
-          setContinuationInfo(null);
-          toast.error(t('meetingMinutes.generation_error'));
-        } else if (status === 'continuing') {
-          setContinuationInfo({
-            attempt: data?.continuationAttempt || 0,
-            maxAttempts: data?.maxContinuationAttempts || 5,
-          });
-        }
-      });
+      generateMinutes(currentTranscriptText, modelId, handleGenerationStatus);
     }
   }, [
     hasTranscriptText,
@@ -663,9 +670,10 @@ const MeetingMinutesPage: React.FC = () => {
     minutesLoading,
     modelId,
     generateMinutes,
-    t,
+    handleGenerationStatus,
     minutesStyle,
     customPrompt,
+    t,
   ]);
 
   // Clear minutes only handler

--- a/packages/web/src/pages/MeetingMinutesPage.tsx
+++ b/packages/web/src/pages/MeetingMinutesPage.tsx
@@ -962,8 +962,7 @@ const MeetingMinutesPage: React.FC = () => {
                     {autoGenerate && countdownSeconds > 0 && (
                       <div className="text-sm text-gray-600">
                         {t('meetingMinutes.next_generation_in')}
-                        {Math.floor(countdownSeconds / 60)}
-                        {t('common.colon')}
+                        {Math.floor(countdownSeconds / 60)}:
                         {(countdownSeconds % 60).toString().padStart(2, '0')}
                       </div>
                     )}

--- a/packages/web/src/pages/MeetingMinutesPage.tsx
+++ b/packages/web/src/pages/MeetingMinutesPage.tsx
@@ -317,12 +317,24 @@ const MeetingMinutesPage: React.FC = () => {
       }
     ) => {
       switch (status) {
+        case 'generating':
+          // Generation started - UI already shows loading state via minutesLoading
+          break;
         case 'success':
           setContinuationInfo(null);
-          toast.success(t('meetingMinutes.generation_success'));
+          // Show warning if output may be incomplete (max continuation attempts reached)
+          if (data?.message) {
+            toast.warning(data.message);
+          } else {
+            toast.success(t('meetingMinutes.generation_success'));
+          }
           break;
         case 'error':
           setContinuationInfo(null);
+          // Show detailed error message if available for debugging
+          if (data?.message) {
+            console.error('Generation error details:', data.message);
+          }
           toast.error(t('meetingMinutes.generation_error'));
           break;
         case 'continuing':

--- a/packages/web/src/pages/MeetingMinutesPage.tsx
+++ b/packages/web/src/pages/MeetingMinutesPage.tsx
@@ -324,7 +324,7 @@ const MeetingMinutesPage: React.FC = () => {
           setContinuationInfo(null);
           // Show warning if output may be incomplete (max continuation attempts reached)
           if (data?.message) {
-            toast.warning(data.message);
+            toast.warning(t('meetingMinutes.output_may_be_incomplete'));
           } else {
             toast.success(t('meetingMinutes.generation_success'));
           }


### PR DESCRIPTION
## Summary

長い文字起こしテキスト（27KB以上）を処理する際、LLMのmaxTokens制限に達して出力が途中で切れる問題を修正しました。

### 主な変更点

#### 🔄 継続生成機能の追加
- `stopReason='max_tokens'` を検出し、自動で継続生成を行うロジックを追加（最大5回）
- 継続生成中の進捗状況をUIに表示（「議事録生成中（継続 1/5 回目）...」）
- 最大継続回数に達した場合、出力が不完全な可能性があることをユーザーに警告

#### 🛡️ エラーハンドリングの改善
- ストリーム処理における連続パースエラーの検出と適切なエラーハンドリング
- JSONパースエラー時のログ出力で機密情報の露出を防止（チャンクプレビューのみ出力）
- APIエラーレスポンスの適切な検出と再スロー
- 空のストリームレスポンスの検出とエラー通知

#### 🔔 ユーザー通知の改善
- スクリーン音声取得失敗時のフォールバック通知を追加
- 生成成功/エラー/警告の適切なtoast通知

#### 🐛 バグ修正
- 自動生成タイマーで「4common.colon54」のように表示される翻訳エラーを修正

### 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `useMeetingMinutes.ts` | 継続生成ロジック、ストリーム処理改善 |
| `MeetingMinutesPage.tsx` | 継続状態のUI表示、コールバック処理統合 |
| `translation/*.yaml` | 新しい翻訳キー追加（5言語） |

## Test plan

### 継続生成機能
- [ ] 27KB以上の長文テキストをアップロードまたは直接入力
- [ ] 「文字起こし」スタイルを選択して議事録生成を実行
- [ ] 出力が途切れず最後まで生成されることを確認
- [ ] 継続生成の進捗表示（「継続 X/5 回目」）が正しく表示されることを確認

### エラーハンドリング
- [ ] ネットワークエラー発生時にエラーtoastが表示されることを確認
- [ ] 生成成功時に成功toastが表示されることを確認

### タイマー表示
- [ ] 自動生成をONにしてタイマー表示が「4:54」のように正しく表示されることを確認

### スクリーン録音
- [ ] スクリーン音声取得失敗時に警告toastが表示され、マイクのみで録音が開始されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)