### PR TITLE
:sparkles: feat(web): モデル機能に基づくファイル添付制限の追加

### DIFF
--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -572,7 +572,10 @@ files:
       The allowed image file size is {{allowedDimensions}} (the uploaded image
       size is {{uploadedDimension}})
     mimeMismatch: "{{fileName}} has a file type that doesn't match its extension."
+    modelNotSupportDoc: '{{fileName}} cannot be sent because {{modelName}} does not support document files.'
+    modelNotSupportImage: '{{fileName}} cannot be sent because {{modelName}} does not support image files.'
     modelNotSupported: This model does not support files.
+    modelNotSupportVideo: '{{fileName}} cannot be sent because {{modelName}} does not support video files.'
     videoCountExceeded: Please limit video files to {{maxCount}} or fewer
   uploadFiles: Upload Files
 flow:

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -517,7 +517,10 @@ files:
       指定可能な画像ファイルのサイズは {{allowedDimensions}} です (アップロードされた画像のサイズ
       {{uploadedDimension}})
     mimeMismatch: '{{fileName}} のファイル形式が不正です。'
+    modelNotSupportDoc: '{{modelName}} はドキュメントファイルに対応していないため、{{fileName}} を送信できません。'
+    modelNotSupportImage: '{{modelName}} は画像ファイルに対応していないため、{{fileName}} を送信できません。'
     modelNotSupported: モデルが対応していません。
+    modelNotSupportVideo: '{{modelName}} は動画ファイルに対応していないため、{{fileName}} を送信できません。'
     videoCountExceeded: 動画数は {{maxCount}} 個以下にしてください。
   uploadFiles: ファイルをアップロード
 flow:

--- a/packages/web/public/locales/translation/th.yaml
+++ b/packages/web/public/locales/translation/th.yaml
@@ -433,7 +433,10 @@ files:
     invalidImageDimension: >-
       ขนาดไฟล์รูปภาพที่อนุญาตคือ {{allowedDimensions}} (ขนาดรูปภาพที่อัปโหลดคือ {{uploadedDimension}})
     mimeMismatch: '{{fileName}} มีประเภทไฟล์ที่ไม่ตรงกับนามสกุล'
+    modelNotSupportDoc: 'ไม่สามารถส่ง {{fileName}} ได้เนื่องจาก {{modelName}} ไม่รองรับไฟล์เอกสาร'
+    modelNotSupportImage: 'ไม่สามารถส่ง {{fileName}} ได้เนื่องจาก {{modelName}} ไม่รองรับไฟล์รูปภาพ'
     modelNotSupported: โมเดลนี้ไม่รองรับไฟล์
+    modelNotSupportVideo: 'ไม่สามารถส่ง {{fileName}} ได้เนื่องจาก {{modelName}} ไม่รองรับไฟล์วิดีโอ'
     videoCountExceeded: 'โปรดจำกัดไฟล์วิดีโอไม่เกิน {{maxCount}} ไฟล์'
   uploadFiles: อัปโหลดไฟล์
 flow:

--- a/packages/web/public/locales/translation/vi.yaml
+++ b/packages/web/public/locales/translation/vi.yaml
@@ -429,7 +429,10 @@ files:
     invalidExtension: '{{fileName}} có đuôi file không được phép. Các đuôi file được phép là {{acceptedExtensions}}.'
     invalidImageDimension: Kích thước file ảnh có thể chỉ định là {{allowedDimensions}} (kích thước ảnh đã tải lên {{uploadedDimension}})
     mimeMismatch: 'Định dạng file của {{fileName}} không đúng.'
+    modelNotSupportDoc: 'Không thể gửi {{fileName}} vì {{modelName}} không hỗ trợ tệp tài liệu.'
+    modelNotSupportImage: 'Không thể gửi {{fileName}} vì {{modelName}} không hỗ trợ tệp hình ảnh.'
     modelNotSupported: Mô hình không hỗ trợ.
+    modelNotSupportVideo: 'Không thể gửi {{fileName}} vì {{modelName}} không hỗ trợ tệp video.'
     videoCountExceeded: Số lượng video phải không quá {{maxCount}} video.
   uploadFiles: Tải lên tập tin
 flow:

--- a/packages/web/public/locales/translation/zh.yaml
+++ b/packages/web/public/locales/translation/zh.yaml
@@ -356,7 +356,10 @@ files:
     invalidExtension: '{{fileName}} 是不允许的扩展名。允许的扩展名为 {{acceptedExtensions}}。'
     invalidImageDimension: 可指定的图像文件尺寸为 {{allowedDimensions}}（上传的图像尺寸为 {{uploadedDimension}}）
     mimeMismatch: '{{fileName}} 的文件格式不正确。'
