### PR TITLE
:bug: fix(summary): シングルアカウントデプロイでの生成サマリー機能の修正

### DIFF
--- a/packages/cdk/lambda/utils/tenantDynamoDBClient.ts
+++ b/packages/cdk/lambda/utils/tenantDynamoDBClient.ts
@@ -63,21 +63,39 @@ export async function createTenantDynamoDBClient(
 export async function createTenantDynamoDBClientForBackgroundJob(
   tenantId: string
 ): Promise<DynamoDBClient> {
-  // Use default credentials for default tenant
+  // Use default credentials for default tenant (single account deployment)
   if (isDefaultTenant(tenantId)) {
+    console.log(
+      `Using local credentials for default tenant: ${tenantId}`
+    );
     return new DynamoDBClient({ region: process.env.AWS_REGION! });
   }
 
   // Get tenant info to get role ARN and region
   const tenant = await getTenant(tenantId);
   if (!tenant) {
-    throw new Error(`Tenant ${tenantId} not found`);
+    // For single account deployment, tenant might not be in the table
+    // Check if this looks like the default tenant (shouldn't reach here due to isDefaultTenant check above)
+    console.warn(
+      `Tenant ${tenantId} not found in Tenants table. ` +
+        `For single account deployment, ensure DEFAULT_TENANT_ID env var is set correctly.`
+    );
+    throw new Error(
+      `Tenant ${tenantId} not found in Tenants table. ` +
+        `For single account deployment, use the default tenant ID.`
+    );
   }
   if (!tenant.roleArn) {
-    throw new Error(`Tenant ${tenantId} missing roleArn`);
+    throw new Error(
+      `Tenant ${tenantId} is missing roleArn configuration. ` +
+        `Cross-account tenant access requires roleArn to be set in the Tenants table.`
+    );
   }
   if (!tenant.region) {
-    throw new Error(`Tenant ${tenantId} missing region`);
+    throw new Error(
+      `Tenant ${tenantId} is missing region configuration. ` +
+        `Cross-account tenant access requires region to be set in the Tenants table.`
+    );
   }
 
   console.log(`Assuming role for tenant ${tenantId}: ${tenant.roleArn}`);

--- a/packages/cdk/lambda/utils/tenantS3Utils.ts
+++ b/packages/cdk/lambda/utils/tenantS3Utils.ts
@@ -2,14 +2,16 @@ import * as crypto from 'crypto';
 
 // Constants at file level
 const ENVIRONMENT = process.env.ENVIRONMENT!;
-const DEFAULT_TENANT_ID = process.env.DEFAULT_TENANT_ID!;
+const DEFAULT_TENANT_ID = process.env.DEFAULT_TENANT_ID || 'default';
 const AWS_REGION = process.env.AWS_REGION!;
 
 /**
  * Check if the tenant is the default tenant
+ * Handles both configured DEFAULT_TENANT_ID and hardcoded 'default' string
+ * for single account deployments where Tenants table may not be configured
  */
 export function isDefaultTenant(tenantId: string): boolean {
-  return tenantId === DEFAULT_TENANT_ID;
+  return tenantId === DEFAULT_TENANT_ID || tenantId === 'default';
 }
 
 /**


### PR DESCRIPTION
## 問題点

シングルアカウントデプロイにおいて、生成サマリー機能が失敗していました。

### エラー内容
- AssumeRole エラーが発生
- `isDefaultTenant()` 関数が DEFAULT_TENANT_ID 環境変数が未設定の場合に正しく動作していませんでした

## 根本原因

`tenantS3Utils.ts` の `isDefaultTenant()` 関数が、`DEFAULT_TENANT_ID` 環境変数のみをチェックしていました。
シングルアカウントデプロイでは、この環境変数が未設定であるため、デフォルトテナントとして正しく判別されていませんでした。

## 解決策

### 1. tenantS3Utils.ts の改善
```typescript
export function isDefaultTenant(tenantId: string): boolean {
  return tenantId === DEFAULT_TENANT_ID || tenantId === 'default';
}
```

`DEFAULT_TENANT_ID` 環境変数のチェックに加えて、'default' 文字列との直接比較を追加しました。
これにより、シングルアカウントデプロイでテナントテーブルが未設定の場合でも、デフォルトテナントとして正しく認識されます。

### 2. tenantDynamoDBClient.ts の強化
- エラーハンドリングと警告ログを改善
- `createTenantDynamoDBClientForBackgroundJob()` での default tenant 判定をより堅牢に
- 詳細なエラーメッセージでシングルアカウントデプロイのトラブルシューティングを支援

## テスト
- シングルアカウントデプロイでのサマリー生成が正常に機能することを確認してください
- 既存のマルチテナントデプロイメントが影響を受けないことを確認してください

## 関連ファイル
- `packages/cdk/lambda/utils/tenantS3Utils.ts`
- `packages/cdk/lambda/utils/tenantDynamoDBClient.ts`