### PR TITLE
🚨 fix(web): ESLint警告・エラーを修正

### DIFF
--- a/packages/web/src/components/Base64Image.tsx
+++ b/packages/web/src/components/Base64Image.tsx
@@ -19,7 +19,7 @@ const Base64Image: React.FC<Props> = (props) => {
 
   const onClick = useCallback(() => {
     if (props.clickable) {
-      props.onClick ? props.onClick() : null;
+      props.onClick?.();
     }
   }, [props]);
 

--- a/packages/web/src/components/InputText.tsx
+++ b/packages/web/src/components/InputText.tsx
@@ -30,7 +30,7 @@ const InputText: React.FC<Props> = (props) => {
         placeholder={props.placeholder || t('common.enter_text')}
         disabled={props.disabled}
         onChange={(e) => {
-          props.onChange ? props.onChange(e.target.value) : null;
+          props.onChange?.(e.target.value);
         }}
       />
     </div>

--- a/packages/web/src/components/Slider.tsx
+++ b/packages/web/src/components/Slider.tsx
@@ -23,7 +23,7 @@ const Slider: React.FC<Props> = (props) => {
           max={props.max}
           step={props.step || 1}
           onChange={(e) => {
-            props.onChange ? props.onChange(Number(e.target.value)) : null;
+            props.onChange?.(Number(e.target.value));
           }}
         />
         <span className="w-12 text-right text-sm font-medium">

--- a/packages/web/src/components/Writer/selectors/ColorSelector.tsx
+++ b/packages/web/src/components/Writer/selectors/ColorSelector.tsx
@@ -130,12 +130,13 @@ export const ColorSelector = ({ open, onOpenChange }: ColorSelectorProps) => {
               key={name}
               onSelect={() => {
                 editor.commands.unsetColor();
-                name !== t('writer.colors.default') &&
+                if (name !== t('writer.colors.default')) {
                   editor
                     .chain()
                     .focus()
                     .setColor(color || '')
                     .run();
+                }
                 onOpenChange(false);
               }}
               className="hover:bg-accent flex cursor-pointer items-center justify-between px-2 py-1 text-sm">
@@ -160,8 +161,9 @@ export const ColorSelector = ({ open, onOpenChange }: ColorSelectorProps) => {
               key={name}
               onSelect={() => {
                 editor.commands.unsetHighlight();
-                name !== t('writer.colors.default') &&
+                if (name !== t('writer.colors.default')) {
                   editor.chain().focus().setHighlight({ color }).run();
+                }
                 onOpenChange(false);
               }}
               className="hover:bg-accent flex cursor-pointer items-center justify-between px-2 py-1 text-sm">

--- a/packages/web/src/components/Writer/ui/Command.tsx
+++ b/packages/web/src/components/Writer/ui/Command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/packages/web/src/hooks/useRoleMonitor.ts
+++ b/packages/web/src/hooks/useRoleMonitor.ts
@@ -161,6 +161,7 @@ const useRoleMonitor = (config: RoleMonitorConfig = {}) => {
         isCheckingRef.current = false;
       }
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- checkRoleStatus is intentionally excluded to avoid circular dependency
     [
       api,
       enabled,

--- a/packages/web/src/hooks/useRoleMonitor.ts
+++ b/packages/web/src/hooks/useRoleMonitor.ts
@@ -161,7 +161,7 @@ const useRoleMonitor = (config: RoleMonitorConfig = {}) => {
         isCheckingRef.current = false;
       }
     },
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- checkRoleStatus is intentionally excluded to avoid circular dependency
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- checkRoleStatus is used inside setInterval callback and doesn't need to trigger checkAdminStatus re-creation
     [
       api,
       enabled,

--- a/packages/web/src/pages/AssistantChatPage.tsx
+++ b/packages/web/src/pages/AssistantChatPage.tsx
@@ -93,6 +93,7 @@ const AssistantChatPage: React.FC = () => {
       // Update currentChatId when conversationId changes
       setCurrentChatId(conversationId);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- fetchAssistant and fetchMessages are intentionally excluded to avoid infinite loops
   }, [assistantId, conversationId]);
 
   useEffect(() => {

--- a/packages/web/src/pages/AssistantHistoryPage.tsx
+++ b/packages/web/src/pages/AssistantHistoryPage.tsx
@@ -41,10 +41,12 @@ const AssistantHistoryPage: React.FC = () => {
 
   useEffect(() => {
     fetchAssistantsWithMessages();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- intentionally run only on mount
   }, []);
 
   useEffect(() => {
     filterAssistants();
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- filterAssistants is controlled by assistants and searchQuery
   }, [assistants, searchQuery]);
 
   // Polling for assistants with non-final sync status


### PR DESCRIPTION
## Summary

- webパッケージのESLint警告・エラー10件（6エラー、4警告）を修正
- `no-unused-expressions`: 三項演算子/短絡評価をOptional chainingまたはif文に置換
- `no-empty-object-type`: 空のinterfaceをtype aliasに変更
- `react-hooks/exhaustive-deps`: 意図的な依存配列除外にeslint-disableコメント追加

## Test plan

- [ ] `npm -w packages/web run lint` がエラー・警告0で通過することを確認
- [ ] 既存の動作に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)