### PR TITLE
🚨 fix(web): ESLint jsx-no-hardcoded-content 警告をすべて解消

### DIFF
--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -1114,6 +1114,7 @@ settings:
   deleteAccountConfirmDescription: This action cannot be undone. Please enter the following to confirm.
   deleteAccountConfirmTitle: Confirm Account Deletion
   deleteAccountDeleteLabel: Type "DELETE" to confirm
+  deleteAccountDeletePlaceholder: DELETE
   deleteAccountDescription: Deleting your account will permanently remove all your data. This action cannot be undone.
   deleteAccountEmailLabel: Enter your email address
 shared:

--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -49,13 +49,13 @@ adminPortal:
     failedToCheckAdminStatus: Failed to verify admin status
     failedToLoadUsers: Failed to load users
     failedToRefreshSession: Failed to refresh authentication session
-    verifyingAdminPrivileges: Verifying admin privileges...
     failedToRemoveUser: Failed to remove user
     failedToUpdateUserRole: Failed to update user role
     loading: Loading...
     noUsersFound: No users found
     refreshingSession: Refreshing session...
     removeUserConfirmation: 'Are you sure you want to remove user {{username}}? This action cannot be undone.'
+    verifyingAdminPrivileges: Verifying admin privileges...
   roles:
     admin: Admin
     regularUser: Regular User
@@ -89,24 +89,24 @@ assistant:
     copy: Copy
     createChatError: Failed to create chat
     failedAlertTitle: Sync Failed
-    model: Model
-    ragEnabled: RAG Enabled
-    sources: Sources
-    view: View
     inputPlaceholder: Type a message...
     instruction: Instruction
+    model: Model
     noMessages: No messages
     partialAlertMessage: '{{count}} knowledge source(s) failed to sync.'
     partialAlertTitle: Partial Sync
     quickStarters: Quick Starters
+    ragEnabled: RAG Enabled
     send: Send
     sendError: Failed to send message
+    sources: Sources
     syncStatus: Sync Status
     syncSucceeded: Knowledge base sync completed successfully!
     syncingAlertMessage: The assistant's knowledge base is currently syncing. You'll be able to chat once it's ready. We're refreshing every 5 seconds.
     syncingAlertTitle: Syncing Knowledge Base
     syncingPlaceholder: Knowledge base is syncing...
     title: Assistant Chat
+    view: View
   confirmDelete: Are you sure you want to delete this assistant?
   createNew: Create New Assistant
   delete: Delete
@@ -229,15 +229,15 @@ auth:
   title: Generative AI Use Cases on AWS
 chat:
   advanced_options: Advanced Options
-  createChatError: Failed to create chat. Please try again.
-  defaultSystemPrompt: You are a helpful and knowledgeable AI assistant. Please provide accurate and easy-to-understand answers to user questions.
   button:
     newChat: New Chat
+  createChatError: Failed to create chat. Please try again.
   create_link: Create Link
   create_link_message: >-
     By creating a link, you will share the conversation history with all users
     who can log in to this application.
   create_system_prompt: Create System Prompt
+  defaultSystemPrompt: You are a helpful and knowledgeable AI assistant. Please provide accurate and easy-to-understand answers to user questions.
   delete_chat_confirmation: Are you sure you want to delete the chat "{{title}}"?
   delete_confirmation: Delete Confirmation
   delete_link: Delete Link
@@ -282,9 +282,9 @@ common:
   clear: Clear
   close: Close
   complete: Complete
-  ellipsis: '...'
   create: Create
   delete: Delete
+  ellipsis: '...'
   enter_text: Enter text
   error: An error occurred
   errorNoSuggestions: No suggestions were found.
@@ -916,7 +916,6 @@ meetingMinutes:
   generating_continuation: Generating minutes (continuation {{current}}/{{max}})...
   generation_error: Failed to generate meeting minutes. Please try again.
   generation_success: Meeting minutes generated successfully
-  output_may_be_incomplete: Output may be incomplete due to length limits. Consider splitting the transcript.
   language: Language
   language_auto: Auto Detect
   language_chinese: Chinese
@@ -929,6 +928,7 @@ meetingMinutes:
   minutes_placeholder: Minutes will appear here after generation
   model: Model
   next_generation_in: 'Next generation in : '
+  output_may_be_incomplete: Output may be incomplete due to length limits. Consider splitting the transcript.
   record_transcribe: Record & Transcribe
   speech_recognition: Speech Recognition
   style: Minutes Style
@@ -986,9 +986,6 @@ optimizePrompt:
 pptx:
   description: Create professional presentations automatically with AI assistance
   download: Download
-  model:
-    help: Select the AI model to generate presentation content
-    label: AI Model
   examples:
     business:
       content: Create a presentation about quarterly business review, including market analysis, financial performance, and strategic initiatives for the next quarter.
@@ -1008,6 +1005,9 @@ pptx:
     help: Describe what you want in your presentation. Be specific about the topic, structure, and any special requirements.
     label: Presentation Instructions
     placeholder: Enter your presentation topic and requirements here...
+  model:
+    help: Select the AI model to generate presentation content
+    label: AI Model
   options:
     summarySlide: Include Summary Slide
     titleSlide: Include Title Slide
@@ -1086,6 +1086,16 @@ rag:
   retrieving: Retrieving reference documents from Kendra...
   title: RAG Chat
 settings:
+  deleteAccount: Delete Account
+  deleteAccountButton: Delete Account
+  deleteAccountCancel: Cancel
+  deleteAccountConfirm: Delete
+  deleteAccountConfirmDescription: This action cannot be undone. Please enter the following to confirm.
+  deleteAccountConfirmTitle: Confirm Account Deletion
+  deleteAccountDeleteLabel: Type "DELETE" to confirm
+  deleteAccountDeletePlaceholder: DELETE
+  deleteAccountDescription: Deleting your account will permanently remove all your data. This action cannot be undone.
+  deleteAccountEmailLabel: Enter your email address
   labels:
     customInstructions: Custom Instructions
     enableCustomize: Enable customization
@@ -1107,16 +1117,6 @@ settings:
     dark: Dark
     light: Light
     system: Follow system settings
-  deleteAccount: Delete Account
-  deleteAccountButton: Delete Account
-  deleteAccountCancel: Cancel
-  deleteAccountConfirm: Delete
-  deleteAccountConfirmDescription: This action cannot be undone. Please enter the following to confirm.
-  deleteAccountConfirmTitle: Confirm Account Deletion
-  deleteAccountDeleteLabel: Type "DELETE" to confirm
-  deleteAccountDeletePlaceholder: DELETE
-  deleteAccountDescription: Deleting your account will permanently remove all your data. This action cannot be undone.
-  deleteAccountEmailLabel: Enter your email address
 shared:
   contact_admin: Please contact the administrator.
   error: Error
@@ -1166,10 +1166,6 @@ transcribe:
   stop_recording: Stop Recording
   supported_files: mp3, mp4, wav, flac, ogg, amr, webm, m4a files are available
   title: Speech Recognition
-userMenu:
-  ariaLabel: User menu
-  logout: Log out
-  settings: Settings
 translate:
   additional_context: Additional context
   additional_context_placeholder: You can enter additional points to consider (e.g., casualness, etc.)
@@ -1488,6 +1484,10 @@ useCaseBuilder:
   updateDescription: Update the use case with the above content.
   updateErrorCondition: 'The following conditions must be met:'
   updating: Updating...
+userMenu:
+  ariaLabel: User menu
+  logout: Log out
+  settings: Settings
 video:
   aspectRatio: Aspect Ratio
   clear: Clear

--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -49,6 +49,7 @@ adminPortal:
     failedToCheckAdminStatus: Failed to verify admin status
     failedToLoadUsers: Failed to load users
     failedToRefreshSession: Failed to refresh authentication session
+    verifyingAdminPrivileges: Verifying admin privileges...
     failedToRemoveUser: Failed to remove user
     failedToUpdateUserRole: Failed to update user role
     loading: Loading...
@@ -88,6 +89,10 @@ assistant:
     copy: Copy
     createChatError: Failed to create chat
     failedAlertTitle: Sync Failed
+    model: Model
+    ragEnabled: RAG Enabled
+    sources: Sources
+    view: View
     inputPlaceholder: Type a message...
     instruction: Instruction
     noMessages: No messages
@@ -135,6 +140,7 @@ assistant:
     sourceUrls: Source URLs
     title: Name
     uploadFiles: Upload Files
+    uploadingFiles: Uploading files...
   editTitle: Edit
   filterAll: All
   filterPrivate: Private
@@ -144,11 +150,13 @@ assistant:
     back: Back
     confirmBulkDelete: 'Are you sure you want to delete {{count}} conversations?'
     confirmDelete: Are you sure you want to delete this conversation?
+    createdWithDate: 'Created: {{date}}'
     daysAgo: '{{days}} days ago'
     deleteSelected: Delete Selected
     deselectAll: Deselect All
     hoursAgo: '{{hours}} hours ago'
     lastMessage: Last message
+    lastMessageWithDate: 'Last message: {{date}}'
     messageCount: 'Messages: {{count}}'
     minutesAgo: '{{minutes}} minutes ago'
     noConversations: No conversations found
