### PR TITLE
🔧 fix(cdk): ESLint設定でビルド生成JSファイルを除外

### DIFF
--- a/packages/cdk/eslint.config.cjs
+++ b/packages/cdk/eslint.config.cjs
@@ -39,6 +39,14 @@ module.exports = defineConfig([
       'cdk.out/**',
       'cloudfront-functions/**',
       'custom-resources/**',
+      // TypeScriptビルドで生成されるJSファイルを除外（.gitignoreと同期）
+      'lambda/**/*.js',
+      'lib/**/*.js',
+      'bin/**/*.js',
+      'test/**/*.js',
+      '*.js',
+      '*.d.ts',
+      '**/*.d.ts',
     ],
   },
 ]);


### PR DESCRIPTION
## Summary
- TypeScriptビルドで生成される.jsファイルと.d.tsファイルをESLintの対象から除外
- コミット#295で追加されたJS対象設定により、gitignoreされているビルド生成ファイルがESLintに引っかかる問題を修正

## Test plan
- [ ] `npm run lint`を実行し、ビルド生成の.jsファイルがESLintエラーを出さないことを確認
- [ ] 意図的に`packages/cdk/lambda/`などで.tsファイルを編集してESLintが正しく動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)