### PR TITLE
🚨 fix(cdk): ESLint no-undef エラーを修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "4.3.2",
   "scripts": {
     "lint": "run-s custom-lint:build lint:root web:lint cdk:lint cdk:lambda-build-dryrun",
-    "lint:fix": "run-s custom-lint:build lint:root:fix web:lint:fix cdk:lint cdk:lambda-build-dryrun",
+    "lint:fix": "run-s custom-lint:build lint:root:fix web:lint:fix cdk:lint:fix cdk:lambda-build-dryrun",
     "lint:root": "eslint . --report-unused-disable-directives --max-warnings 0",
     "lint:root:fix": "eslint . --report-unused-disable-directives --max-warnings 0 --fix",
     "test": "run-s web:test",
@@ -28,6 +28,7 @@
     "cdk:tenant:destroy": "npm -w packages/cdk run cdk -- --app 'npx ts-node --prefer-ts-exts bin/generative-ai-use-cases-tenant.ts' destroy --all",
     "cdk:destroy": "npm -w packages/cdk run cdk destroy -- --all",
     "cdk:lint": "npm -w packages/cdk run lint",
+    "cdk:lint:fix": "npm -w packages/cdk run lint:fix",
     "cdk:lambda-build-dryrun": "npm -w packages/cdk run lambda-build-dryrun",
     "cdk:test": "npm -w packages/cdk run test",
     "cdk:test:update-snapshot": "npm -w packages/cdk run test -- --update-snapshot",

--- a/packages/cdk/eslint.config.cjs
+++ b/packages/cdk/eslint.config.cjs
@@ -14,7 +14,9 @@ module.exports = defineConfig([
     languageOptions: {
       ...typescriptConfig.languageOptions,
       globals: {
+        ...typescriptConfig.languageOptions.globals, // 共有設定のglobalsを継承
         ...globals.node,
+        awslambda: 'readonly', // AWS Lambda Response Streaming用
       },
     },
     rules: {

--- a/packages/cdk/eslint.config.cjs
+++ b/packages/cdk/eslint.config.cjs
@@ -24,6 +24,15 @@ module.exports = defineConfig([
       '@typescript-eslint/no-namespace': 'off',
     },
   },
+  // テストファイル専用の設定（Jestグローバル）
+  {
+    files: ['test/**/*.test.ts'],
+    languageOptions: {
+      globals: {
+        ...globals.jest, // Jestグローバル (describe, test, expect, jest, beforeEach, afterAll, etc.)
+      },
+    },
+  },
   {
     ignores: [
       ...commonIgnores.ignores,

--- a/packages/cdk/lambda/assistantMessageStreamHandler.ts
+++ b/packages/cdk/lambda/assistantMessageStreamHandler.ts
@@ -29,7 +29,6 @@ interface AssistantMessageStreamRequest {
 }
 
 declare global {
-  // eslint-disable-next-line @typescript-eslint/no-namespace
   namespace awslambda {
     function streamifyResponse(
       f: (

--- a/packages/cdk/lambda/utils/liteLlmApi.ts
+++ b/packages/cdk/lambda/utils/liteLlmApi.ts
@@ -218,7 +218,7 @@ const liteLlmApi: ApiInterface = {
   invoke: async function (
     model: Model,
     messages: UnrecordedMessage[],
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+     
     id: string
   ): Promise<string> {
     const litellmEndpoint = process.env.LITELLM_ENDPOINT;
@@ -262,9 +262,9 @@ const liteLlmApi: ApiInterface = {
   invokeStream: async function* (
     model: Model,
     messages: UnrecordedMessage[],
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+     
     id: string,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+     
     idToken?: string | undefined
   ): AsyncIterable<string> {
     const litellmEndpoint = process.env.LITELLM_ENDPOINT;
@@ -365,17 +365,17 @@ const liteLlmApi: ApiInterface = {
     }
   },
   generateImage: function (
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+     
     model: Model,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+     
     params: GenerateImageParams
   ): Promise<string> {
     throw new Error('Function not implemented.');
   },
   generateVideo: function (
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+     
     model: Model,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+     
     params: GenerateVideoParams
   ): Promise<string> {
     throw new Error('Function not implemented.');

--- a/packages/cdk/lambda/utils/liteLlmApi.ts
+++ b/packages/cdk/lambda/utils/liteLlmApi.ts
@@ -218,7 +218,7 @@ const liteLlmApi: ApiInterface = {
   invoke: async function (
     model: Model,
     messages: UnrecordedMessage[],
-     
+
     id: string
   ): Promise<string> {
     const litellmEndpoint = process.env.LITELLM_ENDPOINT;
@@ -262,9 +262,9 @@ const liteLlmApi: ApiInterface = {
   invokeStream: async function* (
     model: Model,
     messages: UnrecordedMessage[],
-     
+
     id: string,
-     
+
     idToken?: string | undefined
   ): AsyncIterable<string> {
     const litellmEndpoint = process.env.LITELLM_ENDPOINT;
@@ -365,17 +365,15 @@ const liteLlmApi: ApiInterface = {
     }
   },
   generateImage: function (
-     
     model: Model,
-     
+
     params: GenerateImageParams
   ): Promise<string> {
     throw new Error('Function not implemented.');
   },
   generateVideo: function (
-     
     model: Model,
-     
+
     params: GenerateVideoParams
   ): Promise<string> {
     throw new Error('Function not implemented.');

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -8,6 +8,7 @@
     "test:lambda:watch": "jest lambda --watchAll",
     "cdk": "cdk",
     "lint": "eslint . --ext ts --report-unused-disable-directives --max-warnings 0",
+    "lint:fix": "eslint . --ext ts --report-unused-disable-directives --max-warnings 0 --fix",
     "lambda-build-dryrun": "tsc --noEmit --skipLibCheck",
     "postinstall": "npm ci --prefix custom-resources"
   },


### PR DESCRIPTION
## Summary
- CDKパッケージのESLint設定に共有設定のglobalsを継承するよう修正
- `awslambda`グローバル変数をreadonly定義に追加（Lambda Response Streaming用）
- テストファイル用のJestグローバル設定を追加（describe, test, expect, jest, beforeEach, afterAll等）

## Test plan
- [ ] `npm run cdk:lint` でno-undefエラーが発生しないことを確認
- [ ] テストファイルでJestのグローバル変数が認識されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)