@@ -207,8 +215,10 @@ assistant:
     makeItPublic: Make it Public
     private: Private
     privateDescription: Only you can use this assistant
+    privateDescriptionWithParens: (Only you can use this assistant)
     public: Public
     publicDescription: Members of your organization can use this assistant
+    publicDescriptionWithParens: (Members of your organization can use this assistant)
     publicWarning: Making an assistant public will allow all organization members to use it. Make sure the instructions and knowledge base don't contain sensitive information.
     toggleTitle: Change Visibility
     updating: Updating...
@@ -262,12 +272,17 @@ chatList:
   oneDayAgo: 1 day ago
   rename: Rename
   today: Today
+chatSidebar:
+  assistants: Assistants
+  chatHistory: Chat History
+  searchAssistants: Search Assistants
 common:
   ask_gaixr: Ask GaiXer
   cancel: Cancel
   clear: Clear
   close: Close
   complete: Complete
+  ellipsis: '...'
   create: Create
   delete: Delete
   enter_text: Enter text
@@ -296,6 +311,7 @@ common:
   title: Title
   trace: Trace
   try: Try
+  unitMB: MB
   yesterday: Yesterday
 demo:
   inter_use_cases: Use Case Integration
@@ -558,6 +574,7 @@ files:
     mimeMismatch: "{{fileName}} has a file type that doesn't match its extension."
     modelNotSupported: This model does not support files.
     videoCountExceeded: Please limit video files to {{maxCount}} or fewer
+  uploadFiles: Upload Files
 flow:
   title: Flow Chat
 generateImage:
@@ -969,6 +986,9 @@ optimizePrompt:
 pptx:
   description: Create professional presentations automatically with AI assistance
   download: Download
+  model:
+    help: Select the AI model to generate presentation content
+    label: AI Model
   examples:
     business:
       content: Create a presentation about quarterly business review, including market analysis, financial performance, and strategic initiatives for the next quarter.
@@ -993,10 +1013,12 @@ pptx:
     titleSlide: Include Title Slide
   slideCount:
     label: Number of Slides
+    labelWithCount: 'Number of Slides: {{count}}'
   template:
     blank: Blank Template
     blankDescription: Start with a clean, minimal template
     label: Template Selection
+    moreTags: '+{{count}}'
     noTemplates: No custom templates available
     private: Private template
     public: Public template
@@ -1143,6 +1165,10 @@ transcribe:
   stop_recording: Stop Recording
   supported_files: mp3, mp4, wav, flac, ogg, amr, webm, m4a files are available
   title: Speech Recognition
+userMenu:
+  ariaLabel: User menu
+  logout: Log out
+  settings: Settings
 translate:
   additional_context: Additional context
   additional_context_placeholder: You can enter additional points to consider (e.g., casualness, etc.)

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -956,6 +956,7 @@ settings:
   deleteAccountConfirmDescription: この操作は取り消せません。確認のため、以下の情報を入力してください。
   deleteAccountConfirmTitle: アカウント削除の確認
   deleteAccountDeleteLabel: 「DELETE」と入力
+  deleteAccountDeletePlaceholder: DELETE
   deleteAccountDescription: アカウントを削除すると、すべてのデータが失われます。この操作は取り消せません。
   deleteAccountEmailLabel: メールアドレスを入力
 shared:

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -48,7 +48,6 @@ adminPortal:
   messages:
     failedToCheckAdminStatus: 管理者ステータスの確認に失敗しました
     failedToLoadUsers: ユーザーの読み込みに失敗しました
-    verifyingAdminPrivileges: 管理者権限を確認中...
     failedToRefreshSession: 認証セッションの更新に失敗しました
     failedToRemoveUser: ユーザーの削除に失敗しました
     failedToUpdateUserRole: ユーザーの役割更新に失敗しました
@@ -56,6 +55,7 @@ adminPortal:
     noUsersFound: ユーザーが見つかりません
     refreshingSession: セッションを更新中...
     removeUserConfirmation: 'ユーザー {{username}} を削除してもよろしいですか？この操作は元に戻せません。'
+    verifyingAdminPrivileges: 管理者権限を確認中...
   roles:
     admin: 管理者
     regularUser: 一般ユーザー
@@ -88,25 +88,25 @@ assistant:
     confirmClear: 会話履歴をクリアしてもよろしいですか？
     copy: コピー
     createChatError: チャットの作成に失敗しました
-    model: モデル
-    ragEnabled: RAG 有効
-    sources: ソース
-    view: 表示
     failedAlertTitle: 同期失敗
     inputPlaceholder: メッセージを入力...
     instruction: 指示
+    model: モデル
     noMessages: メッセージがありません
     partialAlertMessage: '{{count}}個のナレッジソースの同期に失敗しました。'
     partialAlertTitle: 部分的に同期完了
     quickStarters: クイックスタート
+    ragEnabled: RAG 有効
     send: 送信
     sendError: メッセージの送信に失敗しました
+    sources: ソース
     syncStatus: 同期状態
     syncSucceeded: ナレッジベースの同期が正常に完了しました！
     syncingAlertMessage: アシスタントのナレッジベースは現在同期中です。準備ができ次第チャットできるようになります。5秒ごとに更新しています。
     syncingAlertTitle: ナレッジベース同期中
     syncingPlaceholder: ナレッジベースを同期中...
     title: アシスタント チャット
+    view: 表示
   confirmDelete: このアシスタントを削除してもよろしいですか？
   createNew: 新規アシスタント作成
   delete: 削除
@@ -229,13 +229,13 @@ auth:
   title: Generative AI Use Cases on AWS
 chat:
   advanced_options: 高度なオプション
-  createChatError: チャットの作成に失敗しました。もう一度お試しください。
-  defaultSystemPrompt: あなたは親切で知識豊富なAIアシスタントです。ユーザーの質問に対して、正確で分かりやすい回答を提供してください。
   button:
     newChat: 新しいチャット
+  createChatError: チャットの作成に失敗しました。もう一度お試しください。
   create_link: リンクの作成
   create_link_message: リンクを作成することで、このアプリケーションにログイン可能な全ユーザーに対して会話履歴を公開します。
   create_system_prompt: システムプロンプトの作成
+  defaultSystemPrompt: あなたは親切で知識豊富なAIアシスタントです。ユーザーの質問に対して、正確で分かりやすい回答を提供してください。
   delete_chat_confirmation: チャット「{{title}}」を削除しますか？
   delete_confirmation: 削除確認
   delete_link: リンクの削除
@@ -279,10 +279,10 @@ common:
   cancel: キャンセル
   clear: クリア
   close: 閉じる
-  ellipsis: '...'
   complete: 完了
   create: 作成
   delete: 削除
+  ellipsis: '...'
   enter_text: 入力してください
   error: エラー
   errorNoSuggestions: 候補が見つかりませんでした。
@@ -777,7 +777,6 @@ meetingMinutes:
   generating_continuation: 議事録生成中（継続 {{current}}/{{max}} 回目）...
   generation_error: 議事録の生成に失敗しました。再試行してください。
   generation_success: 議事録が正常に生成されました
-  output_may_be_incomplete: 出力が長さの制限により不完全な可能性があります。文字起こしを分割することを検討してください。
   language: 言語
   language_auto: 自動検出
   language_chinese: 中国語
@@ -790,6 +789,7 @@ meetingMinutes:
   minutes_placeholder: 生成後にここに議事録が表示されます
   model: モデル
   next_generation_in: '次回生成まで : '
+  output_may_be_incomplete: 出力が長さの制限により不完全な可能性があります。文字起こしを分割することを検討してください。
   record_transcribe: 音声認識
   speech_recognition: 音声認識
   style: 議事録スタイル
@@ -845,9 +845,6 @@ optimizePrompt:
 pptx:
   description: AI の支援を使って専門的なプレゼンテーションを自動作成
   download: ダウンロード
-  model:
-    help: プレゼンテーションコンテンツを生成するAIモデルを選択してください
-    label: AI モデル
   examples:
     business:
       content: 四半期ビジネスレビューに関するプレゼンテーションを作成します。市場分析、財務実績、次四半期の戦略的取り組みを含みます。
@@ -867,6 +864,9 @@ pptx:
     help: プレゼンテーションで求めるものを説明してください。トピック、構成、特別な要件について具体的に記述してください。
     label: プレゼンテーション指示
     placeholder: プレゼンテーションのトピックと要件をここに入力してください...
+  model:
+    help: プレゼンテーションコンテンツを生成するAIモデルを選択してください
+    label: AI モデル
   options:
     summarySlide: まとめスライドを含める
     titleSlide: タイトルスライドを含める
@@ -928,6 +928,16 @@ rag:
   retrieving: Kendra から参考ドキュメントを取得しています...
   title: RAG チャット
 settings:
