### PR TITLE
🐛 ログイン画面のメールアドレスフィールドラベルを修正

### DIFF
--- a/packages/web/src/components/AuthWithSamlOrUserpool.tsx
+++ b/packages/web/src/components/AuthWithSamlOrUserpool.tsx
@@ -43,6 +43,16 @@ const AuthWithSamlOrUserpool: React.FC<Props> = (props) => {
 
   useEffect(() => {
     I18n.putVocabularies(translations);
+    /* eslint-disable i18nhelper/no-jp-string -- Amplify UI translation override */
+    I18n.putVocabularies({
+      ja: {
+        Username: 'メールアドレス',
+        'Enter your username': 'メールアドレスを入力',
+        'Enter your Username': 'メールアドレスを入力',
+        'Username cannot be empty': 'メールアドレスは入力必須です',
+      },
+    });
+    /* eslint-enable i18nhelper/no-jp-string */
     I18n.setLanguage(i18n.language === 'ja' ? 'ja' : 'en');
   }, [i18n.language]);
 

--- a/packages/web/src/components/AuthWithUserpool.tsx
+++ b/packages/web/src/components/AuthWithUserpool.tsx
@@ -14,6 +14,16 @@ const AuthWithUserpool: React.FC<Props> = (props) => {
 
   useEffect(() => {
     I18n.putVocabularies(translations);
+    /* eslint-disable i18nhelper/no-jp-string -- Amplify UI translation override */
+    I18n.putVocabularies({
+      ja: {
+        Username: 'メールアドレス',
+        'Enter your username': 'メールアドレスを入力',
+        'Enter your Username': 'メールアドレスを入力',
+        'Username cannot be empty': 'メールアドレスは入力必須です',
+      },
+    });
+    /* eslint-enable i18nhelper/no-jp-string */
     I18n.setLanguage(i18n.language === 'ja' ? 'ja' : 'en');
   }, [i18n.language]);
 


### PR DESCRIPTION
## Summary
- ログイン/サインアップ画面のメールアドレスフィールドのラベルを「ユーザー名」から「メールアドレス」に修正
- Amplify UIのデフォルト翻訳をI18n.putVocabulariesでオーバーライド
- プレースホルダーとバリデーションエラーメッセージも日本語化

## Test plan
- [ ] 開発サーバーを起動: `npm run web:devw`
- [ ] ログイン画面でメールアドレス入力フィールドのラベルが「メールアドレス」になっていることを確認
- [ ] サインアップ画面（セルフサインアップ有効時）も同様に確認
- [ ] フィールドを空のまま送信し、エラーメッセージが「メールアドレスは入力必須です」になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)