### PR TITLE
✨  保護者メールアドレスの自己入力防止バリデーション追加

### DIFF
--- a/packages/cdk/lambda/billing/user-api/subscriptions/sendCheckoutLinkToParent.ts
+++ b/packages/cdk/lambda/billing/user-api/subscriptions/sendCheckoutLinkToParent.ts
@@ -462,6 +462,18 @@ export const handler = async (
       });
     }
 
+    // アカウントメールアドレスと同一でないかチェック
+    if (childEmail && parentEmail.toLowerCase() === childEmail.toLowerCase()) {
+      return badRequest400Response({
+        message:
+          '保護者のメールアドレスにはご自身のアカウントとは異なるメールアドレスを入力してください',
+        code: 'SAME_AS_USER_EMAIL',
+        details: {
+          field: 'parentEmail',
+        },
+      });
+    }
+
     console.log('Creating checkout session for parental control:', {
       planId,
       parentEmail,

--- a/packages/cdk/lambda/billing/user-api/subscriptions/sendCheckoutLinkToParent.ts
+++ b/packages/cdk/lambda/billing/user-api/subscriptions/sendCheckoutLinkToParent.ts
@@ -19,7 +19,10 @@ import {
 } from '@aws-sdk/client-dynamodb';
 import { randomUUID } from 'crypto';
 import { getTenantId } from '../../../utils/tenantUtils';
-import { getUserIdFromCognitoEvent, getUserEmailFromCognitoEvent } from '../../../utils/cognitoUtils';
+import {
+  getUserIdFromCognitoEvent,
+  getUserEmailFromCognitoEvent,
+} from '../../../utils/cognitoUtils';
 import { invokeDataAccessFunction } from '../../utils/dataAccessClient';
 import { Plan } from '../../data-access/repositories/types';
 import {
@@ -343,11 +346,16 @@ async function invalidatePendingCheckoutRequests(
     const pendingRequests = queryResult.Items || [];
 
     if (pendingRequests.length === 0) {
-      console.log('No pending checkout requests to invalidate for user:', userId);
+      console.log(
+        'No pending checkout requests to invalidate for user:',
+        userId
+      );
       return;
     }
 
-    console.log(`Found ${pendingRequests.length} pending checkout request(s) to invalidate`);
+    console.log(
+      `Found ${pendingRequests.length} pending checkout request(s) to invalidate`
+    );
 
     // 各保留中リクエストを無効化
     for (const item of pendingRequests) {
@@ -361,7 +369,8 @@ async function invalidatePendingCheckoutRequests(
         new UpdateItemCommand({
           TableName: PENDING_PARENTAL_CHECKOUTS_TABLE_NAME,
           Key: { requestId: { S: requestId } },
-          UpdateExpression: 'SET #status = :cancelled, cancelledAt = :cancelledAt',
+          UpdateExpression:
+            'SET #status = :cancelled, cancelledAt = :cancelledAt',
           ExpressionAttributeNames: {
             '#status': 'status',
           },
@@ -381,12 +390,18 @@ async function invalidatePendingCheckoutRequests(
           console.log('Expired Stripe checkout session:', checkoutSessionId);
         } catch (stripeError) {
           // セッションが既に期限切れの場合などはエラーを無視
-          console.log('Could not expire Stripe session (may already be expired):', checkoutSessionId, stripeError);
+          console.log(
+            'Could not expire Stripe session (may already be expired):',
+            checkoutSessionId,
+            stripeError
+          );
         }
       }
     }
 
-    console.log(`Successfully invalidated ${pendingRequests.length} pending checkout request(s)`);
+    console.log(
+      `Successfully invalidated ${pendingRequests.length} pending checkout request(s)`
+    );
   } catch (error) {
     // 無効化の失敗は致命的ではないため、ログに記録して続行
     console.error('Error invalidating pending checkout requests:', error);
@@ -465,8 +480,7 @@ export const handler = async (
     // アカウントメールアドレスと同一でないかチェック
     if (childEmail && parentEmail.toLowerCase() === childEmail.toLowerCase()) {
       return badRequest400Response({
-        message:
-          '保護者のメールアドレスにはご自身のアカウントとは異なるメールアドレスを入力してください',
+        message: 'ご自身のアカウントとは異なるメールアドレスを入力してください',
         code: 'SAME_AS_USER_EMAIL',
         details: {
           field: 'parentEmail',
@@ -636,7 +650,11 @@ export const handler = async (
       childEmail
     );
 
-    await sendEmail(parentEmail, emailContent.subject, emailContent.htmlContent);
+    await sendEmail(
+      parentEmail,
+      emailContent.subject,
+      emailContent.htmlContent
+    );
 
     console.log('Parent payment request email sent:', {
       sessionId: session.id,

--- a/packages/cdk/lambda/billing/user-api/subscriptions/sendPlanChangeLinkToParent.ts
+++ b/packages/cdk/lambda/billing/user-api/subscriptions/sendPlanChangeLinkToParent.ts
@@ -551,11 +551,16 @@ async function invalidatePendingPlanChangeRequests(
     const pendingRequests = queryResult.Items || [];
 
     if (pendingRequests.length === 0) {
-      console.log('No pending plan change requests to invalidate for user:', userId);
+      console.log(
+        'No pending plan change requests to invalidate for user:',
+        userId
+      );
       return;
     }
 
-    console.log(`Found ${pendingRequests.length} pending plan change request(s) to invalidate`);
+    console.log(
+      `Found ${pendingRequests.length} pending plan change request(s) to invalidate`
+    );
 
     // StripeサブスクリプションIDを収集（重複排除）
     const stripeSubscriptionIds = new Set<string>();
@@ -572,7 +577,8 @@ async function invalidatePendingPlanChangeRequests(
         new UpdateItemCommand({
           TableName: PENDING_PLAN_CHANGES_TABLE_NAME,
           Key: { requestId: { S: requestId } },
-          UpdateExpression: 'SET #status = :cancelled, cancelledAt = :cancelledAt',
+          UpdateExpression:
+            'SET #status = :cancelled, cancelledAt = :cancelledAt',
           ExpressionAttributeNames: {
             '#status': 'status',
           },
@@ -600,7 +606,9 @@ async function invalidatePendingPlanChangeRequests(
       console.log('Marked subscription for metadata cleanup:', subscriptionId);
     });
 
-    console.log(`Successfully invalidated ${pendingRequests.length} pending plan change request(s)`);
+    console.log(
+      `Successfully invalidated ${pendingRequests.length} pending plan change request(s)`
+    );
   } catch (error) {
     // 無効化の失敗は致命的ではないため、ログに記録して続行
     console.error('Error invalidating pending plan change requests:', error);
@@ -679,6 +687,18 @@ export const handler = async (
       return badRequest400Response({
         message: '有効なメールアドレスを入力してください',
         code: 'INVALID_EMAIL',
+        details: {
+          field: 'parentEmail',
+        },
+      });
+    }
+
+    // アカウントメールアドレスと同一でないかチェック
+    if (childEmail && parentEmail.toLowerCase() === childEmail.toLowerCase()) {
+      return badRequest400Response({
+        message:
+          '保護者のメールアドレスにはご自身のアカウントとは異なるメールアドレスを入力してください',
+        code: 'SAME_AS_USER_EMAIL',
         details: {
           field: 'parentEmail',
         },

--- a/packages/cdk/lambda/billing/user-api/subscriptions/sendPlanChangeLinkToParent.ts
+++ b/packages/cdk/lambda/billing/user-api/subscriptions/sendPlanChangeLinkToParent.ts
@@ -696,8 +696,7 @@ export const handler = async (
     // アカウントメールアドレスと同一でないかチェック
     if (childEmail && parentEmail.toLowerCase() === childEmail.toLowerCase()) {
       return badRequest400Response({
-        message:
-          '保護者のメールアドレスにはご自身のアカウントとは異なるメールアドレスを入力してください',
+        message: 'ご自身のアカウントとは異なるメールアドレスを入力してください',
         code: 'SAME_AS_USER_EMAIL',
         details: {
           field: 'parentEmail',


### PR DESCRIPTION
## Summary
- 保護者向け決済リンク送信時に、保護者メールアドレスがユーザー自身のアカウントメールアドレスと同一でないかチェックするバリデーションを追加
- チェックアウトリンク送信（`sendCheckoutLinkToParent`）とプラン変更リンク送信（`sendPlanChangeLinkToParent`）の両方に適用

## 変更内容
- `parentEmail` と `childEmail` が同一（大文字小文字を無視して比較）の場合、エラーコード `SAME_AS_USER_EMAIL` で400エラーを返す
- エラーメッセージ: 「保護者のメールアドレスにはご自身のアカウントとは異なるメールアドレスを入力してください」

## Test plan
- [ ] チェックアウトリンク送信で自分自身のメールアドレスを入力した場合にエラーになることを確認
- [ ] プラン変更リンク送信で自分自身のメールアドレスを入力した場合にエラーになることを確認
- [ ] 異なるメールアドレスを入力した場合は正常に送信されることを確認