+  deleteAccount: アカウント削除
+  deleteAccountButton: アカウントを削除
+  deleteAccountCancel: キャンセル
+  deleteAccountConfirm: 削除する
+  deleteAccountConfirmDescription: この操作は取り消せません。確認のため、以下の情報を入力してください。
+  deleteAccountConfirmTitle: アカウント削除の確認
+  deleteAccountDeleteLabel: 「DELETE」と入力
+  deleteAccountDeletePlaceholder: DELETE
+  deleteAccountDescription: アカウントを削除すると、すべてのデータが失われます。この操作は取り消せません。
+  deleteAccountEmailLabel: メールアドレスを入力
   labels:
     customInstructions: カスタム指示
     enableCustomize: カスタマイズを有効にする
@@ -949,16 +959,6 @@ settings:
     dark: ダーク
     light: ライト
     system: システム設定に従う
-  deleteAccount: アカウント削除
-  deleteAccountButton: アカウントを削除
-  deleteAccountCancel: キャンセル
-  deleteAccountConfirm: 削除する
-  deleteAccountConfirmDescription: この操作は取り消せません。確認のため、以下の情報を入力してください。
-  deleteAccountConfirmTitle: アカウント削除の確認
-  deleteAccountDeleteLabel: 「DELETE」と入力
-  deleteAccountDeletePlaceholder: DELETE
-  deleteAccountDescription: アカウントを削除すると、すべてのデータが失われます。この操作は取り消せません。
-  deleteAccountEmailLabel: メールアドレスを入力
 shared:
   contact_admin: 管理者に問い合わせてください。
   error: エラー
@@ -1006,10 +1006,6 @@ transcribe:
   stop_recording: 録音を停止する
   supported_files: mp3, mp4, wav, flac, ogg, amr, webm, m4a ファイルが利用可能です
   title: 音声認識
-userMenu:
-  ariaLabel: ユーザーメニュー
-  logout: ログアウト
-  settings: 設定
 translate:
   additional_context: 追加コンテキスト
   additional_context_placeholder: 追加で考慮してほしい点を入力することができます（カジュアルさ等）
@@ -1250,6 +1246,10 @@ useCaseBuilder:
   updateDescription: ユースケースを更新します。ユースケースが共有され他ユーザーも利用している場合、その内容も更新されます。
   updateErrorCondition: 更新するためには、以下条件を全て満たしてください。
   updating: 更新中...
+userMenu:
+  ariaLabel: ユーザーメニュー
+  logout: ログアウト
+  settings: 設定
 video:
   aspectRatio: アスペクト比
   clear: クリア

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -48,6 +48,7 @@ adminPortal:
   messages:
     failedToCheckAdminStatus: 管理者ステータスの確認に失敗しました
     failedToLoadUsers: ユーザーの読み込みに失敗しました
+    verifyingAdminPrivileges: 管理者権限を確認中...
     failedToRefreshSession: 認証セッションの更新に失敗しました
     failedToRemoveUser: ユーザーの削除に失敗しました
     failedToUpdateUserRole: ユーザーの役割更新に失敗しました
@@ -87,6 +88,10 @@ assistant:
     confirmClear: 会話履歴をクリアしてもよろしいですか？
     copy: コピー
     createChatError: チャットの作成に失敗しました
+    model: モデル
+    ragEnabled: RAG 有効
+    sources: ソース
+    view: 表示
     failedAlertTitle: 同期失敗
     inputPlaceholder: メッセージを入力...
     instruction: 指示
@@ -135,6 +140,7 @@ assistant:
     sourceUrls: ソースURL
     title: 名前
     uploadFiles: ファイルをアップロード
+    uploadingFiles: ファイルをアップロード中...
   editTitle: 編集
   filterAll: すべて
   filterPrivate: プライベート
@@ -144,11 +150,13 @@ assistant:
     back: 戻る
     confirmBulkDelete: '{{count}}件の会話を削除してもよろしいですか？'
     confirmDelete: この会話を削除してもよろしいですか？
+    createdWithDate: '作成日: {{date}}'
     daysAgo: '{{days}}日前'
     deleteSelected: 選択した項目を削除
     deselectAll: 選択解除
     hoursAgo: '{{hours}}時間前'
     lastMessage: 最終メッセージ
+    lastMessageWithDate: '最終メッセージ: {{date}}'
     messageCount: 'メッセージ数: {{count}}'
     minutesAgo: '{{minutes}}分前'
     noConversations: 会話履歴がありません
@@ -207,8 +215,10 @@ assistant:
     makeItPublic: パブリックにする
     private: プライベート
     privateDescription: 自分だけが利用できます
+    privateDescriptionWithParens: (自分だけが利用できます)
     public: パブリック
     publicDescription: 組織内のメンバーが利用できます
+    publicDescriptionWithParens: (組織内のメンバーが利用できます)
     publicWarning: アシスタントをパブリックにすると、組織内の全メンバーが利用できるようになります。指示やナレッジベースに機密情報が含まれていないことを確認してください。
     toggleTitle: 公開設定を変更
     updating: 更新中...
@@ -260,11 +270,16 @@ chatList:
   oneDayAgo: 1日前
   rename: 名前を変更
   today: 今日
+chatSidebar:
+  assistants: アシスタント
+  chatHistory: チャット履歴
+  searchAssistants: アシスタントを探す
 common:
   ask_gaixr: GaiXerに聞く
   cancel: キャンセル
   clear: クリア
   close: 閉じる
+  ellipsis: '...'
   complete: 完了
   create: 作成
   delete: 削除
@@ -294,6 +309,7 @@ common:
   title: タイトル
   trace: トレース
   try: 試す
+  unitMB: MB
   yesterday: 昨日
 demo:
   inter_use_cases: ユースケース連携
@@ -503,6 +519,7 @@ files:
     mimeMismatch: '{{fileName}} のファイル形式が不正です。'
     modelNotSupported: モデルが対応していません。
     videoCountExceeded: 動画数は {{maxCount}} 個以下にしてください。
+  uploadFiles: ファイルをアップロード
 flow:
   title: Flow チャット
 generateImage:
@@ -828,6 +845,9 @@ optimizePrompt:
 pptx:
   description: AI の支援を使って専門的なプレゼンテーションを自動作成
   download: ダウンロード
+  model:
+    help: プレゼンテーションコンテンツを生成するAIモデルを選択してください
+    label: AI モデル
   examples:
     business:
       content: 四半期ビジネスレビューに関するプレゼンテーションを作成します。市場分析、財務実績、次四半期の戦略的取り組みを含みます。
@@ -852,10 +872,12 @@ pptx:
     titleSlide: タイトルスライドを含める
   slideCount:
     label: スライド数
+    labelWithCount: 'スライド数: {{count}}'
   template:
     blank: 空白テンプレート
     blankDescription: クリーンで最小限のテンプレートから開始
     label: テンプレート選択
+    moreTags: '+{{count}}'
     noTemplates: カスタムテンプレートがありません
     private: プライベートテンプレート
     public: パブリックテンプレート
@@ -983,6 +1005,10 @@ transcribe:
   stop_recording: 録音を停止する
   supported_files: mp3, mp4, wav, flac, ogg, amr, webm, m4a ファイルが利用可能です
   title: 音声認識
+userMenu:
+  ariaLabel: ユーザーメニュー
+  logout: ログアウト
+  settings: 設定
 translate:
   additional_context: 追加コンテキスト
   additional_context_placeholder: 追加で考慮してほしい点を入力することができます（カジュアルさ等）

--- a/packages/web/public/locales/translation/th.yaml
+++ b/packages/web/public/locales/translation/th.yaml
@@ -1254,6 +1254,7 @@ writer:
   tutorial_success: โหลดบทเรียนแล้ว
   useAsTextEditor: ใช้เป็นเครื่องมือแก้ไขข้อความ
 settings:
+  deleteAccountDeletePlaceholder: DELETE
   labels:
     customInstructions: คำสั่งที่กำหนดเอง
     enableCustomize: เปิดใช้งานการปรับแต่ง

--- a/packages/web/public/locales/translation/th.yaml
+++ b/packages/web/public/locales/translation/th.yaml
@@ -54,6 +54,7 @@ adminPortal:
     noUsersFound: ไม่พบผู้ใช้
     refreshingSession: กำลังรีเฟรชเซสชัน...
     removeUserConfirmation: 'คุณแน่ใจหรือไม่ว่าต้องการลบผู้ใช้ {{username}}? การดำเนินการนี้ไม่สามารถยกเลิกได้'
+    verifyingAdminPrivileges: กำลังตรวจสอบสิทธิ์ผู้ดูแลระบบ...
   roles:
     admin: ผู้ดูแลระบบ
     regularUser: ผู้ใช้ทั่วไป
@@ -116,6 +117,10 @@ chatList:
   oneDayAgo: 1 วันที่แล้ว
   rename: เปลี่ยนชื่อ
   today: วันนี้
+chatSidebar:
+  assistants: ผู้ช่วย
+  chatHistory: ประวัติการสนทนา
+  searchAssistants: ค้นหาผู้ช่วย
 common:
   cancel: ยกเลิก
   clear: ล้าง
@@ -123,6 +128,7 @@ common:
   complete: เสร็จสิ้น
   create: สร้าง
   delete: ลบ
+  ellipsis: '...'
   enter_text: ป้อนข้อความ
   error: เกิดข้อผิดพลาด
   errorNoSuggestions: ไม่พบคำแนะนำ
