### PR TITLE
🚧  ✨  アシスタントのナレッジ同期を非同期にする

### DIFF
--- a/packages/cdk/lambda/assistantHandler.ts
+++ b/packages/cdk/lambda/assistantHandler.ts
@@ -5,24 +5,16 @@ import {
   getAssistant,
   updateAssistant,
   deleteAssistant,
-  updateKnowledgeSourceStatus,
   updateAssistantSyncStatus,
 } from './repository/assistant';
 import { deleteAllMessagesForAssistant } from './repository/chat';
-import {
-  loadDocuments,
-  chunkDocuments,
-  addMetadata,
-} from './utils/documentLoader';
-import {
-  indexDocuments,
-  deleteAssistantDocuments,
-} from './repository/assistantSearch';
+import { deleteAssistantDocuments } from './repository/assistantSearch';
 import {
   Assistant,
   CreateAssistantRequest,
   UpdateAssistantRequest,
   ListAssistantsResponse,
+  KnowledgeSource,
 } from 'generative-ai-use-cases';
 import { getTenantId } from './utils/tenantUtils';
 import { canAccessAssistant } from './utils/assistantAccessControl';
@@ -36,6 +28,60 @@ import {
   notFound404Response,
   ok200Response,
 } from './utils/apiResponse';
+import {
+  LambdaClient,
+  InvokeCommand,
+  InvocationType,
+} from '@aws-sdk/client-lambda';
+
+const lambdaClient = new LambdaClient({});
+const KNOWLEDGE_SYNC_FUNCTION_NAME =
+  process.env.ASSISTANT_KNOWLEDGE_SYNC_FUNCTION_NAME;
+
+type KnowledgeSyncPayload = {
+  assistantId: string;
+  userId: string;
+  tenantId: string;
+  authorization?: string;
+  clearExistingIndex?: boolean;
+};
+
+function ensureKnowledgeSourceIds(
+  sources?: KnowledgeSource[]
+): KnowledgeSource[] | undefined {
+  if (!sources) {
+    return sources;
+  }
+
+  return sources.map((source) => {
+    if (source.id) {
+      return source;
+    }
+    return { ...source, id: crypto.randomUUID() };
+  });
+}
+
+function getAuthorizationHeader(
+  event: APIGatewayProxyEvent
+): string | undefined {
+  return event.headers?.Authorization || event.headers?.authorization;
+}
+
+async function enqueueKnowledgeSync(
+  payload: KnowledgeSyncPayload
+): Promise<void> {
+  if (!KNOWLEDGE_SYNC_FUNCTION_NAME) {
+    throw new Error('ASSISTANT_KNOWLEDGE_SYNC_FUNCTION_NAME is not set');
+  }
+
+  await lambdaClient.send(
+    new InvokeCommand({
+      FunctionName: KNOWLEDGE_SYNC_FUNCTION_NAME,
+      InvocationType: InvocationType.Event,
+      Payload: JSON.stringify(payload),
+    })
+  );
+}
 
 /**
  * Helper function to normalize assistant data for API responses
@@ -134,6 +180,7 @@ async function handleCreate(
   }
 
   const body: CreateAssistantRequest = JSON.parse(event.body || '{}');
+  body.knowledgeSources = ensureKnowledgeSourceIds(body.knowledgeSources);
 
   console.log(
     `Creating assistant: ragEnabled=${body.ragEnabled}, knowledgeSources=${body.knowledgeSources?.length || 0}`
@@ -148,121 +195,22 @@ async function handleCreate(
 
   const assistant = await createAssistant(userId, body, event);
 
-  // If RAG is enabled, process knowledge sources and update status
+  // If RAG is enabled, queue knowledge sync and update status
   if (body.ragEnabled) {
-    console.log(`RAG is enabled, checking knowledge sources...`);
-    // If knowledge sources are provided, ingest documents
+    console.log(`RAG is enabled, queuing knowledge sync...`);
+    await updateAssistantSyncStatus(assistant, event);
     if (body.knowledgeSources && body.knowledgeSources.length > 0) {
-      const cleanAssistantId = assistant.assistantId.replace('assistant#', '');
-
-      // Process each knowledge source individually to track status per-source
-      for (const source of body.knowledgeSources) {
-        try {
-          // Generate ID server-side if not provided (for backward compatibility and URL sources)
-          if (!source.id) {
-            source.id = crypto.randomUUID();
-            console.log(
-              `Generated ID ${source.id} for knowledge source without ID`
-            );
-          }
-
-          console.log(
-            `Processing knowledge source ${source.id} (type=${source.type}, storageKey=${source.storageKey}) for assistant ${cleanAssistantId}`
-          );
-
-          // Update status to SYNCING
-          await updateKnowledgeSourceStatus(
-            assistant,
-            source.id,
-            'SYNCING',
-            undefined,
-            event
-          );
-
-          // Load document for this source
-          const documents = await loadDocuments([source], userId, event);
-
-          // Chunk documents
-          const chunks = await chunkDocuments(documents, 1000, 200);
-
-          // Add metadata
-          const docsWithMetadata = addMetadata(
-            chunks,
-            cleanAssistantId,
-            userId
-          );
-
-          // Index to OpenSearch
-          await indexDocuments(cleanAssistantId, docsWithMetadata, event);
-
-          // Update status to SUCCEEDED
-          await updateKnowledgeSourceStatus(
-            assistant,
-            source.id,
-            'SUCCEEDED',
-            undefined,
-            event
-          );
-
-          console.log(
-            `Successfully ingested knowledge source ${source.id} for assistant ${cleanAssistantId}`
-          );
-        } catch (error) {
-          console.error(
-            `Error ingesting knowledge source ${source.id}:`,
-            error
-          );
-
-          // Update status to FAILED with detailed error message
-          let errorMessage = 'Unknown error';
-          if (error instanceof Error) {
-            errorMessage = error.message;
-
-            // Extract additional details from OpenSearch ResponseError
-            if ('meta' in error && error.meta) {
-              const meta = error.meta as any;
-              if (meta.statusCode) {
-                errorMessage = `${error.message} (HTTP ${meta.statusCode})`;
-              }
-              if (meta.body && meta.body.Message) {
-                // AWS IAM error message format
-                errorMessage += `: ${meta.body.Message}`;
-              } else if (meta.body && meta.body.error) {
-                // OpenSearch error format
-                if (typeof meta.body.error === 'string') {
-                  errorMessage += `: ${meta.body.error}`;
-                } else if (meta.body.error.reason) {
-                  errorMessage += `: ${meta.body.error.reason}`;
-                }
-              }
-            }
-          }
-
-          if (source.id) {
-            await updateKnowledgeSourceStatus(
-              assistant,
-              source.id,
-              'FAILED',
-              errorMessage,
-              event
-            ).catch((statusError) => {
-              // Don't fail if status update fails
-              console.error('Failed to update source status:', statusError);
-            });
-          }
-
-          // Don't fail the assistant creation if one source fails
-          // Continue processing other sources
-        }
-      }
+      await enqueueKnowledgeSync({
+        assistantId: assistant.assistantId.replace(/^assistant#/, ''),
+        userId,
+        tenantId: getTenantId(event),
+        authorization: getAuthorizationHeader(event),
+      });
     } else {
       console.log(
         `No knowledge sources provided (knowledgeSources=${body.knowledgeSources?.length || 0})`
       );
     }
-
-    // After all sources are processed (or if no sources), update overall assistant status
-    await updateAssistantSyncStatus(assistant, event);
   } else {
     console.log(`RAG is not enabled`);
   }
@@ -348,119 +296,22 @@ async function handleUpdate(
   event: APIGatewayProxyEvent
 ): Promise<APIGatewayProxyResult> {
   const body: UpdateAssistantRequest = JSON.parse(event.body || '{}');
+  body.knowledgeSources = ensureKnowledgeSourceIds(body.knowledgeSources);
 
   try {
     const assistant = await updateAssistant(assistantId, userId, body, event);
 
-    // If knowledge sources were updated and RAG is enabled, re-index documents
+    // If knowledge sources were updated and RAG is enabled, queue re-indexing
     if (body.knowledgeSources !== undefined && assistant.ragEnabled) {
-      console.log(`Re-indexing documents for assistant ${assistantId}`);
-
-      // KNOWN LIMITATION: We delete old documents before indexing new ones.
-      // If ALL sources fail to index, the assistant will have no documents.
-      // Proper solutions would require:
-      // 1. Adding sync timestamps to documents and deleting only older versions
-      // 2. Implementing async job queue with rollback capability
-      // 3. Using temporary index with atomic swap
-      await deleteAssistantDocuments(assistantId, event);
-
-      // If new knowledge sources are provided, index them
-      if (body.knowledgeSources && body.knowledgeSources.length > 0) {
-        let hasAnySuccess = false;
-        let lastError: Error | undefined;
-
-        // Process each knowledge source individually to track status per-source
-        for (const source of body.knowledgeSources) {
-          try {
-            // Generate ID server-side if not provided (for backward compatibility and URL sources)
-            if (!source.id) {
-              source.id = crypto.randomUUID();
-              console.log(
-                `Generated ID ${source.id} for knowledge source without ID`
-              );
-            }
-
-            console.log(
-              `Processing knowledge source ${source.id} for assistant ${assistantId}`
-            );
-
-            // Update status to SYNCING
-            await updateKnowledgeSourceStatus(
-              assistant,
-              source.id,
-              'SYNCING',
-              undefined,
-              event
-            );
-
-            // Load document for this source
-            const documents = await loadDocuments([source], userId, event);
-
-            // Chunk documents
-            const chunks = await chunkDocuments(documents, 1000, 200);
-
-            // Add metadata
-            const docsWithMetadata = addMetadata(chunks, assistantId, userId);
-
-            // Index to OpenSearch
-            await indexDocuments(assistantId, docsWithMetadata, event);
-
-            // Update status to SUCCEEDED
-            await updateKnowledgeSourceStatus(
-              assistant,
-              source.id,
-              'SUCCEEDED',
-              undefined,
-              event
-            );
-
-            hasAnySuccess = true;
-            console.log(
-              `Successfully re-indexed knowledge source ${source.id} for assistant ${assistantId}`
-            );
-          } catch (error) {
-            console.error(
-              `Error re-indexing knowledge source ${source.id}:`,
-              error
-            );
-
-            // Update status to FAILED with error message
-            const errorMessage =
-              error instanceof Error ? error.message : 'Unknown error';
-            // source.id is guaranteed to exist at this point (generated above if not provided)
-            await updateKnowledgeSourceStatus(
-              assistant,
-              source.id!,
-              'FAILED',
-              errorMessage,
-              event
-            ).catch((statusError) => {
-              // Don't fail if status update fails
-              console.error('Failed to update source status:', statusError);
-            });
-
-            lastError =
-              error instanceof Error ? error : new Error('Unknown error');
-          }
-        }
-
-        // After all sources are processed, update overall assistant status
-        await updateAssistantSyncStatus(assistant, event);
-
-        // If all sources failed, throw error to surface to user
-        if (!hasAnySuccess && lastError) {
-          throw new Error(
-            `Failed to re-index all knowledge sources. Last error: ${lastError.message}`
-          );
-        }
-      } else {
-        console.log(
-          `Cleared all documents for assistant ${assistantId} (no new sources)`
-        );
-
-        // Update status even when clearing all documents
-        await updateAssistantSyncStatus(assistant, event);
-      }
+      console.log(`Queueing document re-index for assistant ${assistantId}`);
+      await updateAssistantSyncStatus(assistant, event);
+      await enqueueKnowledgeSync({
+        assistantId,
+        userId,
+        tenantId: getTenantId(event),
+        authorization: getAuthorizationHeader(event),
+        clearExistingIndex: true,
+      });
     }
 
     return ok200Response(stripAssistantPrefix(assistant));

--- a/packages/cdk/lambda/assistantKnowledgeSync.ts
+++ b/packages/cdk/lambda/assistantKnowledgeSync.ts
@@ -1,0 +1,186 @@
+import { APIGatewayProxyEvent } from 'aws-lambda';
+import {
+  getAssistant,
+  updateKnowledgeSourceStatus,
+  updateAssistantSyncStatus,
+} from './repository/assistant';
+import {
+  deleteAssistantDocuments,
+  indexDocuments,
+} from './repository/assistantSearch';
+import {
+  loadDocuments,
+  chunkDocuments,
+  addMetadata,
+} from './utils/documentLoader';
+
+type KnowledgeSyncRequest = {
+  assistantId: string;
+  userId: string;
+  tenantId: string;
+  authorization?: string;
+  clearExistingIndex?: boolean;
+};
+
+function buildRequestEvent(
+  payload: KnowledgeSyncRequest
+): APIGatewayProxyEvent {
+  return {
+    headers: {
+      Authorization: payload.authorization || '',
+    },
+    requestContext: {
+      authorizer: {
+        claims: {
+          'custom:tenant_id': payload.tenantId,
+          'cognito:username': payload.userId,
+        },
+        'custom:tenant_id': payload.tenantId,
+        'cognito:username': payload.userId,
+      },
+    },
+  } as APIGatewayProxyEvent;
+}
+
+function normalizeAssistantId(assistantId: string): string {
+  return assistantId.replace(/^assistant#/, '');
+}
+
+function getErrorMessage(error: unknown): string {
+  if (!(error instanceof Error)) {
+    return 'Unknown error';
+  }
+
+  let message = error.message;
+  if ('meta' in error && error.meta) {
+    const meta = error.meta as {
+      statusCode?: number;
+      body?: { Message?: string; error?: string | { reason?: string } };
+    };
+    if (meta.statusCode) {
+      message = `${error.message} (HTTP ${meta.statusCode})`;
+    }
+    if (meta.body && meta.body.Message) {
+      message += `: ${meta.body.Message}`;
+    } else if (meta.body && meta.body.error) {
+      if (typeof meta.body.error === 'string') {
+        message += `: ${meta.body.error}`;
+      } else if (meta.body.error.reason) {
+        message += `: ${meta.body.error.reason}`;
+      }
+    }
+  }
+
+  return message;
+}
+
+export const handler = async (event: KnowledgeSyncRequest): Promise<void> => {
+  if (!event?.assistantId || !event?.userId || !event?.tenantId) {
+    console.error('Missing knowledge sync payload fields:', event);
+    return;
+  }
+
+  const requestEvent = buildRequestEvent(event);
+  const assistant = await getAssistant(event.assistantId, requestEvent);
+
+  if (!assistant) {
+    console.error(`Assistant not found: ${event.assistantId}`);
+    return;
+  }
+
+  if (!assistant.ragEnabled) {
+    console.log(
+      `RAG is disabled for assistant ${assistant.assistantId}; skipping sync`
+    );
+    return;
+  }
+
+  const cleanAssistantId = normalizeAssistantId(assistant.assistantId);
+
+  if (event.clearExistingIndex) {
+    console.log(`Clearing documents for assistant ${cleanAssistantId}`);
+    await deleteAssistantDocuments(cleanAssistantId, requestEvent);
+  }
+
+  const sources = assistant.knowledgeSources || [];
+  if (sources.length === 0) {
+    console.log(`No knowledge sources to sync for ${cleanAssistantId}`);
+    await updateAssistantSyncStatus(assistant, requestEvent);
+    return;
+  }
+
+  let hasAnySuccess = false;
+  let lastError: Error | undefined;
+
+  for (const source of sources) {
+    try {
+      if (!source.id) {
+        source.id = crypto.randomUUID();
+        console.log(
+          `Generated ID ${source.id} for knowledge source without ID`
+        );
+      }
+
+      console.log(
+        `Processing knowledge source ${source.id} for assistant ${cleanAssistantId}`
+      );
+
+      await updateKnowledgeSourceStatus(
+        assistant,
+        source.id,
+        'SYNCING',
+        undefined,
+        requestEvent
+      );
+
+      const documents = await loadDocuments([source], event.userId, requestEvent);
+      const chunks = await chunkDocuments(documents, 1000, 200);
+      const docsWithMetadata = addMetadata(
+        chunks,
+        cleanAssistantId,
+        event.userId
+      );
+
+      await indexDocuments(cleanAssistantId, docsWithMetadata, requestEvent);
+
+      await updateKnowledgeSourceStatus(
+        assistant,
+        source.id,
+        'SUCCEEDED',
+        undefined,
+        requestEvent
+      );
+
+      hasAnySuccess = true;
+      console.log(
+        `Successfully indexed knowledge source ${source.id} for assistant ${cleanAssistantId}`
+      );
+    } catch (error) {
+      console.error(
+        `Error indexing knowledge source ${source.id}:`,
+        error
+      );
+
+      const errorMessage = getErrorMessage(error);
+      await updateKnowledgeSourceStatus(
+        assistant,
+        source.id!,
+        'FAILED',
+        errorMessage,
+        requestEvent
+      ).catch((statusError) => {
+        console.error('Failed to update source status:', statusError);
+      });
+
+      lastError = error instanceof Error ? error : new Error('Unknown error');
+    }
+  }
+
+  await updateAssistantSyncStatus(assistant, requestEvent);
+
+  if (!hasAnySuccess && lastError) {
+    throw new Error(
+      `Failed to index all knowledge sources. Last error: ${lastError.message}`
+    );
+  }
+};

--- a/packages/cdk/lib/construct/api/assistant.ts
+++ b/packages/cdk/lib/construct/api/assistant.ts
@@ -54,19 +54,46 @@ class AssistantApi extends Construct {
       }),
     });
 
+    // Background handler for knowledge sync (async indexing)
+    const knowledgeSyncHandler = new NodejsFunction(
+      this,
+      'AssistantKnowledgeSyncHandler',
+      {
+        runtime: LAMBDA_RUNTIME_NODEJS,
+        entry: './lambda/assistantKnowledgeSync.ts',
+        timeout: Duration.minutes(15),
+        environment: getBaseEnvironment(this, props, {
+          ASSISTANT_TABLE_NAME: ASSISTANT_TABLE_PREFIX,
+          DEFAULT_ASSISTANT_TABLE_NAME: assistantTable.tableName,
+          OPENSEARCH_INDEX: 'assistant-docs',
+          ASSISTANT_FILES_BUCKET_NAME: fileBucket?.bucketName || '',
+          TENANTS_TABLE_NAME: tenantManager?.tenantsTable.tableName || '',
+        }),
+      }
+    );
+
+    assistantHandler.addEnvironment(
+      'ASSISTANT_KNOWLEDGE_SYNC_FUNCTION_NAME',
+      knowledgeSyncHandler.functionName
+    );
+    knowledgeSyncHandler.grantInvoke(assistantHandler);
+
     // Grant permissions for all CRUD operations
     assistantTable.grantReadWriteData(assistantHandler);
     table.grantReadWriteData(assistantHandler);
+    assistantTable.grantReadWriteData(knowledgeSyncHandler);
 
     // Grant S3 read permissions for document loading (create/update operations)
     // Used for both legacy S3 URLs and new assistant file uploads
     if (fileBucket) {
       fileBucket.grantRead(assistantHandler);
+      fileBucket.grantRead(knowledgeSyncHandler);
     }
 
     // Grant Bedrock permissions for document embeddings (RAG indexing)
     if (props.bedrockPolicy) {
       assistantHandler.addToRolePolicy(props.bedrockPolicy);
+      knowledgeSyncHandler.addToRolePolicy(props.bedrockPolicy);
     }
 
     // Grant OpenSearch permissions for tenant OpenSearch domains (cross-account)
@@ -81,6 +108,19 @@ class AssistantApi extends Construct {
           'es:ESHttpHead',
         ],
         resources: ['*'], // Wildcard needed for multi-tenant cross-account access
+      })
+    );
+    knowledgeSyncHandler.addToRolePolicy(
+      new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: [
+          'es:ESHttpGet',
+          'es:ESHttpPost',
+          'es:ESHttpPut',
+          'es:ESHttpDelete',
+          'es:ESHttpHead',
+        ],
+        resources: ['*'],
       })
     );
 
@@ -321,6 +361,7 @@ class AssistantApi extends Construct {
     if (tenantManager) {
       tenantManager.tenantsTable.grantReadData(assistantHandler);
       tenantManager.tenantsTable.grantReadData(assistantMessageHandler);
+      tenantManager.tenantsTable.grantReadData(knowledgeSyncHandler);
     }
 
     // Grant LiteLLM proxy invocation permissions


### PR DESCRIPTION
## 概要
Assistant のRAG同期をリクエスト同期処理から非同期Lambdaに移行し、作成/更新APIはキューイングのみ行うように変更しました。

## 変更内容
- `assistantHandler` でknowledgeSourcesのID付与と同期Lambdaの非同期起動
- `assistantKnowledgeSync` でドキュメントのロード/分割/索引を実行
- CDKで新Lambda追加、環境変数と権限付与

## 影響/注意点
- RAG同期は非同期で完了が遅延します
- 再同期時は `clearExistingIndex` で既存を削除して再索引
