### PR TITLE
✨ ナレッジソース数の上限チェックとアップロードエラー表示を追加

### DIFF
--- a/packages/cdk/lambda/assistantHandler.ts
+++ b/packages/cdk/lambda/assistantHandler.ts
@@ -36,6 +36,7 @@ import {
   notFound404Response,
   ok200Response,
 } from './utils/apiResponse';
+import { ASSISTANT_LIMITS } from './utils/assistantLimits';
 
 /**
  * Helper function to normalize assistant data for API responses
@@ -138,6 +139,17 @@ async function handleCreate(
   console.log(
     `Creating assistant: ragEnabled=${body.ragEnabled}, knowledgeSources=${body.knowledgeSources?.length || 0}`
   );
+
+  // Knowledge sources limit (files + URLs)
+  const knowledgeSourceCount = body.knowledgeSources?.length ?? 0;
+  if (knowledgeSourceCount > ASSISTANT_LIMITS.MAX_KNOWLEDGE_SOURCES) {
+    return badRequest400Response({
+      message: `Too many knowledge sources: ${knowledgeSourceCount} (max ${ASSISTANT_LIMITS.MAX_KNOWLEDGE_SOURCES})`,
+      code: 'KNOWLEDGE_SOURCES_LIMIT_EXCEEDED',
+      max: ASSISTANT_LIMITS.MAX_KNOWLEDGE_SOURCES,
+      current: knowledgeSourceCount,
+    });
+  }
 
   // Basic validation
   if (!body.name || !body.instruction || !body.modelId) {
@@ -348,6 +360,20 @@ async function handleUpdate(
   event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResult> {
   const body: UpdateAssistantRequest = JSON.parse(event.body || '{}');
+
+  // Knowledge sources limit (files + URLs)
+  const knowledgeSourceCount = body.knowledgeSources?.length;
+  if (
+    knowledgeSourceCount !== undefined &&
+    knowledgeSourceCount > ASSISTANT_LIMITS.MAX_KNOWLEDGE_SOURCES
+  ) {
+    return badRequest400Response({
+      message: `Too many knowledge sources: ${knowledgeSourceCount} (max ${ASSISTANT_LIMITS.MAX_KNOWLEDGE_SOURCES})`,
+      code: 'KNOWLEDGE_SOURCES_LIMIT_EXCEEDED',
+      max: ASSISTANT_LIMITS.MAX_KNOWLEDGE_SOURCES,
+      current: knowledgeSourceCount,
+    });
+  }
 
   try {
     const assistant = await updateAssistant(assistantId, userId, body, event);

--- a/packages/cdk/lambda/repository/assistant.ts
+++ b/packages/cdk/lambda/repository/assistant.ts
@@ -49,6 +49,18 @@ function removeUndefinedValues(obj: any): any {
 }
 
 /**
+ * Truncate a string to avoid exceeding DynamoDB item size limits when storing
+ * large error messages (e.g., nested OpenSearch/IAM errors).
+ */
+function truncateString(value: string, maxLength: number): string {
+  if (value.length <= maxLength) return value;
+  // Keep it ASCII to avoid encoding surprises in logs/clients.
+  return `${value.slice(0, Math.max(0, maxLength - 3))}...`;
+}
+
+const KNOWLEDGE_SOURCE_ERROR_MAX_LENGTH = 2048;
+
+/**
  * Normalize knowledge sources by initializing status to QUEUED and clearing error field
  * This ensures consistent state for new or updated knowledge sources
  */