@@ -415,6 +421,7 @@ files:
     mimeMismatch: '{{fileName}} มีประเภทไฟล์ที่ไม่ตรงกับนามสกุล'
     modelNotSupported: โมเดลนี้ไม่รองรับไฟล์
     videoCountExceeded: 'โปรดจำกัดไฟล์วิดีโอไม่เกิน {{maxCount}} ไฟล์'
+  uploadFiles: อัปโหลดไฟล์
 flow:
   title: Flow Chat
 generateImage:
@@ -738,11 +745,15 @@ pptx:
     help: อธิบายสิ่งที่คุณต้องการในงานนำเสนอ ระบุเฉพาะเจาะจงเกี่ยวกับหัวข้อ โครงสร้าง และข้อกำหนดพิเศษใดๆ
     label: คำแนะนำสำหรับงานนำเสนอ
     placeholder: ป้อนหัวข้องานนำเสนอและข้อกำหนดของคุณที่นี่...
+  model:
+    help: เลือกโมเดล AI เพื่อสร้างเนื้อหางานนำเสนอ
+    label: โมเดล AI
   options:
     summarySlide: รวมสลายด์สรุป
     titleSlide: รวมสลายด์หัวข้อ
   slideCount:
     label: จำนวนสลายด์
+    labelWithCount: 'จำนวนสลายด์: {{count}}'
   template:
     blank: เทมเพลตว่าง
     blankDescription: เริ่มต้นด้วยเทมเพลตที่สะอาดและอย่างง่าย
@@ -837,6 +848,10 @@ translate:
   result_placeholder: ผลการแปลจะแสดงที่นี่
   text_to_translate: ข้อความที่จะแปล
   title: แปล
+userMenu:
+  ariaLabel: เมนูผู้ใช้
+  logout: ออกจากระบบ
+  settings: ตั้งค่า
 useCaseBuilder:
   accessError: ข้อผิดพลาดในการเข้าถึง
   addInputExample: เพิ่มตัวอย่างอินพุต

--- a/packages/web/public/locales/translation/th.yaml
+++ b/packages/web/public/locales/translation/th.yaml
@@ -97,13 +97,13 @@ auth:
   title: Generative AI Use Cases on AWS
 chat:
   advanced_options: ตัวเลือกขั้นสูง
-  createChatError: ไม่สามารถสร้างแชทได้ กรุณาลองใหม่อีกครั้ง
-  defaultSystemPrompt: คุณเป็นผู้ช่วย AI ที่เป็นมิตรและมีความรู้มาก กรุณาให้คำตอบที่ถูกต้องและเข้าใจง่ายสำหรับคำถามของผู้ใช้
   button:
     newChat: แชทใหม่
+  createChatError: ไม่สามารถสร้างแชทได้ กรุณาลองใหม่อีกครั้ง
   create_link: สร้างลิงก์
   create_link_message: การสร้างลิงก์จะแชร์ประวัติการสนทนากับผู้ใช้ทุกคนที่สามารถเข้าสู่ระบบแอปพลิเคชันนี้ได้
   create_system_prompt: สร้าง System Prompt
+  defaultSystemPrompt: คุณเป็นผู้ช่วย AI ที่เป็นมิตรและมีความรู้มาก กรุณาให้คำตอบที่ถูกต้องและเข้าใจง่ายสำหรับคำถามของผู้ใช้
   delete_chat_confirmation: 'คุณแน่ใจหรือไม่ว่าต้องการลบแชท "{{title}}"?'
   delete_confirmation: ยืนยันการลบ
   delete_link: ลบลิงก์
@@ -675,7 +675,6 @@ meetingMinutes:
   generating_continuation: กำลังสร้างรายงานการประชุม (ต่อเนื่อง {{current}}/{{max}})...
   generation_error: ไม่สามารถสร้างรายงานการประชุมได้ กรุณาลองอีกครั้ง
   generation_success: สร้างรายงานการประชุมสำเร็จ
-  output_may_be_incomplete: ผลลัพธ์อาจไม่สมบูรณ์เนื่องจากข้อจำกัดด้านความยาว กรุณาพิจารณาแบ่งการถอดความ
   language: ภาษา
   language_auto: ตรวจจับอัตโนมัติ
   language_chinese: จีน
@@ -688,6 +687,7 @@ meetingMinutes:
   minutes_placeholder: รายงานการประชุมจะปรากฏที่นี่หลังจากสร้าง
   model: โมเดล
   next_generation_in: 'สร้างครั้งถัดไปใน : '
+  output_may_be_incomplete: ผลลัพธ์อาจไม่สมบูรณ์เนื่องจากข้อจำกัดด้านความยาว กรุณาพิจารณาแบ่งการถอดความ
   record_transcribe: บันทึกและถอดความ
   speech_recognition: การรู้จำเสียงพูด
   style: รูปแบบรายงานการประชุม
@@ -815,6 +815,29 @@ rag:
   please_refer: .
   retrieving: กำลังค้นคืนเอกสารอ้างอิงจาก Kendra...
   title: RAG Chat
+settings:
+  deleteAccountDeletePlaceholder: DELETE
+  labels:
+    customInstructions: คำสั่งที่กำหนดเอง
+    enableCustomize: เปิดใช้งานการปรับแต่ง
+    language: ภาษา
+    sendMessage: ส่งข้อความ
+    theme: ธีม
+  language:
+    auto: ตรวจจับอัตโนมัติ
+    ja: 日本語
+  placeholders:
+    customInstructions: การตั้งค่าเพิ่มเติมสำหรับพฤติกรรม สไตล์ และโทน
+  sendMessage:
+    ctrlCmdEnter: ส่งด้วย Ctrl/⌘+Enter
+    enter: ส่งด้วย Enter
+  tabs:
+    aiCustomize: ปรับแต่ง AI
+    general: ทั่วไป
+  theme:
+    dark: มืด
+    light: สว่าง
+    system: ตามการตั้งค่าระบบ
 shared:
   contact_admin: โปรดติดต่อผู้ดูแลระบบ
   error: ข้อผิดพลาด
@@ -862,10 +885,6 @@ translate:
   result_placeholder: ผลการแปลจะแสดงที่นี่
   text_to_translate: ข้อความที่จะแปล
   title: แปล
-userMenu:
-  ariaLabel: เมนูผู้ใช้
-  logout: ออกจากระบบ
-  settings: ตั้งค่า
 useCaseBuilder:
   accessError: ข้อผิดพลาดในการเข้าถึง
   addInputExample: เพิ่มตัวอย่างอินพุต
@@ -1117,6 +1136,10 @@ useCaseBuilder:
   updateDescription: อัปเดต use cases ด้วยเนื้อหาข้างต้น
   updateErrorCondition: 'ต้องมีเงื่อนไขต่อไปนี้:'
   updating: กำลังอัปเดต...
+userMenu:
+  ariaLabel: เมนูผู้ใช้
+  logout: ออกจากระบบ
+  settings: ตั้งค่า
 video:
   aspectRatio: อัตราส่วนภาพ
   clear: ล้าง
@@ -1282,26 +1305,3 @@ writer:
   tutorial: บทเรียน
   tutorial_success: โหลดบทเรียนแล้ว
   useAsTextEditor: ใช้เป็นเครื่องมือแก้ไขข้อความ
-settings:
-  deleteAccountDeletePlaceholder: DELETE
-  labels:
-    customInstructions: คำสั่งที่กำหนดเอง
-    enableCustomize: เปิดใช้งานการปรับแต่ง
-    language: ภาษา
-    sendMessage: ส่งข้อความ
-    theme: ธีม
-  language:
-    auto: ตรวจจับอัตโนมัติ
-    ja: 日本語
-  placeholders:
-    customInstructions: การตั้งค่าเพิ่มเติมสำหรับพฤติกรรม สไตล์ และโทน
-  sendMessage:
-    ctrlCmdEnter: ส่งด้วย Ctrl/⌘+Enter
-    enter: ส่งด้วย Enter
-  tabs:
-    aiCustomize: ปรับแต่ง AI
-    general: ทั่วไป
-  theme:
-    dark: มืด
-    light: สว่าง
-    system: ตามการตั้งค่าระบบ

--- a/packages/web/public/locales/translation/th.yaml
+++ b/packages/web/public/locales/translation/th.yaml
@@ -149,6 +149,7 @@ common:
   title: ชื่อเรื่อง
   trace: ติดตาม
   try: ลอง
+  unitMB: MB
 demo:
   inter_use_cases: การบูรณาการ Use Case
 diagram:
@@ -746,6 +747,7 @@ pptx:
     blank: เทมเพลตว่าง
     blankDescription: เริ่มต้นด้วยเทมเพลตที่สะอาดและอย่างง่าย
     label: การเลือกเทมเพลต
+    moreTags: '+{{count}}'
     noTemplates: ไม่มีเทมเพลตกำหนดเอง
     private: เทมเพลตส่วนตัว
     public: เทมเพลตสาธารณะ

--- a/packages/web/public/locales/translation/th.yaml
+++ b/packages/web/public/locales/translation/th.yaml
@@ -76,6 +76,20 @@ adminPortal:
 agent:
   drop_files: วางไฟล์เพื่ออัปโหลด
   title: Agent Chat
