### PR TITLE
🐛  fix(web): チャット編集時のTextareaの視認性を改善

### DIFF
--- a/packages/web/src/components/ChatMessage.tsx
+++ b/packages/web/src/components/ChatMessage.tsx
@@ -375,6 +375,7 @@ const ChatMessage: React.FC<Props> = (props) => {
                   <>
                     {editing ? (
                       <Textarea
+                        className="bg-white text-black"
                         value={editingPrompt}
                         onChange={setEditingPrompt}
                       />


### PR DESCRIPTION
## 概要
チャットメッセージ編集時のTextareaに背景色とテキスト色を明示的に指定し、視認性を改善しました。

## 変更内容
- `ChatMessage.tsx`の編集用Textareaに`className="bg-white text-black"`を追加

## 背景
編集用Textareaのテキストが見えにくくなる問題がありました。

## テスト方法
1. チャットメッセージの編集ボタンをクリック
2. Textareaが白背景・黒文字で表示されることを確認