### PR TITLE
:bug: fix(auth): メタデータフィールド名の統一

### DIFF
--- a/packages/cdk/lambda/getUserMetadata.ts
+++ b/packages/cdk/lambda/getUserMetadata.ts
@@ -16,8 +16,11 @@ const docClient = DynamoDBDocumentClient.from(dynamoClient);
 const USER_REGISTRATION_METADATA_TABLE_NAME =
   process.env.USER_REGISTRATION_METADATA_TABLE_NAME!;
 
+type MetadataValue = string | boolean;
+type UserMetadata = Record<string, MetadataValue>;
+
 interface GetUserMetadataResponse {
-  metadata: Record<string, string>;
+  metadata: UserMetadata;
 }
 
 export const handler = async (
@@ -56,7 +59,7 @@ export const handler = async (
       })
     );
 
-    const metadata = (result.Item?.metadata as Record<string, string>) || {};
+    const metadata = (result.Item?.metadata as UserMetadata) || {};
 
     return ok200Response<GetUserMetadataResponse>({ metadata });
   } catch (error) {

--- a/packages/cdk/lambda/putUserMetadata.ts
+++ b/packages/cdk/lambda/putUserMetadata.ts
@@ -25,14 +25,17 @@ const USER_REGISTRATION_METADATA_TABLE_NAME =
 
 const MAX_METADATA_SIZE_BYTES = 100 * 1024; // 100KB
 
+type MetadataValue = string | boolean;
+type UserMetadata = Record<string, MetadataValue>;
+
 interface PutUserMetadataRequest {
-  metadata: Record<string, string>;
+  metadata: UserMetadata;
   mode?: 'merge' | 'replace';
 }
 
 interface PutUserMetadataResponse {
   message: string;
-  metadata: Record<string, string>;
+  metadata: UserMetadata;
 }
 
 function validateMetadata(metadata: unknown): string | null {
@@ -47,8 +50,8 @@ function validateMetadata(metadata: unknown): string | null {
     if (typeof key !== 'string' || key.length === 0) {
       return 'metadata keys must be non-empty strings';
     }
-    if (typeof value !== 'string') {
-      return `metadata value for key "${key}" must be a string`;
+    if (typeof value !== 'string' && typeof value !== 'boolean') {
+      return `metadata value for key "${key}" must be a string or boolean`;
     }
   }
 
@@ -112,7 +115,7 @@ export const handler = async (
     const mode = requestBody.mode || 'merge';
     const newMetadata = requestBody.metadata;
 
-    let finalMetadata: Record<string, string>;
+    let finalMetadata: UserMetadata;
 
     if (mode === 'replace') {
       await docClient.send(
@@ -138,7 +141,7 @@ export const handler = async (
       );
 
       const existingMetadata =
-        (existingResult.Item?.metadata as Record<string, string>) || {};
+        (existingResult.Item?.metadata as UserMetadata) || {};
       const prevUpdatedAt =
         (existingResult.Item?.metadataUpdatedAt as string | undefined) ?? null;
       finalMetadata = { ...existingMetadata, ...newMetadata };

--- a/packages/cdk/lambda/saveUserRegistrationMetadata.ts
+++ b/packages/cdk/lambda/saveUserRegistrationMetadata.ts
@@ -23,7 +23,7 @@ export interface UserRegistrationMetadata {
   userId: string;
   registeredAt: string;
   birthdate?: string;
-  clientMetadata?: Record<string, string>;
+  metadata?: Record<string, string>;
 }
 
 /**
@@ -61,11 +61,11 @@ export async function saveUserRegistrationMetadata(
   const { birthdate: _, ...restClientMetadata } = clientMetadata || {};
   const hasRestClientMetadata = Object.keys(restClientMetadata).length > 0;
 
-  const metadata: UserRegistrationMetadata = {
+  const userRegistrationMetadata: UserRegistrationMetadata = {
     userId,
     registeredAt,
     birthdate: birthdate || undefined,
-    clientMetadata: hasRestClientMetadata ? restClientMetadata : undefined,
+    metadata: hasRestClientMetadata ? restClientMetadata : undefined,
   };
 
   try {
@@ -74,15 +74,15 @@ export async function saveUserRegistrationMetadata(
     );
     // PIIをマスクしてログ出力（birthdateは個人情報のため）
     const maskedMetadata = {
-      ...metadata,
-      birthdate: metadata.birthdate ? '****-**-**' : undefined,
+      ...userRegistrationMetadata,
+      birthdate: userRegistrationMetadata.birthdate ? '****-**-**' : undefined,
     };
     console.log('Metadata:', JSON.stringify(maskedMetadata, null, 2));
 
     await docClient.send(
       new PutCommand({
         TableName: USER_REGISTRATION_METADATA_TABLE_NAME,
-        Item: metadata,
+        Item: userRegistrationMetadata,
         ConditionExpression: 'attribute_not_exists(userId)',
       })
     );


### PR DESCRIPTION
## 問題
`saveUserRegistrationMetadata.ts` では `clientMetadata` フィールドを使用していたが、`getUserMetadata.ts` と `putUserMetadata.ts` の API では `metadata` フィールドを使用していました。これにより、フロントエンドから送信された `isNewUser` などのメタデータが正常に保存されていませんでした。

## 解決
フィールド名を `metadata` に統一しました。これにより、フロントエンドからのメタデータ保存が正常に動作するようになりました。

## 変更内容
- `UserRegistrationMetadata` インターフェースで `clientMetadata` を `metadata` に変更
- `saveUserRegistrationMetadata.ts` の保存ロジックで `clientMetadata` を `metadata` に変更
- API との一貫性を確保しました