### PR TITLE
:sparkles: feat(api): メタデータAPIでboolean型をサポート

### DIFF
--- a/packages/cdk/lambda/getUserMetadata.ts
+++ b/packages/cdk/lambda/getUserMetadata.ts
@@ -16,8 +16,11 @@ const docClient = DynamoDBDocumentClient.from(dynamoClient);
 const USER_REGISTRATION_METADATA_TABLE_NAME =
   process.env.USER_REGISTRATION_METADATA_TABLE_NAME!;
 
+type MetadataValue = string | boolean;
+type UserMetadata = Record<string, MetadataValue>;
+
 interface GetUserMetadataResponse {
-  metadata: Record<string, string>;
+  metadata: UserMetadata;
 }
 
 export const handler = async (
@@ -56,7 +59,7 @@ export const handler = async (
       })
     );
 
-    const metadata = (result.Item?.metadata as Record<string, string>) || {};
+    const metadata = (result.Item?.metadata as UserMetadata) || {};
 
     return ok200Response<GetUserMetadataResponse>({ metadata });
   } catch (error) {

--- a/packages/cdk/lambda/putUserMetadata.ts
+++ b/packages/cdk/lambda/putUserMetadata.ts
@@ -25,14 +25,17 @@ const USER_REGISTRATION_METADATA_TABLE_NAME =
 
 const MAX_METADATA_SIZE_BYTES = 100 * 1024; // 100KB
 
+type MetadataValue = string | boolean;
+type UserMetadata = Record<string, MetadataValue>;
+
 interface PutUserMetadataRequest {
-  metadata: Record<string, string>;
+  metadata: UserMetadata;
   mode?: 'merge' | 'replace';
 }
 
 interface PutUserMetadataResponse {
   message: string;
-  metadata: Record<string, string>;
+  metadata: UserMetadata;
 }
 
 function validateMetadata(metadata: unknown): string | null {
@@ -47,8 +50,8 @@ function validateMetadata(metadata: unknown): string | null {
     if (typeof key !== 'string' || key.length === 0) {
       return 'metadata keys must be non-empty strings';
     }
-    if (typeof value !== 'string') {
-      return `metadata value for key "${key}" must be a string`;
+    if (typeof value !== 'string' && typeof value !== 'boolean') {
+      return `metadata value for key "${key}" must be a string or boolean`;
     }
   }
 
@@ -112,7 +115,7 @@ export const handler = async (
     const mode = requestBody.mode || 'merge';
     const newMetadata = requestBody.metadata;
 
-    let finalMetadata: Record<string, string>;
+    let finalMetadata: UserMetadata;
 
     if (mode === 'replace') {
       await docClient.send(
@@ -138,7 +141,7 @@ export const handler = async (
       );
 
       const existingMetadata =
-        (existingResult.Item?.metadata as Record<string, string>) || {};
+        (existingResult.Item?.metadata as UserMetadata) || {};
       const prevUpdatedAt =
         (existingResult.Item?.metadataUpdatedAt as string | undefined) ?? null;
       finalMetadata = { ...existingMetadata, ...newMetadata };


### PR DESCRIPTION
## サマリー
フロントエンドPR (FIXER.TopAnswer.WebApp#222) の変更に対応し、メタデータAPIでboolean型の値をサポートするように更新しました。

## 変更内容
- `getUserMetadata.ts`: レスポンス型を`string | boolean`に対応
- `putUserMetadata.ts`: バリデーションを更新し、boolean型の値を許可

## 対象フィールド
- `isNewUser`
- `tutorialCompleted`
- `welcomeModalShown`
- `customizeEnabled`
- `webSearchEnabled`

## 関連PR
- フロントエンド: FIXER.TopAnswer.WebApp#222