+    modelNotSupportDoc: '无法发送 {{fileName}}，因为 {{modelName}} 不支持文档文件。'
+    modelNotSupportImage: '无法发送 {{fileName}}，因为 {{modelName}} 不支持图像文件。'
     modelNotSupported: 模型不支持。
+    modelNotSupportVideo: '无法发送 {{fileName}}，因为 {{modelName}} 不支持视频文件。'
     videoCountExceeded: 视频数量不能超过 {{maxCount}} 个。
   uploadFiles: 上传文件
 flow:

--- a/packages/web/src/components/InputChatContent.tsx
+++ b/packages/web/src/components/InputChatContent.tsx
@@ -13,7 +13,7 @@ import {
   PiSlidersHorizontal,
   PiGlobe,
 } from 'react-icons/pi';
-import useFiles from '../hooks/useFiles';
+import useFiles, { ModelFlags } from '../hooks/useFiles';
 import FileCard from './FileCard';
 import { FileLimit } from 'generative-ai-use-cases';
 import { useTranslation } from 'react-i18next';
@@ -34,6 +34,8 @@ type Props = {
   fileUpload?: boolean;
   fileLimit?: FileLimit;
   accept?: string[];
+  modelFlags?: ModelFlags;
+  modelName?: string;
   canStop?: boolean;
   className?: string;
   isCreatingChat?: boolean;
@@ -72,25 +74,25 @@ const InputChatContent: React.FC<Props> = (props) => {
   // When the model is changed, etc., display the error message (do not automatically delete the file)
   useEffect(() => {
     if (props.fileLimit && props.accept) {
-      checkFiles(props.fileLimit, props.accept);
+      checkFiles(props.fileLimit, props.accept, props.modelFlags, props.modelName);
     }
-  }, [checkFiles, props.fileLimit, props.accept]);
+  }, [checkFiles, props.fileLimit, props.accept, props.modelFlags, props.modelName]);
 
   const onChangeFiles = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
     if (files && props.fileLimit && props.accept) {
       // Reflect the file and upload it
-      uploadFiles(Array.from(files), props.fileLimit, props.accept);
+      uploadFiles(Array.from(files), props.fileLimit, props.accept, props.modelFlags, props.modelName);
     }
   };
 
   const deleteFile = useCallback(
     (fileId: string) => {
       if (props.fileLimit && props.accept) {
-        deleteUploadedFile(fileId, props.fileLimit, props.accept);
+        deleteUploadedFile(fileId, props.fileLimit, props.accept, props.modelFlags, props.modelName);
       }
     },
-    [deleteUploadedFile, props.fileLimit, props.accept]
+    [deleteUploadedFile, props.fileLimit, props.accept, props.modelFlags, props.modelName]
   );
   const handlePaste = async (pasteEvent: React.ClipboardEvent) => {
     const fileList = pasteEvent.clipboardData.items || [];
@@ -99,7 +101,7 @@ const InputChatContent: React.FC<Props> = (props) => {
       .map((file) => file.getAsFile() as File);
     if (files.length > 0 && props.fileLimit && props.accept) {
       // Upload the file
-      uploadFiles(Array.from(files), props.fileLimit, props.accept);
+      uploadFiles(Array.from(files), props.fileLimit, props.accept, props.modelFlags, props.modelName);
       // Since the file name is also pasted when the file is pasted, stop the default behavior
       pasteEvent.preventDefault();
     }

--- a/packages/web/src/hooks/useFiles.ts
+++ b/packages/web/src/hooks/useFiles.ts
@@ -6,6 +6,7 @@ import { useCallback } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import i18next from 'i18next';
 import {
+  AcceptedDotExtensions,
   getFileTypeFromMimeType,
   getMimeTypeFromFileHeader,
   validateMimeTypeAndExtension,
@@ -15,17 +16,27 @@ export const extractBaseURL = (url: string) => {
   return url.split(/[?#]/)[0];
 };
 
+export type ModelFlags = {
+  doc?: boolean;
+  image?: boolean;
+  video?: boolean;
+};
+
 const useFilesState = create<{
   uploadFiles: (
     id: string,
     files: File[],
     fileLimit: FileLimit,
-    accept: string[]
+    accept: string[],
+    modelFlags?: ModelFlags,
+    modelName?: string
   ) => Promise<void>;
   checkFiles: (
     id: string,
     fileLimit: FileLimit,
-    accept: string[]
+    accept: string[],
+    modelFlags?: ModelFlags,
+    modelName?: string
   ) => Promise<void>;
   uploadedFilesDict: Record<string, UploadedFileType[]>;
   errorMessagesDict: Record<string, string[]>;
@@ -33,7 +44,9 @@ const useFilesState = create<{
     id: string,
     fileId: string,
     fileLimit: FileLimit,
-    accept: string[]
+    accept: string[],
+    modelFlags?: ModelFlags,
+    modelName?: string
   ) => Promise<boolean>;
   clear: (id: string) => void;
   base64Cache: Record<string, string>;
@@ -104,11 +117,49 @@ const useFilesState = create<{
     });
   };
 
+  // Helper to determine why a file extension is not accepted
+  const getModelNotSupportedErrorKey = (
+    extension: string,
+    modelFlags?: ModelFlags
+  ): string | null => {
+    if (!modelFlags) return null;
+
+    const dotExt = `.${extension.toLowerCase()}`;
+
+    // Check if extension is a doc type but model doesn't support doc
+    if (
+      !modelFlags.doc &&
+      AcceptedDotExtensions.doc.includes(dotExt)
+    ) {
+      return 'files.error.modelNotSupportDoc';
+    }
+
+    // Check if extension is an image type but model doesn't support image
+    if (
+      !modelFlags.image &&
+      AcceptedDotExtensions.image.includes(dotExt)
+    ) {
+      return 'files.error.modelNotSupportImage';
+    }
+
+    // Check if extension is a video type but model doesn't support video
+    if (
+      !modelFlags.video &&
+      AcceptedDotExtensions.video.includes(dotExt)
+    ) {
+      return 'files.error.modelNotSupportVideo';
+    }
+
+    return null;
+  };
+
   // Validated given uploadedFiles, return updated uploadedFiles (no side effect) and errorMessages
   const validateUploadedFiles = async (
     uploadedFiles: UploadedFileType[],
     fileLimit: FileLimit,
-    accept: string[]
+    accept: string[],
+    modelFlags?: ModelFlags,
+    modelName?: string
   ) => {
     let fileCount = 0;
     let imageFileCount = 0;
@@ -128,12 +179,26 @@ const useFilesState = create<{
         if (accept && accept.length === 0) {
           errorMessages.push(i18next.t('files.error.modelNotSupported'));
         } else if (!isFileExtensionAccepted) {
-          errorMessages.push(
-            i18next.t('files.error.invalidExtension', {
-              fileName: uploadedFile.file.name,
-              acceptedExtensions: accept.join(', '),
-            })
+          // Check if this is due to model not supporting the file type
+          const modelErrorKey = getModelNotSupportedErrorKey(
+            extension,
+            modelFlags
           );
+          if (modelErrorKey && modelName) {
+            errorMessages.push(
+              i18next.t(modelErrorKey, {
+                fileName: uploadedFile.file.name,
+                modelName: modelName,
+              })
+            );
+          } else {
+            errorMessages.push(
+              i18next.t('files.error.invalidExtension', {
+                fileName: uploadedFile.file.name,
+                acceptedExtensions: accept.join(', '),
+              })
+            );
+          }
         } else if (!isMimeTypeValid) {
           errorMessages.push(
             i18next.t('files.error.mimeMismatch', {
@@ -238,14 +303,22 @@ const useFilesState = create<{
   const checkFiles = async (
     id: string,
     fileLimit: FileLimit,
-    accept: string[]
+    accept: string[],
+    modelFlags?: ModelFlags,
+    modelName?: string
   ) => {
     // Get current files
     const currentUploadedFiles = get().uploadedFilesDict[id] ?? [];
 
     // Get updated error messages
     const { uploadedFiles: newUploadedFiles, errorMessages } =
-      await validateUploadedFiles(currentUploadedFiles, fileLimit, accept);
+      await validateUploadedFiles(
+        currentUploadedFiles,
+        fileLimit,
+        accept,
+        modelFlags,
+        modelName
+      );
 
     set(
       produce((state) => {
@@ -260,7 +333,9 @@ const useFilesState = create<{
     id: string,
     files: File[],
     fileLimit: FileLimit,
-    accept: string[]
+    accept: string[],
+    modelFlags?: ModelFlags,
+    modelName?: string
   ) => {
     // Get File
     const currentUploadedFiles = get().uploadedFilesDict[id] ?? [];
@@ -274,7 +349,13 @@ const useFilesState = create<{
 
     // Validate File
     const { uploadedFiles: validatedFiles, errorMessages } =
-      await validateUploadedFiles(newUploadedFiles, fileLimit, accept);
+      await validateUploadedFiles(
+        newUploadedFiles,
+        fileLimit,
+        accept,
+        modelFlags,
+        modelName
+      );
 
     // Update zustand to reflect current status to UI
 
@@ -336,7 +417,9 @@ const useFilesState = create<{
     id: string,
     fileId: string,
     fileLimit: FileLimit,
-    accept: string[]
+    accept: string[],
+    modelFlags?: ModelFlags,
+    modelName?: string
   ) => {
     const findTargetIndex = () =>
       get().uploadedFilesDict[id].findIndex((file) => file.id === fileId);
@@ -368,7 +451,7 @@ const useFilesState = create<{
         );
 
         // Refresh error messages
-        await checkFiles(id, fileLimit, accept);
+        await checkFiles(id, fileLimit, accept, modelFlags, modelName);
 
         return true;
       }
@@ -435,11 +518,20 @@ const useFiles = (id: string) => {
   } = useFilesState();
 
   return {
-    uploadFiles: (files: File[], fileLimit: FileLimit, accept: string[]) =>
-      uploadFiles(id, files, fileLimit, accept),
+    uploadFiles: (
+      files: File[],
+      fileLimit: FileLimit,
+      accept: string[],
+      modelFlags?: ModelFlags,
+      modelName?: string
+    ) => uploadFiles(id, files, fileLimit, accept, modelFlags, modelName),
     checkFiles: useCallback(
-      (fileLimit: FileLimit, accept: string[]) =>
-        checkFiles(id, fileLimit, accept),
+      (
+        fileLimit: FileLimit,
+        accept: string[],
+        modelFlags?: ModelFlags,
+        modelName?: string
+      ) => checkFiles(id, fileLimit, accept, modelFlags, modelName),
       [checkFiles, id]
     ),
     errorMessages: errorMessagesDict[id] ?? [],
@@ -448,8 +540,11 @@ const useFiles = (id: string) => {
     deleteUploadedFile: (
       fileId: string,
       fileLimit: FileLimit,
-      accept: string[]
-    ) => deleteUploadedFile(id, fileId, fileLimit, accept),
+      accept: string[],
+      modelFlags?: ModelFlags,
+      modelName?: string
+    ) =>
+      deleteUploadedFile(id, fileId, fileLimit, accept, modelFlags, modelName),
     uploading:
       uploadedFilesDict[id]?.some((uploadedFile) => uploadedFile.uploading) ??
       false,

--- a/packages/web/src/pages/ChatPage.tsx
+++ b/packages/web/src/pages/ChatPage.tsx
@@ -144,6 +144,16 @@ ${baseContext}
     }
   }, [chatId, getChatTitle, t]);
 
+  const modelFlags = useMemo(() => {
+    if (!modelId) return undefined;
+    const feature = MODELS.modelMetadata[modelId];
+    if (!feature) return undefined;
+    return feature.flags;
+  }, [modelId]);
+  const modelName = useMemo(() => {
+    if (!modelId) return undefined;
+    return MODELS.modelDisplayName(modelId);
+  }, [modelId]);
   const accept = useMemo(() => {
     if (!modelId) return [];
     const feature = MODELS.modelMetadata[modelId];
@@ -399,7 +409,7 @@ ${baseContext}
     setIsOver(false);
     if (event.dataTransfer.files) {
       // Reflect the file and upload it
-      uploadFiles(Array.from(event.dataTransfer.files), fileLimit, accept);
+      uploadFiles(Array.from(event.dataTransfer.files), fileLimit, accept, modelFlags, modelName);
     }
   };
 
@@ -477,6 +487,8 @@ ${baseContext}
               fileUpload={fileUpload}
               fileLimit={fileLimit}
               accept={accept}
+              modelFlags={modelFlags}
+              modelName={modelName}
               setting={setting}
               onSetting={() => {
                 setShowSetting(true);
@@ -532,6 +544,8 @@ ${baseContext}
                 fileUpload={fileUpload}
                 fileLimit={fileLimit}
                 accept={accept}
+                modelFlags={modelFlags}
+                modelName={modelName}
                 setting={setting}
                 onSetting={() => {
                   setShowSetting(true);


### PR DESCRIPTION
## 概要
- ファイル添付後にモデルを切り替えた際、そのモデルがファイルタイプに対応していない場合、具体的なエラーメッセージを表示するように改善
- 従来の「拡張子がサポートされていません」という一般的なエラーから、「{{モデル名}}は{{ファイルタイプ}}に対応していないため、{{ファイル名}}を送信できません」という明確なメッセージに変更

## 変更内容
- 5言語（英語、日本語、ベトナム語、中国語、タイ語）に新しい翻訳キーを追加
- \`useFiles.ts\`: モデル機能制限を検出するバリデーションロジックを強化
- \`InputChatContent.tsx\`: \`modelFlags\`と\`modelName\`プロパティを追加
- \`ChatPage.tsx\`: モデル情報をファイル操作に渡すように更新

## テスト方法
1. Claude 3.5 Sonnet（ドキュメント対応）を選択
2. PDFファイルを添付
3. Nova Micro（ドキュメント非対応）に切り替え
4. 確認事項：
   - モデル名を含む警告メッセージが表示される
   - 送信ボタンが無効化される
   - ファイルがエラー状態（赤枠）で表示される
5. Claude 3.5 Sonnetに戻す
6. 確認事項：
   - 警告が消える
   - 送信ボタンが有効化される

🤖 Generated with [Claude Code](https://claude.com/claude-code)