+assistant:
+  chatPage:
+    model: โมเดล
+    ragEnabled: RAG เปิดใช้งาน
+    sources: แหล่งที่มา
+    view: ดู
+  edit:
+    uploadingFiles: กำลังอัปโหลดไฟล์...
+  history:
+    createdWithDate: 'สร้างเมื่อ: {{date}}'
+    lastMessageWithDate: 'ข้อความล่าสุด: {{date}}'
+  visibility:
+    privateDescriptionWithParens: (เฉพาะคุณเท่านั้นที่สามารถใช้ได้)
+    publicDescriptionWithParens: (สมาชิกในองค์กรสามารถใช้ได้)
 auth:
   loading: กำลังโหลด...
   login: เข้าสู่ระบบ

--- a/packages/web/public/locales/translation/vi.yaml
+++ b/packages/web/public/locales/translation/vi.yaml
@@ -54,6 +54,7 @@ adminPortal:
     noUsersFound: Không tìm thấy người dùng
     refreshingSession: Đang làm mới phiên...
     removeUserConfirmation: 'Bạn có chắc chắn muốn xóa người dùng {{username}}? Hành động này không thể hoàn tác.'
+    verifyingAdminPrivileges: Đang xác minh quyền quản trị viên...
   roles:
     admin: Quản Trị Viên
     regularUser: Người Dùng Thường
@@ -116,6 +117,10 @@ chatList:
   oneDayAgo: 1 ngày trước
   rename: Đổi tên
   today: Hôm nay
+chatSidebar:
+  assistants: Trợ lý
+  chatHistory: Lịch sử trò chuyện
+  searchAssistants: Tìm kiếm trợ lý
 common:
   cancel: Hủy
   clear: Xóa
@@ -123,6 +128,7 @@ common:
   complete: Hoàn thành
   create: Tạo
   delete: Xóa
+  ellipsis: '...'
   enter_text: Vui lòng nhập
   error: Lỗi
   errorNoSuggestions: Không tìm thấy gợi ý.
@@ -411,6 +417,7 @@ files:
     mimeMismatch: 'Định dạng file của {{fileName}} không đúng.'
     modelNotSupported: Mô hình không hỗ trợ.
     videoCountExceeded: Số lượng video phải không quá {{maxCount}} video.
+  uploadFiles: Tải lên tập tin
 flow:
   title: Flow Chat
 generateImage:
@@ -720,11 +727,15 @@ pptx:
     help: Mô tả những gì bạn muốn trong bản trình bày. Hãy cụ thể về chủ đề, cấu trúc và bất kỳ yêu cầu đặc biệt nào.
     label: Hướng dẫn bản trình bày
     placeholder: Nhập chủ đề và yêu cầu bản trình bày của bạn tại đây...
+  model:
+    help: Chọn mô hình AI để tạo nội dung bản trình bày
+    label: Mô hình AI
   options:
     summarySlide: Bao gồm slide tóm tắt
     titleSlide: Bao gồm slide tiêu đề
   slideCount:
     label: Số slide
+    labelWithCount: 'Số slide: {{count}}'
   template:
     blank: Mẫu trắng
     blankDescription: Bắt đầu với mẫu sạch và tối giản
@@ -811,6 +822,10 @@ translate:
   result_placeholder: Kết quả dịch thuật sẽ được hiển thị ở đây
   text_to_translate: Văn bản muốn dịch
   title: Dịch thuậ
+userMenu:
+  ariaLabel: Menu người dùng
+  logout: Đăng xuất
+  settings: Cài đặt
 useCaseBuilder:
   accessError: Lỗi truy cập
   addInputExample: Thêm ví dụ đầu vào

--- a/packages/web/public/locales/translation/vi.yaml
+++ b/packages/web/public/locales/translation/vi.yaml
@@ -76,6 +76,20 @@ adminPortal:
 agent:
   drop_files: Thả file để tải lên
   title: Chat Agent
+assistant:
+  chatPage:
+    model: Mô hình
+    ragEnabled: RAG Đã bật
+    sources: Nguồn
+    view: Xem
+  edit:
+    uploadingFiles: Đang tải lên tập tin...
+  history:
+    createdWithDate: 'Ngày tạo: {{date}}'
+    lastMessageWithDate: 'Tin nhắn cuối: {{date}}'
+  visibility:
+    privateDescriptionWithParens: (Chỉ bạn mới có thể sử dụng)
+    publicDescriptionWithParens: (Thành viên trong tổ chức có thể sử dụng)
 auth:
   loading: Đang tải...
   login: Đăng nhập

--- a/packages/web/public/locales/translation/vi.yaml
+++ b/packages/web/public/locales/translation/vi.yaml
@@ -97,13 +97,13 @@ auth:
   title: Generative AI Use Cases on AWS
 chat:
   advanced_options: Tùy chọn nâng cao
-  createChatError: Không thể tạo cuộc trò chuyện. Vui lòng thử lại.
-  defaultSystemPrompt: Bạn là trợ lý AI thân thiện và có kiến thức phong phú. Vui lòng cung cấp câu trả lời chính xác và dễ hiểu cho các câu hỏi của người dùng.
   button:
     newChat: Chat mới
+  createChatError: Không thể tạo cuộc trò chuyện. Vui lòng thử lại.
   create_link: Tạo liên kết
   create_link_message: Bằng cách tạo liên kết, bạn sẽ công khai lịch sử cuộc trò chuyện cho tất cả người dùng có thể đăng nhập vào ứng dụng này.
   create_system_prompt: Tạo system prompt
+  defaultSystemPrompt: Bạn là trợ lý AI thân thiện và có kiến thức phong phú. Vui lòng cung cấp câu trả lời chính xác và dễ hiểu cho các câu hỏi của người dùng.
   delete_chat_confirmation: 'Bạn có muốn xóa cuộc trò chuyện "{{title}}" không?'
   delete_confirmation: Xác nhận xóa
   delete_link: Xóa liên kết
@@ -659,7 +659,6 @@ meetingMinutes:
   generating_continuation: Đang tạo biên bản (tiếp tục {{current}}/{{max}})...
   generation_error: Không thể tạo biên bản cuộc họp. Vui lòng thử lại.
   generation_success: Tạo biên bản cuộc họp thành công
-  output_may_be_incomplete: Kết quả có thể không đầy đủ do giới hạn độ dài. Hãy xem xét chia nhỏ bản ghi âm.
   language: Ngôn ngữ
   language_auto: Tự động phát hiện
   language_chinese: Tiếng Trung
@@ -672,6 +671,7 @@ meetingMinutes:
   minutes_placeholder: Biên bản sẽ xuất hiện ở đây sau khi tạo
   model: Mô hình
   next_generation_in: 'Tạo tiếp theo trong : '
+  output_may_be_incomplete: Kết quả có thể không đầy đủ do giới hạn độ dài. Hãy xem xét chia nhỏ bản ghi âm.
   record_transcribe: Ghi âm và chuyển đổi
   speech_recognition: Nhận dạng giọng nói
   style: Kiểu biên bản
@@ -790,6 +790,29 @@ rag:
   please_refer: Vui lòng tham khảo.
   retrieving: Đang lấy tài liệu tham khảo từ Kendra...
   title: RAG Chat
+settings:
+  deleteAccountDeletePlaceholder: DELETE
+  labels:
+    customInstructions: Hướng dẫn tùy chỉnh
+    enableCustomize: Bật tùy chỉnh
+    language: Ngôn ngữ
+    sendMessage: Gửi tin nhắn
+    theme: Giao diện
+  language:
+    auto: Tự động phát hiện
+    ja: 日本語
+  placeholders:
+    customInstructions: Cài đặt bổ sung cho hành vi, phong cách và giọng điệu
+  sendMessage:
+    ctrlCmdEnter: Gửi bằng Ctrl/⌘+Enter
+    enter: Gửi bằng Enter
+  tabs:
+    aiCustomize: Tùy chỉnh AI
+    general: Tổng quát
+  theme:
+    dark: Tối
+    light: Sáng
+    system: Theo cài đặt hệ thống
 shared:
   contact_admin: Vui lòng liên hệ với quản trị viên.
   error: Lỗi
@@ -836,10 +859,6 @@ translate:
   result_placeholder: Kết quả dịch thuật sẽ được hiển thị ở đây
   text_to_translate: Văn bản muốn dịch
   title: Dịch thuậ
-userMenu:
-  ariaLabel: Menu người dùng
-  logout: Đăng xuất
-  settings: Cài đặt
 useCaseBuilder:
   accessError: Lỗi truy cập
   addInputExample: Thêm ví dụ đầu vào
@@ -1081,6 +1100,10 @@ useCaseBuilder:
   updateDescription: Cập nhật trường hợp sử dụng. Nếu trường hợp sử dụng được chia sẻ và người dùng khác cũng đang sử dụng, nội dung đó cũng sẽ được cập nhật.
   updateErrorCondition: Để cập nhật, vui lòng đáp ứng tất cả các điều kiện sau.
   updating: Đang cập nhật...
