### PR TITLE
🔧 fix(cdk): ESLint設定でJSファイルにも適用するよう修正

### DIFF
--- a/packages/cdk/eslint.config.cjs
+++ b/packages/cdk/eslint.config.cjs
@@ -9,7 +9,7 @@ const {
 module.exports = defineConfig([
   baseConfig,
   {
-    files: ['**/*.{ts,tsx}', '../common/**/*.{ts,tsx}'],
+    files: ['**/*.{js,ts,tsx}', '../common/**/*.{js,ts,tsx}'],
     ...typescriptConfig,
     languageOptions: {
       ...typescriptConfig.languageOptions,
@@ -26,7 +26,7 @@ module.exports = defineConfig([
   },
   // テストファイル専用の設定（Jestグローバル）
   {
-    files: ['test/**/*.test.ts'],
+    files: ['test/**/*.test.{js,ts}'],
     languageOptions: {
       globals: {
         ...globals.jest, // Jestグローバル (describe, test, expect, jest, beforeEach, afterAll, etc.)


### PR DESCRIPTION
## Summary
- CDKパッケージのESLint設定で`.js`ファイルも対象に含めるよう修正
- TypeScript設定とJestグローバル設定の両方で対応

## Test plan
- [ ] `npm run cdk:lint`が正常に動作することを確認
- [ ] テストファイル（`.test.js`）もESLintのルールが適用されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)