@@ -505,7 +517,10 @@ export const updateKnowledgeSourceStatus = async (
     if (source.id === sourceId) {
       const updated: any = { ...source, status };
       if (error !== undefined) {
-        updated.error = error;
+        updated.error = truncateString(
+          error,
+          KNOWLEDGE_SOURCE_ERROR_MAX_LENGTH
+        );
       } else {
         // Clear error field when no error is provided (e.g., when transitioning to SYNCING/SUCCEEDED)
         delete updated.error;

--- a/packages/cdk/lambda/utils/assistantLimits.ts
+++ b/packages/cdk/lambda/utils/assistantLimits.ts
@@ -1,0 +1,8 @@
+/**
+ * Assistant feature limits
+ * NOTE: Keep in sync with frontend limits where applicable.
+ */
+export const ASSISTANT_LIMITS = {
+  /** Max number of knowledge sources per assistant (files + URLs) */
+  MAX_KNOWLEDGE_SOURCES: 50,
+} as const;

--- a/packages/cdk/lambda/utils/documentLoader.ts
+++ b/packages/cdk/lambda/utils/documentLoader.ts
@@ -606,15 +606,20 @@ export async function loadDocuments(
 ): Promise<Document[]> {
   const loadPromises = sources.map(async (source) => {
     try {
+      const sourceId = source.id ?? source.storageKey ?? source.sourceUrl;
+      if (!sourceId) {
+        throw new Error('Knowledge source id is required.');
+      }
+
       if (source.type === 'file' && source.storageKey) {
         return await loadDocumentFromFile(
           source.storageKey,
-          source.id,
+          sourceId,
           userId,
           event
         );
       } else if (source.type === 'web' && source.sourceUrl) {
-        return await loadDocumentFromWeb(source.sourceUrl, source.id);
+        return await loadDocumentFromWeb(source.sourceUrl, sourceId);
       } else {
         throw new Error(
           `Invalid source configuration: type=${source.type}, storageKey=${source.storageKey}, sourceUrl=${source.sourceUrl}`

--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -129,6 +129,13 @@ assistant:
     enableRAG: Enable RAG (Knowledge Base)
     instruction: Custom Instructions
     knowledge: Knowledge Base
+    knowledgeSourcesCount: 'Knowledge sources: {{current}} / {{max}}'
+    knowledgeSourcesLimitReached: 'Limit: {{max}}'
+    knowledgeSourcesOverLimit: 'Too many knowledge sources (max {{max}}). Please remove some sources.'
+    uploadErrorSizeExceeded: 'Exceeds size limit ({{maxSize}} MB)'
+    uploadErrorLimitExceeded: 'Exceeds count limit ({{max}})'
+    uploadErrorCombined: '{{sizeMessage}} / {{limitMessage}}'
+    uploadFailed: Upload failed
     modelId: Model
     readOnlyDescription: You are viewing this assistant in read-only mode. Only the owner can edit this assistant.
     readOnlyMode: Read-Only Mode
@@ -136,6 +143,7 @@ assistant:
     save: Save
     saveBeforeUpload: Please save the assistant before uploading files
     saveFailed: Failed to save
+    saveTimeout: Save operation timed out. Please reduce the number of knowledge sources and try again.
     saving: Saving...
     sourceUrls: Source URLs
     title: Name

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -129,6 +129,13 @@ assistant:
     enableRAG: RAGを有効化（ナレッジベース）
     instruction: カスタム指示
     knowledge: ナレッジベース
+    knowledgeSourcesCount: 'ナレッジソース: {{current}} / {{max}}'
+    knowledgeSourcesLimitReached: '上限: {{max}}件'
+    knowledgeSourcesOverLimit: 'ナレッジソース数が上限（{{max}}件）を超えています。不要なソースを削除してください。'
+    uploadErrorSizeExceeded: 'サイズ上限（{{maxSize}} MB）超過'
+    uploadErrorLimitExceeded: '件数上限（{{max}}件）超過'
+    uploadErrorCombined: '{{sizeMessage}} / {{limitMessage}}'
+    uploadFailed: アップロードに失敗しました
     modelId: モデル
     readOnlyDescription: このアシスタントを読み取り専用モードで表示しています。編集は所有者のみが可能です。
     readOnlyMode: 読み取り専用モード
@@ -136,6 +143,7 @@ assistant:
     save: 保存
     saveBeforeUpload: ファイルをアップロードする前にアシスタントを保存してください
     saveFailed: 保存に失敗しました
+    saveTimeout: 保存処理がタイムアウトしました。知識ソースの数を減らして再度お試しください。
     saving: 保存中...
     sourceUrls: ソースURL
     title: 名前

--- a/packages/web/public/locales/translation/th.yaml
+++ b/packages/web/public/locales/translation/th.yaml
@@ -83,6 +83,13 @@ assistant:
     sources: แหล่งที่มา
     view: ดู
   edit:
+    knowledgeSourcesCount: 'แหล่งความรู้: {{current}} / {{max}}'
+    knowledgeSourcesLimitReached: 'ขีดจำกัด: {{max}}'
+    knowledgeSourcesOverLimit: 'มีแหล่งความรู้มากเกินไป (สูงสุด {{max}}) กรุณาลบบางรายการออก'
+    uploadErrorSizeExceeded: 'เกินขนาดสูงสุด ({{maxSize}} MB)'
+    uploadErrorLimitExceeded: 'เกินจำนวนสูงสุด ({{max}})'
+    uploadErrorCombined: '{{sizeMessage}} / {{limitMessage}}'
+    uploadFailed: อัปโหลดล้มเหลว
     uploadingFiles: กำลังอัปโหลดไฟล์...
   history:
     createdWithDate: 'สร้างเมื่อ: {{date}}'

--- a/packages/web/public/locales/translation/vi.yaml
+++ b/packages/web/public/locales/translation/vi.yaml
@@ -83,6 +83,13 @@ assistant:
     sources: Nguồn
     view: Xem
   edit:
+    knowledgeSourcesCount: 'Nguồn kiến thức: {{current}} / {{max}}'
+    knowledgeSourcesLimitReached: 'Giới hạn: {{max}}'
+    knowledgeSourcesOverLimit: 'Quá nhiều nguồn kiến thức (tối đa {{max}}). Vui lòng xóa bớt nguồn.'
+    uploadErrorSizeExceeded: 'Vượt quá giới hạn kích thước ({{maxSize}} MB)'
+    uploadErrorLimitExceeded: 'Vượt quá giới hạn số lượng ({{max}})'
+    uploadErrorCombined: '{{sizeMessage}} / {{limitMessage}}'
+    uploadFailed: Tải lên thất bại
     uploadingFiles: Đang tải lên tập tin...
   history:
     createdWithDate: 'Ngày tạo: {{date}}'

--- a/packages/web/public/locales/translation/zh.yaml
+++ b/packages/web/public/locales/translation/zh.yaml
@@ -83,6 +83,13 @@ assistant:
     sources: 来源
     view: 查看
   edit:
+    knowledgeSourcesCount: '知识来源：{{current}} / {{max}}'
+    knowledgeSourcesLimitReached: '上限：{{max}}'
+    knowledgeSourcesOverLimit: '知识来源数量超过上限（最多 {{max}}）。请删除一些来源。'
+    uploadErrorSizeExceeded: '超过大小限制（{{maxSize}} MB）'
+    uploadErrorLimitExceeded: '超过数量限制（{{max}}）'
+    uploadErrorCombined: '{{sizeMessage}} / {{limitMessage}}'
+    uploadFailed: 上传失败
     uploadingFiles: 正在上传文件...
   history:
     createdWithDate: '创建日期: {{date}}'

--- a/packages/web/src/components/FileUploader.tsx
+++ b/packages/web/src/components/FileUploader.tsx
@@ -8,6 +8,7 @@ type Props = BaseProps & {
   multiple?: boolean;
   onFileSelect?: (files: FileList) => void;
   label?: string;
+  disabled?: boolean;
 };
 
 const FileUploader: React.FC<Props> = (props) => {
@@ -15,12 +16,18 @@ const FileUploader: React.FC<Props> = (props) => {
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleClick = () => {
-    inputRef.current?.click();
+    if (!props.disabled) {
+      inputRef.current?.click();
+    }
   };
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && props.onFileSelect) {
       props.onFileSelect(e.target.files);
+    }
+    // 同じファイルを再選択できるようにリセット
+    if (inputRef.current) {
+      inputRef.current.value = '';
     }
   };
 
@@ -37,7 +44,12 @@ const FileUploader: React.FC<Props> = (props) => {
       />
       <button
         onClick={handleClick}
-        className="flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 hover:bg-gray-50">
+        disabled={props.disabled}
+        className={`flex items-center gap-2 rounded-lg border border-gray-300 px-4 py-2 ${
+          props.disabled
+            ? 'cursor-not-allowed bg-gray-100 text-gray-400'
+            : 'hover:bg-gray-50'
+        }`}>
         <PiUploadSimple />
         <span>{t('files.uploadFiles')}</span>
       </button>

--- a/packages/web/src/components/assistants/KnowledgeSection.tsx
+++ b/packages/web/src/components/assistants/KnowledgeSection.tsx
@@ -5,12 +5,19 @@ import { KnowledgeSource } from 'generative-ai-use-cases';
 import Button from '../Button';
 import InputText from '../InputText';
 import FileUploader from '../FileUploader';
+import Alert from '../Alert';
+import { UploadError } from '../../hooks/useAssistantForm';
+import { ASSISTANT_LIMITS } from '../../constants/assistant';
 
 export type KnowledgeSectionProps = {
   ragEnabled: boolean;
   knowledgeSources: KnowledgeSource[];
   newUrl: string;
   uploadingFiles: boolean;
+  uploadError?: UploadError;
+  saveError?: string | null;
+  onClearUploadError?: () => void;
+  onClearSaveError?: () => void;
   onNewUrlChange: (url: string) => void;
   onAddUrl: () => void;
   onRemoveSource: (index: number) => void;
@@ -24,6 +31,10 @@ const KnowledgeSection: React.FC<KnowledgeSectionProps> = ({
   knowledgeSources,
   newUrl,
   uploadingFiles,
+  uploadError,
+  saveError,
+  onClearUploadError,
+  onClearSaveError,
   onNewUrlChange,
   onAddUrl,
   onRemoveSource,
@@ -32,6 +43,22 @@ const KnowledgeSection: React.FC<KnowledgeSectionProps> = ({
   disabled = false,
 }) => {
   const { t } = useTranslation();
+  const maxSources = ASSISTANT_LIMITS.MAX_KNOWLEDGE_SOURCES;
+  const currentSources = knowledgeSources.length;
+  const limitReached = currentSources >= maxSources;
+  const limitExceeded = currentSources > maxSources;
+  const uploadErrorMessage = uploadError
+    ? uploadError.messageKey === 'assistant.edit.uploadErrorCombined'
+      ? t('assistant.edit.uploadErrorCombined', {
+          sizeMessage: t('assistant.edit.uploadErrorSizeExceeded', {
+            maxSize: uploadError.messageParams?.maxSize,
+          }),
+          limitMessage: t('assistant.edit.uploadErrorLimitExceeded', {
+            max: uploadError.messageParams?.max,
+          }),
+        })
+      : t(uploadError.messageKey, uploadError.messageParams)
+    : '';
 
   if (!ragEnabled) {
     return null;
@@ -39,8 +66,54 @@ const KnowledgeSection: React.FC<KnowledgeSectionProps> = ({
 
   return (
     <div className="space-y-4">
+      <div className="flex items-center justify-between text-sm text-gray-600">
+        <span>
+          {t('assistant.edit.knowledgeSourcesCount', {
+            current: currentSources,
+            max: maxSources,
+          })}
+        </span>
+        {limitReached && (
+          <span className={limitExceeded ? 'text-red-600' : 'text-gray-500'}>
+            {t('assistant.edit.knowledgeSourcesLimitReached', {
+              max: maxSources,
+            })}
+          </span>
+        )}
+      </div>
+
+      {saveError && (
+        <Alert
+          severity="error"
+          onDissmiss={disabled ? undefined : onClearSaveError}>
+          <div>{saveError}</div>
+        </Alert>
+      )}
+
+      {uploadError && (
+        <Alert
+          severity="error"
+          onDissmiss={disabled ? undefined : onClearUploadError}>
+          <div>
+            <span>{uploadErrorMessage}</span>
+            {uploadError.files && uploadError.files.length > 0 && (
+              <ul className="mt-1 list-inside list-disc">
+                {uploadError.files.map((file, index) => (
+                  <li key={index}>
+                    <span className="font-bold">{file.name}</span>
+                    {file.size && (
+                      <span className="ml-1 text-gray-600">({file.size})</span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+        </Alert>
+      )}
+
       <div>
-        <label className="mb-2 block text-sm font-medium">
+        <label className="mb-2 text-sm font-medium">
           {t('assistant.edit.sourceUrls')}
         </label>
         {!disabled && (
@@ -50,12 +123,12 @@ const KnowledgeSection: React.FC<KnowledgeSectionProps> = ({
               onChange={onNewUrlChange}
               placeholder="https://example.com"
               className="flex-1"
-              disabled={disabled}
+              disabled={disabled || limitReached}
             />
             <Button
               onClick={onAddUrl}
               outlined
-              disabled={disabled}
+              disabled={disabled || limitReached}
               className="flex items-center gap-1">
               <PiPlus />
               {t('assistant.edit.add')}
@@ -90,15 +163,16 @@ const KnowledgeSection: React.FC<KnowledgeSectionProps> = ({
       </div>
 
       <div>
-        <label className="mb-2 block text-sm font-medium">
+        <label className="mb-2 text-sm font-medium">
           {t('assistant.edit.uploadFiles')}
         </label>
         {!disabled && (
           <>
             <FileUploader
               onFileSelect={onFileUpload}
-              accept=".pdf,.txt,.doc,.docx,.md"
+              accept=".pdf,.txt,.md,.html,.json,.csv"
               multiple
+              disabled={disabled || uploadingFiles || limitReached}
             />
             {uploadingFiles && (
               <p className="mt-2 text-sm text-blue-600">

--- a/packages/web/src/constants/assistant.ts
+++ b/packages/web/src/constants/assistant.ts
@@ -1,0 +1,11 @@
+/**
+ * アシスタントのナレッジベースに関する制限値
+ */
+export const ASSISTANT_LIMITS = {
+  /** ファイルサイズの上限（バイト） - バックエンドと同じ10MB */
+  MAX_FILE_SIZE: 10 * 1024 * 1024,
+  /** ナレッジソース（ファイル + URL）の合計件数上限
+   * NOTE: API Gatewayの29秒タイムアウト回避のため、暫定的に10件に制限
+   */
+  MAX_KNOWLEDGE_SOURCES: 10,
+};

--- a/packages/web/src/hooks/useAssistantForm.ts
+++ b/packages/web/src/hooks/useAssistantForm.ts
@@ -2,6 +2,7 @@ import { useState, useCallback } from 'react';
 import { KnowledgeSource } from 'generative-ai-use-cases';
 import useAssistantApi from './useAssistantApi';
 import { MODELS } from './useModel';
+import { ASSISTANT_LIMITS } from '../constants/assistant';
 
 export type AssistantFormData = {
   name: string;
@@ -17,12 +18,26 @@ export type UseAssistantFormOptions = {
   initialData?: Partial<AssistantFormData>;
 };
 
+export type UploadErrorFile = {
+  name: string;
+  size: string;
+};
+
+export type UploadError = {
+  type: 'size_exceeded' | 'limit_exceeded' | 'upload_failed';
+  messageKey: string;
+  messageParams?: Record<string, string | number>;
+  files?: UploadErrorFile[];
+} | null;
+
 export type UseAssistantFormReturn = {
   formData: AssistantFormData;
   setFormData: React.Dispatch<React.SetStateAction<AssistantFormData>>;
   newUrl: string;
   setNewUrl: React.Dispatch<React.SetStateAction<string>>;
   uploadingFiles: boolean;
+  uploadError: UploadError;
+  clearUploadError: () => void;
   addKnowledgeUrl: () => void;
   removeKnowledgeSource: (index: number) => void;
   handleFileUpload: (files: FileList) => Promise<void>;
@@ -51,18 +66,23 @@ const getInitialFormData = (
  * Browsers don't always correctly detect MIME types for text files like .md
  */
 const getContentType = (file: File): string => {
-  if (file.type) return file.type;
-
   const extension = file.name.split('.').pop()?.toLowerCase();
   const mimeTypes: Record<string, string> = {
     md: 'text/markdown',
     txt: 'text/plain',
     pdf: 'application/pdf',
-    doc: 'application/msword',
-    docx: 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+    html: 'text/html',
+    json: 'application/json',
+    csv: 'text/csv',
   };
 
-  return mimeTypes[extension || ''] || 'application/octet-stream';
+  if (extension && mimeTypes[extension]) {
+    return mimeTypes[extension];
+  }
+
+  if (file.type) return file.type;
+
+  return 'application/octet-stream';
 };
 
 const useAssistantForm = (
@@ -74,9 +94,24 @@ const useAssistantForm = (
   );
   const [newUrl, setNewUrl] = useState('');
   const [uploadingFiles, setUploadingFiles] = useState(false);
+  const [uploadError, setUploadError] = useState<UploadError>(null);
+
+  const clearUploadError = useCallback(() => {
+    setUploadError(null);
+  }, []);
 
   const addKnowledgeUrl = useCallback(() => {
     if (newUrl.trim()) {
+      const maxSources = ASSISTANT_LIMITS.MAX_KNOWLEDGE_SOURCES;
+      if (formData.knowledgeSources.length >= maxSources) {
+        setUploadError({
+          type: 'limit_exceeded',
+          messageKey: 'assistant.edit.knowledgeSourcesOverLimit',
+          messageParams: { max: maxSources },
+        });
+        return;
+      }
+
       const newSource: KnowledgeSource = {
         id: crypto.randomUUID(),
         type: 'web',
@@ -90,8 +125,9 @@ const useAssistantForm = (
         knowledgeSources: [...prev.knowledgeSources, newSource],
       }));
       setNewUrl('');
+      setUploadError(null);
     }
-  }, [newUrl]);
+  }, [newUrl, formData.knowledgeSources.length]);
 
   const removeKnowledgeSource = useCallback((index: number) => {
     setFormData((prev) => ({
@@ -102,10 +138,69 @@ const useAssistantForm = (
 
   const handleFileUpload = useCallback(
     async (files: FileList) => {
+      // エラーをクリア
+      setUploadError(null);
+
+      // ファイルサイズの上限チェック（サイズ超過ファイルとアップロード可能ファイルを分類）
+      const maxSizeMB = ASSISTANT_LIMITS.MAX_FILE_SIZE / (1024 * 1024);
+      const maxSources = ASSISTANT_LIMITS.MAX_KNOWLEDGE_SOURCES;
+      const currentSources = formData.knowledgeSources.length;
+      const availableSlots = Math.max(0, maxSources - currentSources);
+
+      if (availableSlots === 0) {
+        setUploadError({
+          type: 'limit_exceeded',
+          messageKey: 'assistant.edit.knowledgeSourcesOverLimit',
+          messageParams: { max: maxSources },
+        });
+        return;
+      }
+
+      const oversizedFiles: UploadErrorFile[] = [];
+      const exceededFiles: UploadErrorFile[] = [];
+      const validFiles: File[] = [];
+      for (let i = 0; i < files.length; i++) {
+        if (files[i].size > ASSISTANT_LIMITS.MAX_FILE_SIZE) {
+          oversizedFiles.push({
+            name: files[i].name,
+            size: `${(files[i].size / (1024 * 1024)).toFixed(1)}MB`,
+          });
+        } else if (validFiles.length < availableSlots) {
+          validFiles.push(files[i]);
+        } else {
+          exceededFiles.push({
+            name: files[i].name,
+            size: '件数上限超過',
+          });
+        }
+      }
+
+      // サイズ超過ファイルがある場合はエラーを設定
+      if (oversizedFiles.length > 0 || exceededFiles.length > 0) {
+        setUploadError({
+          type: exceededFiles.length > 0 ? 'limit_exceeded' : 'size_exceeded',
+          messageKey:
+            oversizedFiles.length > 0 && exceededFiles.length > 0
+              ? 'assistant.edit.uploadErrorCombined'
+              : oversizedFiles.length > 0
+                ? 'assistant.edit.uploadErrorSizeExceeded'
+                : 'assistant.edit.uploadErrorLimitExceeded',
+          messageParams: {
+            maxSize: maxSizeMB,
+            max: maxSources,
+          },
+          files: [...oversizedFiles, ...exceededFiles],
+        });
+      }
+
+      // アップロード可能なファイルがない場合は終了
+      if (validFiles.length === 0) {
+        return;
+      }
+
       setUploadingFiles(true);
       try {
-        for (let i = 0; i < files.length; i++) {
-          const file = files[i];
+        for (const file of validFiles) {
           try {
             const contentType = getContentType(file);
 
@@ -141,14 +236,18 @@ const useAssistantForm = (
             }));
           } catch (error) {
             console.error('Failed to upload file:', error);
-            alert(`Failed to upload ${file.name}`);
+            setUploadError({
+              type: 'upload_failed',
+              messageKey: 'assistant.edit.uploadFailed',
+              files: [{ name: file.name, size: '' }],
+            });
           }
         }
       } finally {
         setUploadingFiles(false);
       }
     },
-    [requestUploadUrl]
+    [requestUploadUrl, formData.knowledgeSources.length]
   );
 
   const deleteFile = useCallback((sourceId: string) => {
@@ -175,6 +274,8 @@ const useAssistantForm = (
     newUrl,
     setNewUrl,
     uploadingFiles,
+    uploadError,
+    clearUploadError,
     addKnowledgeUrl,
     removeKnowledgeSource,
     handleFileUpload,

--- a/packages/web/src/pages/AssistantFormPage.tsx
+++ b/packages/web/src/pages/AssistantFormPage.tsx
@@ -25,6 +25,7 @@ import LoadingWave from '../components/LoadingWave';
 import BasicInfoFields from '../components/assistants/BasicInfoFields';
 import KnowledgeSection from '../components/assistants/KnowledgeSection';
 import ModalDialogDeleteAssistant from '../components/assistants/ModalDialogDeleteAssistant';
+import { ASSISTANT_LIMITS } from '../constants/assistant';
 
 // Helper function to normalize user IDs for comparison
 const normalizeUserId = (id?: string): string => {
@@ -61,6 +62,7 @@ const AssistantFormPage: React.FC = () => {
   const [deleting, setDeleting] = useState(false);
   const [isOwner, setIsOwner] = useState(!assistantId); // True for create mode, false for edit until verified
   const [assistant, setAssistant] = useState<Assistant | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const [abortController, setAbortController] =
     useState<AbortController | null>(null);
 
@@ -70,6 +72,8 @@ const AssistantFormPage: React.FC = () => {
     newUrl,
     setNewUrl,
     uploadingFiles,
+    uploadError,
+    clearUploadError,
     addKnowledgeUrl,
     removeKnowledgeSource,
     handleFileUpload,
@@ -183,8 +187,21 @@ const AssistantFormPage: React.FC = () => {
   };
 
   const handleSave = async () => {
+    setSaveError(null);
     if (!isValid()) {
       alert(t('assistant.edit.requiredFields'));
+      return;
+    }
+
+    if (
+      formData.ragEnabled &&
+      formData.knowledgeSources.length > ASSISTANT_LIMITS.MAX_KNOWLEDGE_SOURCES
+    ) {
+      alert(
+        t('assistant.edit.knowledgeSourcesOverLimit', {
+          max: ASSISTANT_LIMITS.MAX_KNOWLEDGE_SOURCES,
+        })
+      );
       return;
     }
 
@@ -232,6 +249,16 @@ const AssistantFormPage: React.FC = () => {
         `Failed to ${assistantId ? 'update' : 'create'} assistant:`,
         error
       );
+
+      // 504タイムアウトエラーの検出
+      if (error && typeof error === 'object' && 'response' in error) {
+        const axiosError = error as { response?: { status?: number } };
+        if (axiosError.response?.status === 504) {
+          setSaveError(t('assistant.edit.saveTimeout'));
+          return;
+        }
+      }
+
       alert(t('assistant.edit.saveFailed'));
     } finally {
       setSaving(false);
@@ -389,6 +416,10 @@ const AssistantFormPage: React.FC = () => {
             knowledgeSources={formData.knowledgeSources}
             newUrl={newUrl}
             uploadingFiles={uploadingFiles}
+            uploadError={uploadError}
+            saveError={saveError}
+            onClearUploadError={clearUploadError}
+            onClearSaveError={() => setSaveError(null)}
             onNewUrlChange={setNewUrl}
             onAddUrl={addKnowledgeUrl}
             onRemoveSource={removeKnowledgeSource}


### PR DESCRIPTION
## 概要
アシスタントのナレッジソース数制限とアップロード時のエラーハンドリングを強化しました。APIのタイムアウト回避のため、フロント側で件数制限を先行適用しています。

## 変更点
- API: ナレッジソース件数上限チェックを追加（作成/更新）、エラーコードを返却
- API: ナレッジソースエラーの保存長を制限してDynamoDBサイズ超過を回避
- API: knowledge source id の必須化
- Web: 件数上限表示/制限、アップロードエラー表示、保存タイムアウトの通知
- Web: 許可拡張子の見直し（.pdf/.txt/.md/.html/.json/.csv）とUI無効化
- i18n: 5言語の文言追加/更新
