### PR TITLE
:sparkles: feat(auth): IP制限によるサインイン拒否時にエラーメッセージを表示

### DIFF
--- a/packages/web/src/hooks/useRoleMonitor.ts
+++ b/packages/web/src/hooks/useRoleMonitor.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { toast } from 'sonner';
+import { isAxiosError } from 'axios';
 import useHttp from './useHttp';
 import { performLogoutAndReload, isRoleMismatchError } from '../utils/auth';
 
@@ -74,7 +75,7 @@ const useRoleMonitor = (config: RoleMonitorConfig = {}) => {
 
       // Small delay to allow toast to show
       setTimeout(() => {
-        performLogoutAndReload(reason);
+        performLogoutAndReload(reason, 'role_mismatch');
       }, 100);
     },
     [state.isRoleChangeDetected]
@@ -128,7 +129,7 @@ const useRoleMonitor = (config: RoleMonitorConfig = {}) => {
           clearInterval(intervalRef.current);
           intervalRef.current = null;
         }
-      } catch (error: any) {
+      } catch (error: unknown) {
         // Handle role mismatch errors
         if (isRoleMismatchError(error)) {
           if (lastKnownAdminStatusRef.current === true) {
@@ -140,14 +141,12 @@ const useRoleMonitor = (config: RoleMonitorConfig = {}) => {
         }
 
         // For non-admin users, 403 is expected
+        const status = isAxiosError(error) ? error.response?.status : undefined;
         setState((prev) => ({
           ...prev,
           isAdmin: false,
           isLoading: false,
-          error:
-            error.response?.status === 403
-              ? null
-              : 'Failed to verify admin status',
+          error: status === 403 ? null : 'Failed to verify admin status',
           tenantId: null,
           username: null,
         }));
@@ -162,6 +161,7 @@ const useRoleMonitor = (config: RoleMonitorConfig = {}) => {
         isCheckingRef.current = false;
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- checkRoleStatus is used inside setInterval callback and doesn't need to trigger checkAdminStatus re-creation
     [
       api,
       enabled,
@@ -228,9 +228,10 @@ const useRoleMonitor = (config: RoleMonitorConfig = {}) => {
           window.location.reload();
         }
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       // Handle 403/409 errors indicating role revocation
-      if (error?.response?.status === 403 || error?.response?.status === 409) {
+      const status = isAxiosError(error) ? error.response?.status : undefined;
+      if (status === 403 || status === 409) {
         if (lastKnownAdminStatusRef.current === true) {
           await handleRoleMismatch(
             'Admin privileges likely revoked (403/409 error)'


### PR DESCRIPTION
## 概要
IP制限などの理由でサインインが拒否された場合、ユーザーが無言でログインページにリダイレクトされる問題を修正しました。

## 変更内容
- `performLogoutAndReload()` でログアウト前にエラー理由をsessionStorageに保存
- ログインページ読み込み時にエラーを読み取り、トースト通知で表示する `useAuthError` フックを追加
- 全3つの認証コンポーネントにフックを適用
- 5言語（英語、日本語、中国語、タイ語、ベトナム語）の翻訳を追加

## エラーメッセージ
| 種類 | メッセージ |
|------|----------|
| IP制限 | IPアドレス制限によりサインインが拒否されました。許可されたネットワークから接続してください。 |
| 認可エラー | サインインが拒否されました。管理者にお問い合わせください。 |
| 権限変更 | 権限が変更されました。再度サインインしてください。 |

## 技術的詳細
- sessionStorageを使用（タブを閉じると自動クリア）
- エラーは表示後すぐにクリア
- 30秒以上経過したエラーは無視（古いエラーを表示しない）

## テスト方法
1. IP制限が有効なテナントでサインイン
2. 許可されていないIPアドレスからアクセス
3. サインイン後、エラーメッセージがトーストで表示されることを確認