+userMenu:
+  ariaLabel: Menu người dùng
+  logout: Đăng xuất
+  settings: Cài đặt
 video:
   aspectRatio: Tỷ lệ khung hình
   clear: Xóa
@@ -1243,26 +1266,3 @@ writer:
   tutorial: Hướng dẫn
   tutorial_success: Đã tải hướng dẫn
   useAsTextEditor: Sử dụng như editor văn bản
-settings:
-  deleteAccountDeletePlaceholder: DELETE
-  labels:
-    customInstructions: Hướng dẫn tùy chỉnh
-    enableCustomize: Bật tùy chỉnh
-    language: Ngôn ngữ
-    sendMessage: Gửi tin nhắn
-    theme: Giao diện
-  language:
-    auto: Tự động phát hiện
-    ja: 日本語
-  placeholders:
-    customInstructions: Cài đặt bổ sung cho hành vi, phong cách và giọng điệu
-  sendMessage:
-    ctrlCmdEnter: Gửi bằng Ctrl/⌘+Enter
-    enter: Gửi bằng Enter
-  tabs:
-    aiCustomize: Tùy chỉnh AI
-    general: Tổng quát
-  theme:
-    dark: Tối
-    light: Sáng
-    system: Theo cài đặt hệ thống

--- a/packages/web/public/locales/translation/vi.yaml
+++ b/packages/web/public/locales/translation/vi.yaml
@@ -1215,6 +1215,7 @@ writer:
   tutorial_success: Đã tải hướng dẫn
   useAsTextEditor: Sử dụng như editor văn bản
 settings:
+  deleteAccountDeletePlaceholder: DELETE
   labels:
     customInstructions: Hướng dẫn tùy chỉnh
     enableCustomize: Bật tùy chỉnh

--- a/packages/web/public/locales/translation/vi.yaml
+++ b/packages/web/public/locales/translation/vi.yaml
@@ -148,6 +148,7 @@ common:
   title: Tiêu đề
   trace: Trace
   try: Thử
+  unitMB: MB
 demo:
   inter_use_cases: Liên kết use case
 diagram:
@@ -728,6 +729,7 @@ pptx:
     blank: Mẫu trắng
     blankDescription: Bắt đầu với mẫu sạch và tối giản
     label: Lựa chọn mẫu
+    moreTags: '+{{count}}'
     noTemplates: Không có mẫu tùy chỉnh nào
     private: Mẫu riêng tư
     public: Mẫu công khai

--- a/packages/web/public/locales/translation/zh.yaml
+++ b/packages/web/public/locales/translation/zh.yaml
@@ -1071,6 +1071,7 @@ writer:
   tutorial_success: 已加载教程
   useAsTextEditor: 作为文本编辑器使用
 settings:
+  deleteAccountDeletePlaceholder: DELETE
   labels:
     customInstructions: 自定义指令
     enableCustomize: 启用自定义

--- a/packages/web/public/locales/translation/zh.yaml
+++ b/packages/web/public/locales/translation/zh.yaml
@@ -148,6 +148,7 @@ common:
   title: 标题
   trace: 跟踪
   try: 尝试
+  unitMB: MB
 demo:
   inter_use_cases: 用例集成
 diagram:
@@ -635,6 +636,7 @@ pptx:
     blank: 空白模板
     blankDescription: 从简洁的最少模板开始
     label: 模板选择
+    moreTags: '+{{count}}'
     noTemplates: 没有可用的自定义模板
     private: 私人模板
     public: 公共模板

--- a/packages/web/public/locales/translation/zh.yaml
+++ b/packages/web/public/locales/translation/zh.yaml
@@ -76,6 +76,20 @@ adminPortal:
 agent:
   drop_files: 拖放文件上传
   title: Agent 聊天
+assistant:
+  chatPage:
+    model: 模型
+    ragEnabled: RAG 已启用
+    sources: 来源
+    view: 查看
+  edit:
+    uploadingFiles: 正在上传文件...
+  history:
+    createdWithDate: '创建日期: {{date}}'
+    lastMessageWithDate: '最后消息: {{date}}'
+  visibility:
+    privateDescriptionWithParens: (仅您可以使用)
+    publicDescriptionWithParens: (组织成员可以使用)
 auth:
   loading: 加载中...
   login: 登录

--- a/packages/web/public/locales/translation/zh.yaml
+++ b/packages/web/public/locales/translation/zh.yaml
@@ -97,13 +97,13 @@ auth:
   title: Generative AI Use Cases on AWS
 chat:
   advanced_options: 高级选项
-  createChatError: 创建聊天失败。请重试。
-  defaultSystemPrompt: 你是一个乐于助人且知识渊博的AI助手。请为用户的问题提供准确且易于理解的回答。
   button:
     newChat: 新聊天
+  createChatError: 创建聊天失败。请重试。
   create_link: 创建链接
   create_link_message: 通过创建链接，您将向所有可以登录此应用程序的用户公开对话历史。
   create_system_prompt: 创建系统提示
+  defaultSystemPrompt: 你是一个乐于助人且知识渊博的AI助手。请为用户的问题提供准确且易于理解的回答。
   delete_chat_confirmation: 是否删除聊天"{{title}}"？
   delete_confirmation: 删除确认
   delete_link: 删除链接
@@ -565,7 +565,6 @@ meetingMinutes:
   generating_continuation: 正在生成会议纪要（继续 {{current}}/{{max}} 次）...
   generation_error: 会议纪要生成失败。请重试。
   generation_success: 会议纪要生成成功
-  output_may_be_incomplete: 由于长度限制，输出可能不完整。请考虑分割转录文本。
   language: 语言
   language_auto: 自动检测
   language_chinese: 中文
@@ -578,6 +577,7 @@ meetingMinutes:
   minutes_placeholder: 生成后会议纪要将显示在这里
   model: 模型
   next_generation_in: '下次生成时间 :'
+  output_may_be_incomplete: 由于长度限制，输出可能不完整。请考虑分割转录文本。
   record_transcribe: 录音和转录
   speech_recognition: 语音识别
   style: 会议纪要风格
@@ -690,6 +690,29 @@ rag:
   please_refer: 请参考。
   retrieving: 正在从Kendra获取参考文档...
   title: RAG聊天
+settings:
+  deleteAccountDeletePlaceholder: DELETE
+  labels:
+    customInstructions: 自定义指令
+    enableCustomize: 启用自定义
+    language: 语言
+    sendMessage: 发送消息
+    theme: 主题
+  language:
+    auto: 自动检测
+    ja: 日本語
+  placeholders:
+    customInstructions: 行为、风格和语调的附加设置
+  sendMessage:
+    ctrlCmdEnter: Ctrl/⌘+Enter发送
+    enter: Enter发送
+  tabs:
+    aiCustomize: AI自定义
+    general: 通用
+  theme:
+    dark: 深色
+    light: 浅色
+    system: 跟随系统设置
 shared:
   contact_admin: 请联系管理员。
   error: 错误
@@ -736,10 +759,6 @@ translate:
   result_placeholder: 翻译结果将显示在这里
   text_to_translate: 要翻译的文本
   title: 翻译
-userMenu:
-  ariaLabel: 用户菜单
-  logout: 退出登录
-  settings: 设置
 useCaseBuilder:
   accessError: 访问错误
   addInputExample: 添加输入示例
@@ -941,6 +960,10 @@ useCaseBuilder:
   updateDescription: 更新用例。如果用例已共享且其他用户也在使用，他们的内容也会更新。
   updateErrorCondition: 要更新，请满足以下所有条件。
   updating: 更新中...
+userMenu:
+  ariaLabel: 用户菜单
+  logout: 退出登录
+  settings: 设置
 video:
   aspectRatio: 宽高比
   clear: 清除
@@ -1099,26 +1122,3 @@ writer:
   tutorial: 教程
   tutorial_success: 已加载教程
   useAsTextEditor: 作为文本编辑器使用
-settings:
-  deleteAccountDeletePlaceholder: DELETE
-  labels:
-    customInstructions: 自定义指令
-    enableCustomize: 启用自定义
-    language: 语言
-    sendMessage: 发送消息
-    theme: 主题
-  language:
-    auto: 自动检测
-    ja: 日本語
-  placeholders:
-    customInstructions: 行为、风格和语调的附加设置
-  sendMessage:
-    ctrlCmdEnter: Ctrl/⌘+Enter发送
-    enter: Enter发送
-  tabs:
-    aiCustomize: AI自定义
-    general: 通用
-  theme:
-    dark: 深色
-    light: 浅色
-    system: 跟随系统设置

--- a/packages/web/public/locales/translation/zh.yaml
+++ b/packages/web/public/locales/translation/zh.yaml
@@ -54,6 +54,7 @@ adminPortal:
     noUsersFound: 未找到用户
     refreshingSession: 刷新会话中...
     removeUserConfirmation: '确定要删除用户 {{username}} 吗？此操作无法撤销。'
+    verifyingAdminPrivileges: 正在验证管理员权限...
   roles:
     admin: 管理员
     regularUser: 普通用户
@@ -115,6 +116,10 @@ chatList:
   oneDayAgo: 1天前
   rename: 重命名
   today: 今天
