### PR TITLE
🔧 chore: disable ESLint i18nhelper/no-jp-comment rule

### DIFF
--- a/packages/eslint-config-shared/base.cjs
+++ b/packages/eslint-config-shared/base.cjs
@@ -23,7 +23,6 @@ const typescriptConfig = {
     ...typescriptPlugin.configs.recommended.rules,
     '@typescript-eslint/no-unused-vars': 'off',
     'i18nhelper/no-jp-string': 'warn',
-    'i18nhelper/no-jp-comment': 'warn',
   },
 };
 


### PR DESCRIPTION
## Summary
- ESLintの`i18nhelper/no-jp-comment`ルールを無効化
- 日本語コメントは許可し、翻訳対象は文字列リテラル（`no-jp-string`）のみに限定

## Background
コード内のコメントは開発者向けであり、ユーザーに表示されるものではないため、日本語のままでも問題ないと判断しました。i18n対応が必要なのはUIに表示される文字列リテラルのみです。

## Changes
`packages/eslint-config-shared/base.cjs` から以下のルールを削除：
```diff
- 'i18nhelper/no-jp-comment': 'warn',
```

## Test plan
- [x] `npm run lint` が正常に完了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)