### PR TITLE
🔧 ESLintのYAMLファイル除外設定を修正

### DIFF
--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -5,7 +5,7 @@ const { yamlConfig, commonIgnores } = require('eslint-config-shared');
 module.exports = defineConfig([
   {
     ...yamlConfig,
-    files: ['.github/**/*.{yaml,yml}', 'mkdocs.yml'],
+    ignores: ['.github/**/*.{yaml,yml}', 'mkdocs.yml'],
   },
   {
     ignores: [...commonIgnores.ignores, 'packages/**'],

--- a/packages/eslint-config-shared/yaml.cjs
+++ b/packages/eslint-config-shared/yaml.cjs
@@ -16,11 +16,6 @@ const yamlConfig = {
   },
 };
 
-const yamlIgnores = {
-  ignores: ['mkdocs.yml'],
-};
-
 module.exports = {
   yamlConfig,
-  yamlIgnores,
 };


### PR DESCRIPTION
## Summary
- ESLint設定で特定のYAMLファイル（`.github/**/*.yml`、`mkdocs.yml`）を正しく除外するよう修正
- `files`プロパティを`ignores`プロパティに変更して、対象ファイルをlint対象から除外
- 不要になった`yamlIgnores`の定義を削除

## Changes
- `eslint.config.cjs`: `files`を`ignores`に変更して正しく除外されるように
- `packages/eslint-config-shared/yaml.cjs`: 未使用の`yamlIgnores`を削除

## Test plan
- [ ] `npm run lint`が正常に動作することを確認
- [ ] `.github/`配下のYAMLファイルがlint対象から除外されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)