+chatSidebar:
+  assistants: 助手
+  chatHistory: 聊天记录
+  searchAssistants: 搜索助手
 common:
   cancel: 取消
   clear: 清除
@@ -122,6 +127,7 @@ common:
   complete: 完成
   create: 创建
   delete: 删除
+  ellipsis: '...'
   enter_text: 请输入
   error: 错误
   errorNoSuggestions: 未找到建议。
@@ -338,6 +344,7 @@ files:
     mimeMismatch: '{{fileName}} 的文件格式不正确。'
     modelNotSupported: 模型不支持。
     videoCountExceeded: 视频数量不能超过 {{maxCount}} 个。
+  uploadFiles: 上传文件
 flow:
   title: Flow 聊天
 generateImage:
@@ -627,11 +634,15 @@ pptx:
     help: 描述您想要的演示文稿内容。请具体说明主题、结构和任何特殊要求。
     label: 演示文稿说明
     placeholder: 在此输入您的演示文稿主题和要求...
+  model:
+    help: 选择用于生成演示文稿内容的 AI 模型
+    label: AI 模型
   options:
     summarySlide: 包含总结幻灯片
     titleSlide: 包含标题幻灯片
   slideCount:
     label: 幻灯片数量
+    labelWithCount: '幻灯片数量: {{count}}'
   template:
     blank: 空白模板
     blankDescription: 从简洁的最少模板开始
@@ -711,6 +722,10 @@ translate:
   result_placeholder: 翻译结果将显示在这里
   text_to_translate: 要翻译的文本
   title: 翻译
+userMenu:
+  ariaLabel: 用户菜单
+  logout: 退出登录
+  settings: 设置
 useCaseBuilder:
   accessError: 访问错误
   addInputExample: 添加输入示例

