### PR TITLE
🚨 fix: ESLint @typescript-eslint/no-explicit-any 警告をすべて修正

### DIFF
--- a/packages/web/src/components/PptxTemplateUploader.tsx
+++ b/packages/web/src/components/PptxTemplateUploader.tsx
@@ -88,8 +88,12 @@ const PptxTemplateUploader: React.FC<PptxTemplateUploaderProps> = ({
 
       await onUpload(file, templateData);
       onClose();
-    } catch (err: any) {
-      setError(err.message || t('pptx.upload.failed'));
+    } catch (err: unknown) {
+      if (err instanceof Error) {
+        setError(err.message || t('pptx.upload.failed'));
+      } else {
+        setError(t('pptx.upload.failed'));
+      }
     } finally {
       setIsUploading(false);
     }

--- a/packages/web/src/components/UserInviteDialog.tsx
+++ b/packages/web/src/components/UserInviteDialog.tsx
@@ -229,25 +229,21 @@ const UserInviteDialog: React.FC<UserInviteDialogProps> = ({
         return;
       }
 
-      try {
-        // First, validate domains
-        const domainValidation = await validateDomains(emails);
+      // First, validate domains
+      const domainValidation = await validateDomains(emails);
 
-        // Store pending invitation
-        setPendingInvitation({ emails, sendEmail });
+      // Store pending invitation
+      setPendingInvitation({ emails, sendEmail });
 
-        if (domainValidation.hasAnyUnconfiguredDomains) {
-          // Show warning before proceeding
-          setUnconfiguredEmails(domainValidation.unconfiguredEmails);
-          setShowUnconfiguredWarning(true);
-          // Don't resume monitoring yet - wait for user decision
-        } else {
-          // No unconfigured domains, proceed directly
-          await performInvitation(emails, sendEmail);
-          // performInvitation will handle resuming
-        }
-      } catch (validationError: unknown) {
-        throw validationError;
+      if (domainValidation.hasAnyUnconfiguredDomains) {
+        // Show warning before proceeding
+        setUnconfiguredEmails(domainValidation.unconfiguredEmails);
+        setShowUnconfiguredWarning(true);
+        // Don't resume monitoring yet - wait for user decision
+      } else {
+        // No unconfigured domains, proceed directly
+        await performInvitation(emails, sendEmail);
+        // performInvitation will handle resuming
       }
     } catch (error: unknown) {
       console.error('Failed to prepare invitation:', error);
@@ -263,12 +259,12 @@ const UserInviteDialog: React.FC<UserInviteDialogProps> = ({
 
       // Use the specific error message if available, otherwise use generic message
       let errorMessage = t('adminPortal.invite.errors.invitationFailed');
-      if (error instanceof Error) {
-        errorMessage = error.message;
-      } else if (isAxiosError<{ message?: string }>(error)) {
+      if (isAxiosError<{ message?: string }>(error)) {
         errorMessage =
           error.response?.data?.message ||
           t('adminPortal.invite.errors.invitationFailed');
+      } else if (error instanceof Error) {
+        errorMessage = error.message;
       }
 
       setError(errorMessage);

--- a/packages/web/src/components/UserInviteDialog.tsx
+++ b/packages/web/src/components/UserInviteDialog.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { PiX, PiUserPlus, PiEnvelope, PiUpload } from 'react-icons/pi';
 import { useTranslation } from 'react-i18next';
+import { isAxiosError } from 'axios';
 import Button from './Button';
 import InputText from './InputText';
 import Textarea from './Textarea';
@@ -159,12 +160,16 @@ const UserInviteDialog: React.FC<UserInviteDialogProps> = ({
       if (onInviteSuccess) {
         onInviteSuccess();
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Failed to invite users:', error);
-      setError(
-        error.response?.data?.message ||
-          t('adminPortal.invite.errors.invitationFailed')
-      );
+      if (isAxiosError<{ message?: string }>(error)) {
+        setError(
+          error.response?.data?.message ||
+            t('adminPortal.invite.errors.invitationFailed')
+        );
+      } else {
+        setError(t('adminPortal.invite.errors.invitationFailed'));
+      }
     } finally {
       setLoading(false);
     }
@@ -177,26 +182,29 @@ const UserInviteDialog: React.FC<UserInviteDialogProps> = ({
       });
 
       return response.data;
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Failed to validate domains:', error);
 
       // Provide more specific error messages for domain validation failures
-      if (error.response?.status === 403) {
-        throw new Error(t('adminPortal.invite.errors.noPermission'));
-      } else if (error.response?.status === 409) {
-        throw new Error(t('adminPortal.invite.errors.roleRevoked'));
-      } else if (error.response?.status === 400) {
-        const errorData = error.response?.data;
-        if (errorData?.invalidEmails?.length > 0) {
+      if (isAxiosError<{ invalidEmails?: string[]; message?: string }>(error)) {
+        if (error.response?.status === 403) {
+          throw new Error(t('adminPortal.invite.errors.noPermission'));
+        } else if (error.response?.status === 409) {
+          throw new Error(t('adminPortal.invite.errors.roleRevoked'));
+        } else if (error.response?.status === 400) {
+          const errorData = error.response?.data;
+          const invalidEmails = errorData?.invalidEmails;
+          if (invalidEmails && invalidEmails.length > 0) {
+            throw new Error(
+              t('adminPortal.invite.errors.invalidEmails', {
+                emails: invalidEmails.join(', '),
+              })
+            );
+          }
           throw new Error(
-            t('adminPortal.invite.errors.invalidEmails', {
-              emails: errorData.invalidEmails.join(', '),
-            })
+            errorData?.message || t('adminPortal.invite.errors.invalidRequest')
           );
         }
-        throw new Error(
-          errorData?.message || t('adminPortal.invite.errors.invalidRequest')
-        );
       }
 
       // Let role monitor handle privilege revocation errors to avoid conflicts
@@ -238,24 +246,30 @@ const UserInviteDialog: React.FC<UserInviteDialogProps> = ({
           await performInvitation(emails, sendEmail);
           // performInvitation will handle resuming
         }
-      } catch (validationError: any) {
+      } catch (validationError: unknown) {
         throw validationError;
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Failed to prepare invitation:', error);
 
       // Check for specific admin privilege errors and let role monitor handle them
-      if (error.response?.status === 403 || error.response?.status === 409) {
-        // Let the role monitor handle privilege revocation - just close dialog
-        handleClose();
-        return;
+      if (isAxiosError(error)) {
+        if (error.response?.status === 403 || error.response?.status === 409) {
+          // Let the role monitor handle privilege revocation - just close dialog
+          handleClose();
+          return;
+        }
       }
 
       // Use the specific error message if available, otherwise use generic message
-      const errorMessage =
-        error.message ||
-        error.response?.data?.message ||
-        t('adminPortal.invite.errors.invitationFailed');
+      let errorMessage = t('adminPortal.invite.errors.invitationFailed');
+      if (error instanceof Error) {
+        errorMessage = error.message;
+      } else if (isAxiosError<{ message?: string }>(error)) {
+        errorMessage =
+          error.response?.data?.message ||
+          t('adminPortal.invite.errors.invitationFailed');
+      }
 
       setError(errorMessage);
     }

--- a/packages/web/src/hooks/usePptxGeneration.ts
+++ b/packages/web/src/hooks/usePptxGeneration.ts
@@ -1,4 +1,5 @@
 import { useState, useCallback } from 'react';
+import { isAxiosError } from 'axios';
 import useHttp from './useHttp';
 import {
   PptxGeneration,
@@ -23,8 +24,12 @@ export const usePptxGeneration = () => {
           input
         );
         return response.data;
-      } catch (err: any) {
-        setError(err.response?.data?.detail || 'Failed to generate PPTX');
+      } catch (err: unknown) {
+        if (isAxiosError<{ detail?: string }>(err)) {
+          setError(err.response?.data?.detail || 'Failed to generate PPTX');
+        } else {
+          setError('Failed to generate PPTX');
+        }
         return null;
       } finally {
         setIsGenerating(false);
@@ -40,10 +45,14 @@ export const usePptxGeneration = () => {
           `pptx/generation/${generationId}`
         );
         return response.data ?? null;
-      } catch (err: any) {
-        setError(
-          err.response?.data?.detail || 'Failed to check generation status'
-        );
+      } catch (err: unknown) {
+        if (isAxiosError<{ detail?: string }>(err)) {
+          setError(
+            err.response?.data?.detail || 'Failed to check generation status'
+          );
+        } else {
+          setError('Failed to check generation status');
+        }
         return null;
       }
     },
@@ -61,8 +70,12 @@ export const usePptxGeneration = () => {
         if (response.data?.download_url) {
           window.open(response.data.download_url, '_blank');
         }
-      } catch (err: any) {
-        setError(err.response?.data?.detail || 'Failed to download PPTX');
+      } catch (err: unknown) {
+        if (isAxiosError<{ detail?: string }>(err)) {
+          setError(err.response?.data?.detail || 'Failed to download PPTX');
+        } else {
+          setError('Failed to download PPTX');
+        }
       }
     },
     [http]
@@ -78,8 +91,12 @@ export const usePptxGeneration = () => {
           `pptx/generation?limit=${limit}&offset=${offset}`
         );
         return response.data ?? null;
-      } catch (err: any) {
-        setError(err.response?.data?.detail || 'Failed to list generations');
+      } catch (err: unknown) {
+        if (isAxiosError<{ detail?: string }>(err)) {
+          setError(err.response?.data?.detail || 'Failed to list generations');
+        } else {
+          setError('Failed to list generations');
+        }
         return null;
       }
     },

--- a/packages/web/src/hooks/usePptxGeneration.ts
+++ b/packages/web/src/hooks/usePptxGeneration.ts
@@ -27,6 +27,8 @@ export const usePptxGeneration = () => {
       } catch (err: unknown) {
         if (isAxiosError<{ detail?: string }>(err)) {
           setError(err.response?.data?.detail || 'Failed to generate PPTX');
+        } else if (err instanceof Error) {
+          setError(err.message || 'Failed to generate PPTX');
         } else {
           setError('Failed to generate PPTX');
         }
@@ -50,6 +52,8 @@ export const usePptxGeneration = () => {
           setError(
             err.response?.data?.detail || 'Failed to check generation status'
           );
+        } else if (err instanceof Error) {
+          setError(err.message || 'Failed to check generation status');
         } else {
           setError('Failed to check generation status');
         }
@@ -73,6 +77,8 @@ export const usePptxGeneration = () => {
       } catch (err: unknown) {
         if (isAxiosError<{ detail?: string }>(err)) {
           setError(err.response?.data?.detail || 'Failed to download PPTX');
+        } else if (err instanceof Error) {
+          setError(err.message || 'Failed to download PPTX');
         } else {
           setError('Failed to download PPTX');
         }
@@ -94,6 +100,8 @@ export const usePptxGeneration = () => {
       } catch (err: unknown) {
         if (isAxiosError<{ detail?: string }>(err)) {
           setError(err.response?.data?.detail || 'Failed to list generations');
+        } else if (err instanceof Error) {
+          setError(err.message || 'Failed to list generations');
         } else {
           setError('Failed to list generations');
         }

--- a/packages/web/src/hooks/usePptxTemplates.ts
+++ b/packages/web/src/hooks/usePptxTemplates.ts
@@ -31,6 +31,8 @@ export const usePptxTemplates = () => {
     } catch (err: unknown) {
       if (isAxiosError<{ detail?: string }>(err)) {
         setError(err.response?.data?.detail || 'Failed to load templates');
+      } else if (err instanceof Error) {
+        setError(err.message || 'Failed to load templates');
       } else {
         setError('Failed to load templates');
       }
@@ -100,6 +102,8 @@ export const usePptxTemplates = () => {
     } catch (err: unknown) {
       if (isAxiosError<{ detail?: string }>(err)) {
         setError(err.response?.data?.detail || 'Failed to upload template');
+      } else if (err instanceof Error) {
+        setError(err.message || 'Failed to upload template');
       } else {
         setError('Failed to upload template');
       }
@@ -120,6 +124,8 @@ export const usePptxTemplates = () => {
     } catch (err: unknown) {
       if (isAxiosError<{ detail?: string }>(err)) {
         setError(err.response?.data?.detail || 'Failed to delete template');
+      } else if (err instanceof Error) {
+        setError(err.message || 'Failed to delete template');
       } else {
         setError('Failed to delete template');
       }

--- a/packages/web/src/hooks/usePptxTemplates.ts
+++ b/packages/web/src/hooks/usePptxTemplates.ts
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { isAxiosError } from 'axios';
 import useHttp from './useHttp';
 import {
   PptxTemplate,
@@ -27,8 +28,12 @@ export const usePptxTemplates = () => {
       if (response.data?.templates) {
         setTemplates(response.data.templates);
       }
-    } catch (err: any) {
-      setError(err.response?.data?.detail || 'Failed to load templates');
+    } catch (err: unknown) {
+      if (isAxiosError<{ detail?: string }>(err)) {
+        setError(err.response?.data?.detail || 'Failed to load templates');
+      } else {
+        setError('Failed to load templates');
+      }
     } finally {
       setIsLoading(false);
     }
@@ -92,8 +97,12 @@ export const usePptxTemplates = () => {
       );
 
       return true;
-    } catch (err: any) {
-      setError(err.response?.data?.detail || 'Failed to upload template');
+    } catch (err: unknown) {
+      if (isAxiosError<{ detail?: string }>(err)) {
+        setError(err.response?.data?.detail || 'Failed to upload template');
+      } else {
+        setError('Failed to upload template');
+      }
       return false;
     }
   };
@@ -108,8 +117,12 @@ export const usePptxTemplates = () => {
       setTemplates((prev) => prev.filter((t) => t.template_id !== templateId));
 
       return true;
-    } catch (err: any) {
-      setError(err.response?.data?.detail || 'Failed to delete template');
+    } catch (err: unknown) {
+      if (isAxiosError<{ detail?: string }>(err)) {
+        setError(err.response?.data?.detail || 'Failed to delete template');
+      } else {
+        setError('Failed to delete template');
+      }
       return false;
     }
   };

--- a/packages/web/src/hooks/useRoleMonitor.ts
+++ b/packages/web/src/hooks/useRoleMonitor.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { toast } from 'sonner';
+import { isAxiosError } from 'axios';
 import useHttp from './useHttp';
 import { performLogoutAndReload, isRoleMismatchError } from '../utils/auth';
 
@@ -128,7 +129,7 @@ const useRoleMonitor = (config: RoleMonitorConfig = {}) => {
           clearInterval(intervalRef.current);
           intervalRef.current = null;
         }
-      } catch (error: any) {
+      } catch (error: unknown) {
         // Handle role mismatch errors
         if (isRoleMismatchError(error)) {
           if (lastKnownAdminStatusRef.current === true) {
@@ -140,14 +141,12 @@ const useRoleMonitor = (config: RoleMonitorConfig = {}) => {
         }
 
         // For non-admin users, 403 is expected
+        const status = isAxiosError(error) ? error.response?.status : undefined;
         setState((prev) => ({
           ...prev,
           isAdmin: false,
           isLoading: false,
-          error:
-            error.response?.status === 403
-              ? null
-              : 'Failed to verify admin status',
+          error: status === 403 ? null : 'Failed to verify admin status',
           tenantId: null,
           username: null,
         }));
@@ -228,9 +227,10 @@ const useRoleMonitor = (config: RoleMonitorConfig = {}) => {
           window.location.reload();
         }
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       // Handle 403/409 errors indicating role revocation
-      if (error?.response?.status === 403 || error?.response?.status === 409) {
+      const status = isAxiosError(error) ? error.response?.status : undefined;
+      if (status === 403 || status === 409) {
         if (lastKnownAdminStatusRef.current === true) {
           await handleRoleMismatch(
             'Admin privileges likely revoked (403/409 error)'

--- a/packages/web/src/utils/auth.ts
+++ b/packages/web/src/utils/auth.ts
@@ -21,17 +21,29 @@ export const performLogoutAndReload = async (
   }
 };
 
+interface ErrorWithResponse {
+  response?: {
+    status?: number;
+    data?: {
+      roleChanged?: boolean;
+      refreshRequired?: boolean;
+      message?: string;
+    };
+  };
+}
+
 /**
  * Checks if an error response indicates role mismatch or permission issues
  */
-export const isRoleMismatchError = (error: any): boolean => {
-  if (error?.response?.status === 409) {
-    const responseData = error.response.data;
-    return responseData?.roleChanged && responseData?.refreshRequired;
+export const isRoleMismatchError = (error: unknown): boolean => {
+  const err = error as ErrorWithResponse;
+  if (err?.response?.status === 409) {
+    const responseData = err.response.data;
+    return !!(responseData?.roleChanged && responseData?.refreshRequired);
   }
 
-  if (error?.response?.status === 403) {
-    const errorMessage = error.response.data?.message || '';
+  if (err?.response?.status === 403) {
+    const errorMessage = err.response.data?.message || '';
     return (
       errorMessage.includes('admin') ||
       errorMessage.includes('privilege') ||

--- a/packages/web/src/utils/auth.ts
+++ b/packages/web/src/utils/auth.ts
@@ -1,4 +1,5 @@
 import { signOut } from 'aws-amplify/auth';
+import { isAxiosError } from 'axios';
 
 /**
  * Centralized logout utility for handling user authentication termination
@@ -21,29 +22,27 @@ export const performLogoutAndReload = async (
   }
 };
 
-interface ErrorWithResponse {
-  response?: {
-    status?: number;
-    data?: {
-      roleChanged?: boolean;
-      refreshRequired?: boolean;
-      message?: string;
-    };
-  };
+interface RoleMismatchData {
+  roleChanged?: boolean;
+  refreshRequired?: boolean;
+  message?: string;
 }
 
 /**
  * Checks if an error response indicates role mismatch or permission issues
  */
 export const isRoleMismatchError = (error: unknown): boolean => {
-  const err = error as ErrorWithResponse;
-  if (err?.response?.status === 409) {
-    const responseData = err.response.data;
+  if (!isAxiosError<RoleMismatchData>(error)) {
+    return false;
+  }
+
+  if (error.response?.status === 409) {
+    const responseData = error.response.data;
     return !!(responseData?.roleChanged && responseData?.refreshRequired);
   }
 
-  if (err?.response?.status === 403) {
-    const errorMessage = err.response.data?.message || '';
+  if (error.response?.status === 403) {
+    const errorMessage = error.response.data?.message || '';
     return (
       errorMessage.includes('admin') ||
       errorMessage.includes('privilege') ||
@@ -54,6 +53,13 @@ export const isRoleMismatchError = (error: unknown): boolean => {
   return false;
 };
 
+interface AuthorizationErrorData {
+  code?: string;
+  message?: string;
+  error?: string;
+  details?: string;
+}
+
 /**
  * Checks if an error response indicates an authorization failure
  * This includes IP restriction violations, general authorization denials, etc.
@@ -62,18 +68,26 @@ export const isRoleMismatchError = (error: unknown): boolean => {
  * IMPORTANT: Resource-level permission denials (e.g., accessing another user's assistant)
  * should use specific error codes like ASSISTANT_ACCESS_DENIED to avoid triggering sign-out
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const isAuthorizationError = (error: any): boolean => {
+export const isAuthorizationError = (error: unknown): boolean => {
+  if (!isAxiosError<AuthorizationErrorData | string>(error)) {
+    return false;
+  }
+
   // 403 Forbidden - typically indicates authorization failure
-  if (error?.response?.status === 403) {
+  if (error.response?.status === 403) {
     // Extract error data from response
     const responseData = error.response.data;
-    const errorCode = responseData?.code || '';
+    const errorCode =
+      typeof responseData === 'object' ? responseData?.code || '' : '';
     const errorMessage = (
-      responseData?.message ||
-      responseData?.error ||
-      responseData?.details ||
-      (typeof responseData === 'string' ? responseData : '')
+      typeof responseData === 'object'
+        ? responseData?.message ||
+          responseData?.error ||
+          responseData?.details ||
+          ''
+        : typeof responseData === 'string'
+          ? responseData
+          : ''
     ).toLowerCase();
 
     // Skip resource-level permission denials that have specific error codes


### PR DESCRIPTION
## Summary
- ESLint の `@typescript-eslint/no-explicit-any` 警告（15件）をすべて修正
- `catch (err: any)` を `catch (err: unknown)` に変更し、`isAxiosError` 型ガードまたは `instanceof Error` を使用した型安全なエラーハンドリングに修正
- `auth.ts` の `isRoleMismatchError` 関数のパラメータ型を `any` から `unknown` に変更

## Test plan
- [ ] `npm run lint` で `@typescript-eslint/no-explicit-any` 警告が 0 件であることを確認
- [ ] `npx tsc --noEmit -p packages/web/tsconfig.json` で TypeScript エラーがないことを確認
- [ ] エラーハンドリングが正常に動作することを確認（PPTX生成、テンプレート操作、ユーザー招待など）

🤖 Generated with [Claude Code](https://claude.com/claude-code)