### PR TITLE
:sparkles: feat(predict): add server-side system prompt builder from SSM

### DIFF
--- a/packages/cdk/lambda/predictStream.ts
+++ b/packages/cdk/lambda/predictStream.ts
@@ -1,7 +1,15 @@
-import { Handler, Context } from 'aws-lambda';
-import { PredictRequest } from 'generative-ai-use-cases';
+import { Handler, Context, APIGatewayProxyEvent } from 'aws-lambda';
+import { PredictRequest, UnrecordedMessage } from 'generative-ai-use-cases';
 import api from './utils/api';
 import { defaultModel } from './utils/models';
+import {
+  checkAccessWithQuota,
+  incrementUsage,
+  getLatestUsage,
+  AccessCheckResult,
+} from './utils/accessChecker';
+import { buildSummaryContext } from './utils/summaryContext';
+import { buildSystemPrompt } from './utils/systemPromptBuilder';
 
 declare global {
   namespace awslambda {
@@ -15,18 +23,284 @@ declare global {
   }
 }
 
+/**
+ * メッセージ配列から画像ファイルの数をカウントする
+ * @param messages メッセージ配列
+ * @returns 画像ファイルの数
+ */
+function countImages(messages: UnrecordedMessage[]): number {
+  return messages
+    .flatMap((m) => m.extraData ?? [])
+    .filter((e) => e.type === 'image').length;
+}
+
 export const handler = awslambda.streamifyResponse(
   async (event, responseStream, context) => {
     context.callbackWaitsForEmptyEventLoop = false;
-    const model = event.model || defaultModel;
-    for await (const token of api[model.type].invokeStream?.(
-      model,
-      event.messages,
-      event.id,
-      event.idToken
-    ) ?? []) {
-      responseStream.write(token);
+
+    let accessCheckResult: AccessCheckResult | null = null;
+    let mediaCheckResult: AccessCheckResult | null = null;
+
+    try {
+      const model = event.model || defaultModel;
+
+      // Authorization check: Verify ID token and check LLM access with quota
+      if (!event.idToken) {
+        const errorMessage = JSON.stringify({
+          text: 'ID token is required for authorization',
+          stopReason: 'error',
+        });
+        responseStream.write(errorMessage);
+        responseStream.end();
+        return;
+      }
+
+      // Check permission and quota using accessChecker
+      accessCheckResult = await checkAccessWithQuota(
+        event.idToken,
+        'llm',
+        model.modelId
+      );
+
+      if (!accessCheckResult.allowed) {
+        const userId = accessCheckResult.userContext?.userId || 'unknown';
+        let errorText: string;
+
+        switch (accessCheckResult.reason) {
+          case 'quota_exceeded':
+            console.warn(
+              `User ${userId} has exceeded quota for model ${model.modelId}`
+            );
+            errorText = `利用回数の上限に達しました: ${model.modelId}`;
+            break;
+          case 'no_permission':
+            console.warn(
+              `User ${userId} does not have access to model ${model.modelId}`
+            );
+            errorText = `このモデルを使用する権限がありません: ${model.modelId}`;
+            break;
+          case 'invalid_token':
+            errorText = 'Invalid or expired ID token';
+            break;
+          default:
+            errorText = `You do not have permission to use the model: ${model.modelId}`;
+        }
+
+        const errorMessage = JSON.stringify({
+          text: errorText,
+          stopReason: 'error',
+          errorReason: accessCheckResult.reason,
+        });
+        responseStream.write(errorMessage);
+        responseStream.end();
+        return;
+      }
+
+      // Count images in the current user message only (last message)
+      // 過去のメッセージに含まれる画像は既にカウント済みなので、今回送信されたメッセージのみをカウント対象とする
+      const lastMessage = event.messages[event.messages.length - 1];
+      const imageCount = lastMessage ? countImages([lastMessage]) : 0;
+
+      // Check image input limit if there are images
+      if (imageCount > 0) {
+        mediaCheckResult = await checkAccessWithQuota(
+          event.idToken,
+          'prompt-media',
+          'image',
+          imageCount
+        );
+
+        if (!mediaCheckResult.allowed) {
+          const userId = mediaCheckResult.userContext?.userId || 'unknown';
+          console.warn(
+            `User ${userId} has exceeded image input limit - requested: ${imageCount}`
+          );
+
+          const errorMessage = JSON.stringify({
+            text: `画像入力の利用回数上限に達しました（リクエスト: ${imageCount}枚）`,
+            stopReason: 'error',
+            errorReason: 'media_limit_exceeded',
+          });
+          responseStream.write(errorMessage);
+          responseStream.end();
+          return;
+        }
+      }
+
+      // Inject summary context if idToken is available
+      let messages = event.messages;
+      try {
+        // Extract userId and tenantId from idToken
+        const tokenPayload = JSON.parse(
+          Buffer.from(event.idToken.split('.')[1], 'base64').toString()
+        );
+        const userId = tokenPayload['cognito:username'];
+        const tenantId =
+          tokenPayload['custom:tenant_id'] ||
+          tokenPayload['custom:tenantId'] ||
+          '';
+
+        // Create request context for repository functions
+        const requestContext = {
+          body: null,
+          headers: {
+            Authorization: event.idToken,
+          },
+          multiValueHeaders: {},
+          httpMethod: 'POST',
+          isBase64Encoded: false,
+          path: '',
+          pathParameters: null,
+          queryStringParameters: null,
+          multiValueQueryStringParameters: null,
+          stageVariables: null,
+          resource: '',
+          requestContext: {
+            accountId: '',
+            apiId: '',
+            authorizer: {
+              claims: {
+                'cognito:username': userId,
+                'custom:tenant_id': tenantId,
+              },
+            },
+            protocol: 'HTTP/1.1',
+            httpMethod: 'POST',
+            identity: {
+              accessKey: null,
+              accountId: null,
+              apiKey: null,
+              apiKeyId: null,
+              caller: null,
+              clientCert: null,
+              cognitoAuthenticationProvider: null,
+              cognitoAuthenticationType: null,
+              cognitoIdentityId: null,
+              cognitoIdentityPoolId: null,
+              principalOrgId: null,
+              sourceIp: '',
+              user: null,
+              userAgent: null,
+              userArn: null,
+            },
+            path: '',
+            stage: '',
+            requestId: '',
+            requestTimeEpoch: 0,
+            resourceId: '',
+            resourcePath: '',
+          },
+        } satisfies APIGatewayProxyEvent;
+
+        // Build summary context
+        const summaryContext = await buildSummaryContext(userId, requestContext);
+
+        // Build system prompt from params if provided (hides prompt from frontend)
+        if (event.systemContextParams) {
+          const systemPrompt = await buildSystemPrompt(event.systemContextParams);
+          const systemContent = summaryContext
+            ? `${systemPrompt}\n\n${summaryContext}`
+            : systemPrompt;
+
+          messages = [
+            { role: 'system' as const, content: systemContent },
+            ...event.messages.filter((m) => m.role !== 'system'),
+          ];
+        } else if (summaryContext) {
+          // Backward compatibility: inject summary context into existing system message
+          messages = event.messages.map((msg) => {
+            if (msg.role === 'system') {
+              return {
+                ...msg,
+                content: `${msg.content}\n\n${summaryContext}`,
+              };
+            }
+            return msg;
+          });
+        }
+      } catch (error) {
+        // Continue without summary context if injection fails
+        console.error('Failed to inject summary context:', error);
+      }
+
+      // If authorized, proceed with streaming
+      for await (const token of api[model.type].invokeStream?.(
+        model,
+        messages,
+        event.id,
+        event.idToken
+      ) ?? []) {
+        responseStream.write(token);
+      }
+
+      // Increment usage count after successful streaming and return latest usage info
+      if (
+        accessCheckResult.limitType &&
+        accessCheckResult.limitType !== 'unlimited'
+      ) {
+        try {
+          await incrementUsage(
+            event.idToken,
+            'llm',
+            model.modelId,
+            accessCheckResult.limitType
+          );
+
+          // Get latest usage info after incrementing
+          const latestUsage = await getLatestUsage(
+            event.idToken,
+            'llm',
+            model.modelId
+          );
+
+          // Send final chunk with updated usage info
+          if (latestUsage) {
+            responseStream.write(
+              JSON.stringify({
+                text: '',
+                usage: latestUsage,
+              })
+            );
+          }
+        } catch (error) {
+          console.error('Failed to increment usage count:', error);
+        }
+      }
+
+      // Increment image usage count after successful streaming
+      if (
+        mediaCheckResult &&
+        mediaCheckResult.limitType &&
+        mediaCheckResult.limitType !== 'unlimited'
+      ) {
+        // チェック時と同じく、最後のメッセージのみを対象とする
+        const lastMsg = event.messages[event.messages.length - 1];
+        const imgCount = lastMsg ? countImages([lastMsg]) : 0;
+        try {
+          await incrementUsage(
+            event.idToken,
+            'prompt-media',
+            'image',
+            mediaCheckResult.limitType,
+            imgCount
+          );
+          console.log(
+            `[PredictStream] Image usage incremented - count: ${imgCount}`
+          );
+        } catch (error) {
+          console.error('Failed to increment image usage count:', error);
+        }
+      }
+
+      responseStream.end();
+    } catch (error) {
+      console.error('PredictStream error:', error);
+      const errorMessage = JSON.stringify({
+        text: 'Internal Server Error',
+        stopReason: 'error',
+      });
+      responseStream.write(errorMessage);
+      responseStream.end();
     }
-    responseStream.end();
   }
 );

--- a/packages/cdk/lambda/sendgridCustomEmailSender.ts
+++ b/packages/cdk/lambda/sendgridCustomEmailSender.ts
@@ -115,10 +115,11 @@ const createCredentialsBlock = (
 // Sign up confirmation email
 const createSignUpEmail = (
   code: string
-): { subject: string; htmlContent: string } => {
+): { subject: string; htmlContent: string; textContent: string } => {
   const bodyContent = `
-    <h2 style="margin: 0 0 16px 0; color: ${COLORS.primary}; font-size: 20px;">メールアドレスの確認</h2>
+    <h2 style="margin: 0 0 16px 0; color: ${COLORS.primary}; font-size: 20px;">確認コードのご案内</h2>
     <p style="margin: 0 0 16px 0; color: ${COLORS.text}; font-size: 15px; line-height: 1.6;">
+      このメールは、${SERVICE_NAME}に新規登録された方のみにお送りしています。<br><br>
       ${SERVICE_NAME}へのご登録ありがとうございます。<br>
       アカウントを有効にするため、以下の確認コードを入力してください。
     </p>
@@ -129,16 +130,31 @@ const createSignUpEmail = (
     </p>
   `;
 
+  const textContent = `${SERVICE_NAME}
+
+確認コードのご案内
+
+このメールは、${SERVICE_NAME}に新規登録された方のみにお送りしています。
+
+${SERVICE_NAME}へのご登録ありがとうございます。
+アカウントを有効にするため、以下の確認コードを入力してください。
+
+確認コード: ${code}
+
+このコードは24時間有効です。
+心当たりがない場合は、このメールを無視してください。`;
+
   return {
-    subject: `【${SERVICE_NAME}】メールアドレスの確認`,
-    htmlContent: createEmailHtml('メールアドレスの確認', bodyContent),
+    subject: `【${SERVICE_NAME}】ご登録ありがとうございます｜確認コードのご案内`,
+    htmlContent: createEmailHtml('確認コードのご案内', bodyContent),
+    textContent,
   };
 };
 
 // Password reset email
 const createForgotPasswordEmail = (
   code: string
-): { subject: string; htmlContent: string } => {
+): { subject: string; htmlContent: string; textContent: string } => {
   const bodyContent = `
     <h2 style="margin: 0 0 16px 0; color: ${COLORS.primary}; font-size: 20px;">パスワードリセット</h2>
     <p style="margin: 0 0 16px 0; color: ${COLORS.text}; font-size: 15px; line-height: 1.6;">
@@ -152,9 +168,22 @@ const createForgotPasswordEmail = (
     </p>
   `;
 
+  const textContent = `${SERVICE_NAME}
+
+パスワードリセット
+
+パスワードリセットのリクエストを受け付けました。
+以下の確認コードを入力して、新しいパスワードを設定してください。
+
+確認コード: ${code}
+
+このコードは1時間有効です。
+このリクエストに心当たりがない場合は、このメールを無視してください。アカウントのパスワードは変更されません。`;
+
   return {
     subject: `【${SERVICE_NAME}】パスワードリセット`,
     htmlContent: createEmailHtml('パスワードリセット', bodyContent),
+    textContent,
   };
 };
 
@@ -162,7 +191,7 @@ const createForgotPasswordEmail = (
 const createAdminCreateUserEmail = (
   username: string,
   tempPassword: string
-): { subject: string; htmlContent: string } => {
+): { subject: string; htmlContent: string; textContent: string } => {
   const bodyContent = `
     <h2 style="margin: 0 0 16px 0; color: ${COLORS.primary}; font-size: 20px;">アカウント招待</h2>
     <p style="margin: 0 0 16px 0; color: ${COLORS.text}; font-size: 15px; line-height: 1.6;">
@@ -179,9 +208,26 @@ const createAdminCreateUserEmail = (
   const footerNote =
     'このメールは管理者によって送信されました。心当たりがない場合は、システム管理者にお問い合わせください。';
 
+  const textContent = `${SERVICE_NAME}
+
+アカウント招待
+
+${SERVICE_NAME}へ招待されました。
+以下の情報を使用してログインしてください。
+
+ユーザー名（メールアドレス）: ${username}
+仮パスワード: ${tempPassword}
+
+初回ログイン時にパスワードの変更が求められます。
+セキュリティのため、仮パスワードは安全に管理し、ログイン後すぐに変更してください。
+
+---
+このメールは管理者によって送信されました。心当たりがない場合は、システム管理者にお問い合わせください。`;
+
   return {
     subject: `【${SERVICE_NAME}】アカウント招待`,
     htmlContent: createEmailHtml('アカウント招待', bodyContent, footerNote),
+    textContent,
   };
 };
 
@@ -198,13 +244,18 @@ const decryptCode = async (encryptedCode: string): Promise<string> => {
 const sendEmail = async (
   to: string,
   subject: string,
-  htmlContent: string
+  htmlContent: string,
+  textContent: string
 ): Promise<void> => {
+  // SendGrid requires text/plain before text/html for proper multipart email
   const payload = {
     personalizations: [{ to: [{ email: to }] }],
     from: { email: SENDGRID_FROM_EMAIL },
     subject: subject,
-    content: [{ type: 'text/html', value: htmlContent }],
+    content: [
+      { type: 'text/plain', value: textContent },
+      { type: 'text/html', value: htmlContent },
+    ],
   };
 
   const response = await fetch(SENDGRID_API_URL, {
@@ -243,7 +294,11 @@ export const handler: CustomEmailSenderTriggerHandler = async (
 
   const decryptedCode = await decryptCode(encryptedCode);
 
-  let emailContent: { subject: string; htmlContent: string } | null = null;
+  let emailContent: {
+    subject: string;
+    htmlContent: string;
+    textContent: string;
+  } | null = null;
   // Type guard: userAttributes is a StringMap (Record<string, string>) for most trigger sources
   const userAttributes = request.userAttributes as
     | Record<string, string>
@@ -273,7 +328,8 @@ export const handler: CustomEmailSenderTriggerHandler = async (
     await sendEmail(
       recipientEmail,
       emailContent.subject,
-      emailContent.htmlContent
+      emailContent.htmlContent,
+      emailContent.textContent
     );
   }
 

--- a/packages/cdk/lambda/utils/summaryContext.ts
+++ b/packages/cdk/lambda/utils/summaryContext.ts
@@ -1,0 +1,141 @@
+import { APIGatewayProxyEvent } from 'aws-lambda';
+import { DailySummary, UserSummary } from 'generative-ai-use-cases';
+import {
+  getLatestDailySummary,
+  getUserSummary,
+} from '../repository/userSummary';
+
+// Check if summary feature is enabled (set at deployment time)
+const SUMMARY_JOB_ENABLED = process.env.SUMMARY_JOB_ENABLED === 'true';
+
+/**
+ * Build summary context XML to inject into system prompts
+ * Returns empty string if summary feature is disabled for this environment
+ * @param userId User ID (without 'user#' prefix)
+ * @param event API Gateway event for tenant context
+ * @returns XML-formatted summary context string, or empty string if no summaries or feature disabled
+ */
+export async function buildSummaryContext(
+  userId: string,
+  event: APIGatewayProxyEvent
+): Promise<string> {
+  // Skip if summary feature is not enabled for this environment
+  if (!SUMMARY_JOB_ENABLED) {
+    console.log('Summary feature is disabled (SUMMARY_JOB_ENABLED != true)');
+    return '';
+  }
+
+  console.log(`Building summary context for user: ${userId}`);
+
+  try {
+    // Fetch both summaries in parallel
+    const [dailySummary, userSummary] = await Promise.all([
+      getLatestDailySummary(userId, event).catch((err) => {
+        console.error('Failed to get latest daily summary:', err);
+        return null;
+      }),
+      getUserSummary(userId, event).catch((err) => {
+        console.error('Failed to get user summary:', err);
+        return null;
+      }),
+    ]);
+
+    console.log(
+      `Summary fetch results - daily: ${!!dailySummary}, user: ${!!userSummary}`
+    );
+
+    if (!dailySummary && !userSummary) {
+      console.log('No summaries found for user');
+      return '';
+    }
+
+    const context = formatSummaryContext(dailySummary, userSummary);
+    console.log(`Summary context built, length: ${context.length}`);
+    return context;
+  } catch (error) {
+    console.error('Failed to build summary context:', error);
+    return '';
+  }
+}
+
+/**
+ * Format summary context as XML for system prompt injection
+ * @param dailySummary Latest daily summary (optional)
+ * @param userSummary User's aggregated summary (optional)
+ * @returns Formatted XML context string
+ */
+export function formatSummaryContext(
+  dailySummary: DailySummary | null,
+  userSummary: UserSummary | null
+): string {
+  if (!dailySummary && !userSummary) {
+    return '';
+  }
+
+  let context = '<user_conversation_context>\n';
+
+  if (dailySummary) {
+    context += '  <recent_session_summary>\n';
+    context += `  ${dailySummary.summary}\n`;
+    context += '  </recent_session_summary>\n';
+  }
+
+  if (userSummary) {
+    context += '  <user_coaching_profile>\n';
+    context += `  ${userSummary.summary}\n`;
+    context += '  </user_coaching_profile>\n';
+  }
+
+  context += '</user_conversation_context>';
+
+  return context;
+}
+
+/**
+ * Build complete system message with summary context injected
+ * @param baseInstruction The base assistant/system instruction
+ * @param summaryContext Summary context XML (from buildSummaryContext)
+ * @param ragContext RAG context (optional)
+ * @param customInstructions User's custom instructions (optional)
+ * @returns Complete system message with all context
+ */
+export function buildSystemMessageWithSummary(
+  baseInstruction: string,
+  summaryContext: string,
+  ragContext?: string | null,
+  customInstructions?: string | null
+): string {
+  let message = `<instructions>\n${baseInstruction}\n</instructions>`;
+
+  if (summaryContext) {
+    message += `\n\n${summaryContext}`;
+  }
+
+  if (ragContext) {
+    message += `\n\nRelevant context from documents:\n${ragContext}`;
+  }
+
+  if (customInstructions?.trim()) {
+    message += `\n<user_custom_instructions>\n${customInstructions}\n</user_custom_instructions>`;
+  }
+
+  return message;
+}
+
+/**
+ * Extract user ID from different formats
+ * @param userId User ID potentially with 'user#' prefix
+ * @returns Clean user ID without prefix
+ */
+export function extractUserId(userId: string): string {
+  return userId.startsWith('user#') ? userId.substring(5) : userId;
+}
+
+/**
+ * Build user ID with prefix
+ * @param userId Clean user ID
+ * @returns User ID with 'user#' prefix
+ */
+export function buildUserIdWithPrefix(userId: string): string {
+  return userId.startsWith('user#') ? userId : `user#${userId}`;
+}

--- a/packages/cdk/lambda/utils/systemPromptBuilder.ts
+++ b/packages/cdk/lambda/utils/systemPromptBuilder.ts
@@ -1,0 +1,57 @@
+import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
+import { SystemContextParams } from 'generative-ai-use-cases';
+
+const ssm = new SSMClient({});
+const promptCache: Map<string, string> = new Map();
+
+// SSM path prefix - configurable via environment variable
+const SSM_PREFIX = process.env.SYSTEM_PROMPT_SSM_PREFIX || '/prompts/system';
+
+async function getFromSSM(key: string): Promise<string> {
+  const path = `${SSM_PREFIX}/${key}`;
+  if (promptCache.has(path)) {
+    return promptCache.get(path)!;
+  }
+
+  try {
+    const result = await ssm.send(
+      new GetParameterCommand({
+        Name: path,
+        WithDecryption: false,
+      })
+    );
+    const value = result.Parameter?.Value || '';
+    promptCache.set(path, value);
+    return value;
+  } catch (error) {
+    console.error(`Failed to get SSM parameter ${path}:`, error);
+    return '';
+  }
+}
+
+export async function buildSystemPrompt(
+  params: SystemContextParams
+): Promise<string> {
+  // Get base prompt template from SSM
+  const basePrompt = await getFromSSM('base');
+
+  // Get variant-specific prompt if specified
+  const variantPrompt = params.promptVariant
+    ? await getFromSSM(`variants/${params.promptVariant}`)
+    : '';
+
+  // Build final prompt with user context
+  return `${basePrompt}
+
+${variantPrompt}
+
+<user_context>
+<interests>
+${params.interests || ''}
+</interests>
+
+<goals>
+${params.goals || ''}
+</goals>
+</user_context>`;
+}

--- a/packages/types/src/protocol.d.ts
+++ b/packages/types/src/protocol.d.ts
@@ -73,11 +73,18 @@ export type UpdateTitleResponse = {
   chat: Chat;
 };
 
+export type SystemContextParams = {
+  promptVariant?: string;
+  interests?: string;
+  goals?: string;
+};
+
 export type PredictRequest = {
   model?: Model;
   idToken?: string;
   messages: UnrecordedMessage[];
   id: string;
+  systemContextParams?: SystemContextParams;
 };
 
 export type PredictResponse = string;


### PR DESCRIPTION
## Summary

Add server-side system prompt builder functionality that:
- Retrieves prompt templates from AWS SSM Parameter Store
- Supports prompt variants and user context personalization
- Integrates with the prediction stream to inject server-side configured prompts
- Maintains backward compatibility with existing summary context injection

## Changes

- **packages/types/src/protocol.d.ts**: Added SystemContextParams type and systemContextParams field to PredictRequest
- **packages/cdk/lambda/utils/systemPromptBuilder.ts**: New module for building system prompts from SSM with caching
- **packages/cdk/lambda/utils/summaryContext.ts**: New module for building and formatting user summary context
- **packages/cdk/lambda/predictStream.ts**: Enhanced to use buildSystemPrompt and buildSummaryContext with access control

## Test plan

- [ ] Verify SSM parameter retrieval and caching works correctly
- [ ] Test system prompt injection with and without variant
- [ ] Verify summary context is properly formatted
- [ ] Ensure backward compatibility with existing system messages
- [ ] Test error handling for missing SSM parameters