--- a/packages/web/src/components/ChatSidebar.tsx
+++ b/packages/web/src/components/ChatSidebar.tsx
@@ -50,7 +50,7 @@ const ChatSidebar: React.FC<Props> = ({ onNewChat }) => {
       {/* Assistants Section */}
       <div className="border-b border-gray-200 p-3">
         <div className="mb-2 text-xs font-semibold text-gray-600">
-          アシスタント
+          {t('chatSidebar.assistants')}
         </div>
 
         {/* Featured Assistants List */}
@@ -78,14 +78,14 @@ const ChatSidebar: React.FC<Props> = ({ onNewChat }) => {
               : 'text-gray-600 hover:bg-gray-100'
           }`}>
           <PiMagnifyingGlass className="text-base" />
-          <span>アシスタントを探す</span>
+          <span>{t('chatSidebar.searchAssistants')}</span>
         </button>
       </div>
 
       {/* Chat History Section */}
       <div className="flex flex-1 flex-col overflow-hidden">
         <div className="px-3 py-2 text-xs font-semibold text-gray-600">
-          チャット履歴
+          {t('chatSidebar.chatHistory')}
         </div>
         <div className="scrollbar-thin scrollbar-thumb-gray-300 flex-1 overflow-y-auto px-2">
           <ChatList searchWords={[]} />

--- a/packages/web/src/components/DialogConfirmDeleteAccount.tsx
+++ b/packages/web/src/components/DialogConfirmDeleteAccount.tsx
@@ -72,7 +72,7 @@ const DialogConfirmDeleteAccount: React.FC<Props> = (props) => {
                 type="text"
                 value={deleteInput}
                 onChange={(e) => setDeleteInput(e.target.value)}
-                placeholder="DELETE"
+                placeholder={t('settings.deleteAccountDeletePlaceholder')}
                 className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-red-500 focus:outline-none focus:ring-1 focus:ring-red-500"
                 disabled={props.isDeleting}
               />

--- a/packages/web/src/components/DynamicRouter.tsx
+++ b/packages/web/src/components/DynamicRouter.tsx
@@ -76,6 +76,7 @@ const DynamicRouter: React.FC<DynamicRouterProps> = ({
       <div className="flex min-h-screen items-center justify-center">
         <div className="text-center">
           <div className="mx-auto h-8 w-8 animate-spin rounded-full border-b-2 border-gray-900"></div>
+          {/* eslint-disable-next-line @shopify/jsx-no-hardcoded-content */}
           <p className="mt-2 text-gray-600">Loading...</p>
         </div>
       </div>

--- a/packages/web/src/components/DynamicRouter.tsx
+++ b/packages/web/src/components/DynamicRouter.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import {
   RouterProvider,
   createBrowserRouter,
@@ -62,6 +63,7 @@ const DynamicRouter: React.FC<DynamicRouterProps> = ({
   mcpEnabled,
   pptxEnabled,
 }) => {
+  const { t } = useTranslation();
   const { enabled, loading } = useUseCases();
   const {
     visionEnabled,
@@ -76,8 +78,7 @@ const DynamicRouter: React.FC<DynamicRouterProps> = ({
       <div className="flex min-h-screen items-center justify-center">
         <div className="text-center">
           <div className="mx-auto h-8 w-8 animate-spin rounded-full border-b-2 border-gray-900"></div>
-          {/* eslint-disable-next-line @shopify/jsx-no-hardcoded-content */}
-          <p className="mt-2 text-gray-600">Loading...</p>
+          <p className="mt-2 text-gray-600">{t('common.loading')}</p>
         </div>
       </div>
     );

--- a/packages/web/src/components/FileUploader.tsx
+++ b/packages/web/src/components/FileUploader.tsx
@@ -1,4 +1,5 @@
 import React, { useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import { BaseProps } from '../@types/common';
 import { PiUploadSimple } from 'react-icons/pi';
 
@@ -10,6 +11,7 @@ type Props = BaseProps & {
 };
 
 const FileUploader: React.FC<Props> = (props) => {
+  const { t } = useTranslation();
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleClick = () => {
@@ -37,7 +39,7 @@ const FileUploader: React.FC<Props> = (props) => {
         onClick={handleClick}
         className="flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 hover:bg-gray-50">
         <PiUploadSimple />
-        <span>Upload Files</span>
+        <span>{t('files.uploadFiles')}</span>
       </button>
     </div>
   );

--- a/packages/web/src/components/PptxTemplateSelector.tsx
+++ b/packages/web/src/components/PptxTemplateSelector.tsx
@@ -110,7 +110,9 @@ const PptxTemplateSelector: React.FC<PptxTemplateSelectorProps> = ({
                       ))}
                       {template.tags.length > 3 && (
                         <span className="text-aws-font-color-secondary text-xs">
-                          +{template.tags.length - 3}
+                          {t('pptx.template.moreTags', {
+                            count: template.tags.length - 3,
+                          })}
                         </span>
                       )}
                     </div>

--- a/packages/web/src/components/PptxTemplateUploader.tsx
+++ b/packages/web/src/components/PptxTemplateUploader.tsx
@@ -131,7 +131,8 @@ const PptxTemplateUploader: React.FC<PptxTemplateUploaderProps> = ({
                   {file.name}
                 </p>
                 <p className="text-aws-font-color-secondary text-xs">
-                  {(file.size / (1024 * 1024)).toFixed(2)} MB
+                  {(file.size / (1024 * 1024)).toFixed(2)}{' '}
+                  {t('common.unitMB')}
                 </p>
               </div>
               <ButtonIcon onClick={() => setFile(null)} className="h-6 w-6">
@@ -143,6 +144,7 @@ const PptxTemplateUploader: React.FC<PptxTemplateUploaderProps> = ({
 
         {/* Template Name */}
         <div>
+          {/* eslint-disable-next-line @shopify/jsx-no-hardcoded-content */}
           <label className="text-aws-font-color mb-2 block text-sm font-medium">
             {t('pptx.upload.nameLabel')} *
           </label>

--- a/packages/web/src/components/UserInviteDialog.tsx
+++ b/packages/web/src/components/UserInviteDialog.tsx
@@ -474,6 +474,7 @@ const UserInviteDialog: React.FC<UserInviteDialogProps> = ({
                   {!sendEmail && results.summary.successful > 0 && (
                     <div className="mt-3 rounded bg-yellow-50 p-3">
                       <p className="text-sm text-yellow-800">
+                        {/* eslint-disable-next-line @shopify/jsx-no-hardcoded-content */}
                         <span className="font-semibold">
                           {
                             t('adminPortal.invite.results.warning').split(

--- a/packages/web/src/components/UserMenu.tsx
+++ b/packages/web/src/components/UserMenu.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import * as Popover from '@radix-ui/react-popover';
 import {
   PiGear,
@@ -16,6 +17,7 @@ import { performLogoutAndReload } from '../utils/auth';
 import SettingsModal from './SettingsModal';
 
 const UserMenu: React.FC = () => {
+  const { t } = useTranslation();
   const { userInfo, loading } = useUserInfo();
   const [isOpen, setIsOpen] = useState(false);
   // const [isHelpSubmenuOpen, setIsHelpSubmenuOpen] = useState(false); // Temporarily commented out
@@ -50,7 +52,7 @@ const UserMenu: React.FC = () => {
       <Popover.Trigger asChild>
         <button
           className="flex h-14 w-full items-center justify-center focus:outline-none"
-          aria-label="User menu">
+          aria-label={t('userMenu.ariaLabel')}>
           <div className="text-aws-squid-ink flex h-10 w-10 items-center justify-center rounded-full bg-white text-sm font-semibold">
             {getInitials()}
           </div>
@@ -158,7 +160,7 @@ const UserMenu: React.FC = () => {
                 setIsOpen(false); // Close the user menu
               }}>
               <PiGear className="h-5 w-5 text-gray-500" />
-              <span>設定</span>
+              <span>{t('userMenu.settings')}</span>
             </button>
 
             {/* Logout */}
@@ -166,7 +168,7 @@ const UserMenu: React.FC = () => {
               className="flex w-full items-center gap-3 px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
               onClick={handleLogout}>
               <PiSignOut className="h-5 w-5 text-gray-500" />
-              <span>ログアウト</span>
+              <span>{t('userMenu.logout')}</span>
             </button>
           </div>
         </Popover.Content>

--- a/packages/web/src/components/assistants/KnowledgeSection.tsx
+++ b/packages/web/src/components/assistants/KnowledgeSection.tsx
@@ -101,7 +101,9 @@ const KnowledgeSection: React.FC<KnowledgeSectionProps> = ({
               multiple
             />
             {uploadingFiles && (
-              <p className="mt-2 text-sm text-blue-600">Uploading files...</p>
+              <p className="mt-2 text-sm text-blue-600">
+                {t('assistant.edit.uploadingFiles')}
+              </p>
             )}
           </>
         )}

--- a/packages/web/src/pages/AdminPortal.tsx
+++ b/packages/web/src/pages/AdminPortal.tsx
@@ -325,7 +325,11 @@ const AdminPortal: React.FC = () => {
   }
 
   if (checkingRole) {
-    return <LoadingOverlay>Verifying admin privileges...</LoadingOverlay>;
+    return (
+      <LoadingOverlay>
+        {t('adminPortal.messages.verifyingAdminPrivileges')}
+      </LoadingOverlay>
+    );
   }
 
   return (

--- a/packages/web/src/pages/AssistantChatPage.tsx
+++ b/packages/web/src/pages/AssistantChatPage.tsx
@@ -496,7 +496,9 @@ const AssistantChatPage: React.FC = () => {
           {/* Display sources if available (RAG) */}
           {isAssistant && message.sources && message.sources.length > 0 && (
             <div className="rounded bg-gray-50 p-2 text-xs">
-              <div className="mb-1 font-semibold text-gray-700">Sources:</div>
+              <div className="mb-1 font-semibold text-gray-700">
+                {t('assistant.chatPage.sources')}
+              </div>
               {message.sources.map((source, idx) => (
                 <div key={idx} className="mb-1">
                   <span className="text-gray-600">{source.name}</span>
@@ -506,7 +508,7 @@ const AssistantChatPage: React.FC = () => {
                       target="_blank"
                       rel="noopener noreferrer"
                       className="ml-2 text-blue-600 hover:underline">
-                      View
+                      {t('assistant.chatPage.view')}
                     </a>
                   )}
                 </div>
@@ -587,19 +589,25 @@ const AssistantChatPage: React.FC = () => {
           </h3>
           <div className="space-y-1 text-sm">
             <p>
+              {/* eslint-disable-next-line @shopify/jsx-no-hardcoded-content */}
               <strong>{t('assistant.chatPage.instruction')}:</strong>{' '}
               {assistant.instruction}
             </p>
             <p>
-              <strong>Model:</strong> {assistant.modelId}
+              {/* eslint-disable-next-line @shopify/jsx-no-hardcoded-content */}
+              <strong>{t('assistant.chatPage.model')}:</strong>{' '}
+              {assistant.modelId}
             </p>
             {assistant.ragEnabled && (
               <>
                 <p>
+                  {/* eslint-disable-next-line @shopify/jsx-no-hardcoded-content */}
                   <strong>{t('assistant.chatPage.syncStatus')}:</strong>{' '}
                   {assistant.syncStatus}
                 </p>
-                <p className="text-green-600">RAG Enabled</p>
+                <p className="text-green-600">
+                  {t('assistant.chatPage.ragEnabled')}
+                </p>
               </>
             )}
           </div>

--- a/packages/web/src/pages/AssistantFormPage.tsx
+++ b/packages/web/src/pages/AssistantFormPage.tsx
@@ -347,7 +347,7 @@ const AssistantFormPage: React.FC = () => {
                   {t('assistant.visibility.private')}
                 </span>
                 <span className="text-xs text-gray-500">
-                  ({t('assistant.visibility.privateDescription')})
+                  {t('assistant.visibility.privateDescriptionWithParens')}
                 </span>
               </label>
               <label className="flex cursor-pointer items-center gap-2">
@@ -369,7 +369,7 @@ const AssistantFormPage: React.FC = () => {
                   {t('assistant.visibility.public')}
                 </span>
                 <span className="text-xs text-gray-500">
-                  ({t('assistant.visibility.publicDescription')})
+                  {t('assistant.visibility.publicDescriptionWithParens')}
                 </span>
               </label>
             </div>

--- a/packages/web/src/pages/AssistantHistoryPage.tsx
+++ b/packages/web/src/pages/AssistantHistoryPage.tsx
@@ -254,13 +254,16 @@ const AssistantHistoryPage: React.FC = () => {
                 <div className="flex items-center gap-4 text-sm text-gray-600">
                   <span className="flex items-center gap-1">
                     <PiCalendar />
-                    Created: {formatDate(assistant.createdDate)}
+                    {t('assistant.history.createdWithDate', {
+                      date: formatDate(assistant.createdDate),
+                    })}
                   </span>
                   {lastMessageAt && (
                     <span className="flex items-center gap-1">
                       <PiClock />
-                      {t('assistant.history.lastMessage')}:{' '}
-                      {formatDate(lastMessageAt)}
+                      {t('assistant.history.lastMessageWithDate', {
+                        date: formatDate(lastMessageAt),
+                      })}
                     </span>
                   )}
                   <span className="flex items-center gap-1">

--- a/packages/web/src/pages/MeetingMinutesPage.tsx
+++ b/packages/web/src/pages/MeetingMinutesPage.tsx
@@ -980,6 +980,7 @@ const MeetingMinutesPage: React.FC = () => {
                       }}
                     />
                     {autoGenerate && countdownSeconds > 0 && (
+                      // eslint-disable-next-line @shopify/jsx-no-hardcoded-content
                       <div className="text-sm text-gray-600">
                         {t('meetingMinutes.next_generation_in')}
                         {Math.floor(countdownSeconds / 60)}:

--- a/packages/web/src/pages/PptxGenerationPage.tsx
+++ b/packages/web/src/pages/PptxGenerationPage.tsx
@@ -193,7 +193,7 @@ const PptxGenerationPage: React.FC = () => {
                 {/* Model Selection */}
                 <div>
                   <label className="text-aws-font-color mb-3 block text-sm font-medium">
-                    AI Model
+                    {t('pptx.model.label')}
                   </label>
                   <Select
                     value={selectedModelId}
@@ -204,14 +204,14 @@ const PptxGenerationPage: React.FC = () => {
                     }))}
                   />
                   <p className="text-aws-font-color-secondary mt-2 text-xs">
-                    Select the AI model to generate presentation content
+                    {t('pptx.model.help')}
                   </p>
                 </div>
 
                 {/* Slide Count */}
                 <div>
                   <label className="text-aws-font-color mb-3 block text-sm font-medium">
-                    {t('pptx.slideCount.label')}: {slideCount}
+                    {t('pptx.slideCount.labelWithCount', { count: slideCount })}
                   </label>
                   <Slider
                     value={slideCount}
@@ -222,7 +222,9 @@ const PptxGenerationPage: React.FC = () => {
                     className="w-full"
                   />
                   <div className="text-aws-font-color-secondary mt-1 flex justify-between text-xs">
+                    {/* eslint-disable-next-line @shopify/jsx-no-hardcoded-content */}
                     <span>1</span>
+                    {/* eslint-disable-next-line @shopify/jsx-no-hardcoded-content */}
                     <span>20</span>
                   </div>
                 </div>
@@ -344,7 +346,8 @@ const PptxGenerationPage: React.FC = () => {
                           {example.title}
                         </h4>
                         <p className="text-aws-font-color-secondary mt-1 text-xs">
-                          {example.content.slice(0, 100)}...
+                          {example.content.slice(0, 100)}
+                          {t('common.ellipsis')}
                         </p>
                       </button>
                     ))}


### PR DESCRIPTION
## Summary
- ESLint の `@shopify/jsx-no-hardcoded-content` 警告をすべて解消
- ハードコードされた文字列を `t()` 翻訳関数に置き換え
- 5言語（ja, en, th, zh, vi）の翻訳ファイルに新規キーを追加
- 言語非依存の文字（コロン、括弧、数字、省略記号）には eslint-disable コメントを追加

## Test plan
- [ ] `npm -w packages/web run lint` で `jsx-no-hardcoded-content` 警告が0件であることを確認
- [ ] 各コンポーネントが正常に表示されることを確認
- [ ] 多言語切り替えで翻訳が正しく適用されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)