### PR TITLE
feat: AgentCore に一覧画面を追加しランタイム選択フローを改善

### DIFF
--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -120,9 +120,10 @@ agent_builder:
   updated: Updated date
 agent_core:
   model: Model
+  no_runtimes_available: No runtimes available
   runtime: Runtime
-  start_conversation: Start a conversation with AgentCore
-  title: AgentCore
+  start_conversation: Start a conversation with AI Agent
+  title: AI Agent
 agent_dashboard: {}
 auth:
   loading: Loading...
@@ -453,6 +454,12 @@ drawer:
   generative_ai: Generative AI
   tools: Tools
   use_cases: Use Cases
+error:
+  streamingError:
+    ACCESS_DENIED: The selected model is not enabled. Please enable the model in the Amazon Bedrock console.
+    PAYLOAD_TOO_LARGE: The attached file is too large. Please reduce the file size or number of attachments and try again.
+    THROTTLING: The server is currently experiencing high traffic. Please try again later.
+    UNKNOWN_ERROR: An error occurred. Please try again or contact the administrator.
 feedback:
   additional_feedback: If you have any additional feedback, please enter it here. (optional)
   reason_error: Please select a reason.
@@ -865,7 +872,16 @@ meetingMinutes:
   no_transcript: No Transcript
   option: Option
   partial_indicator: (...)
+  prompt_title_placeholder: Enter a name for this prompt...
   record_transcribe: Record & Transcribe
+  save_as_prompt: Save as Custom Prompt
+  saved_prompt_body: Prompt Content
+  saved_prompt_created: Custom prompt saved
+  saved_prompt_delete_confirm: Delete this prompt?
+  saved_prompt_deleted: Custom prompt deleted
+  saved_prompt_prefix: ★
+  saved_prompt_title: Prompt Title
+  saved_prompt_updated: Custom prompt updated
   screen_audio_error: Screen Audio Error
   settings: Settings
   speech_recognition: Speech Recognition
@@ -891,6 +907,7 @@ meetingMinutes:
 model:
   parameters:
     reasoning_budget: Token budget for extended thinking
+    reasoning_effort: Thinking effort level
 navigation:
   agentChat: Agent Chat
   chat: Chat
@@ -965,6 +982,18 @@ rag:
   please_refer: .
   retrieving: Retrieving reference documents from Kendra...
   title: RAG Chat
+research:
+  description: Conducts various research tasks across industries using web search and creates detailed research reports.
+  general_research: General Research
+  general_research_desc: Researches information across a wide range of fields and provides comprehensive analysis
+  label: Research
+  mini_research: Quick Research
+  mini_research_desc: Quickly researches key points and provides concise answers
+  select_mode: Select a mode
+  start_conversation: Start conversation with Research Agent
+  technical_research: Technical Research
+  technical_research_desc: Conducts detailed technical research and analysis
+  title: Research
 setting:
   ai_items:
     agent_name: Agent Name
@@ -1036,6 +1065,15 @@ summarize:
   result_placeholder: Summarized text will be displayed here
   text_to_summarize: Text to summarize
   title: Summarize
+svg:
+  download_as_png: Download as PNG
+  download_as_svg: Download as SVG
+  invalid_syntax: Invalid SVG syntax
+  png_error: 'PNG output error: '
+  preview_alt: SVG Preview
+  show_code: Show Code
+  show_preview: Show Preview
+  svg_error: 'SVG output error: '
 transcribe:
   detailed_parameters: Detailed parameters
   direct_input: Direct Input

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -111,6 +111,7 @@ agent_builder:
   updated: 更新日
 agent_core:
   model: モデル
+  no_runtimes_available: 利用可能なランタイムがありません
   runtime: ランタイム
   start_conversation: AIエージェントと会話を始める
   title: AIエージェント
@@ -197,7 +198,7 @@ common:
   submit: 送信
   title: タイトル
   trace: トレース
-  try: 開く
+  try: 試す
   update: 更新
 demo:
   inter_use_cases: ユースケース連携
@@ -391,6 +392,12 @@ drawer:
   generative_ai: (生成 AI)
   tools: ツール
   use_cases: ユースケース
+error:
+  streamingError:
+    ACCESS_DENIED: 選択されたモデルが有効化されていません。Amazon Bedrock コンソールでモデルを有効化してください。
+    PAYLOAD_TOO_LARGE: 添付ファイルのサイズが大きすぎます。ファイルサイズまたは添付数を減らして再度お試しください。
+    THROTTLING: サーバーが混み合っています。しばらく待ってから再度お試しください。
+    UNKNOWN_ERROR: エラーが発生しました。再度お試しいただくか、管理者にお問い合わせください。
 feedback:
   additional_feedback: 他にフィードバックがありましたら、入力してください。(任意)
   reason_error: 理由を選択してください。
@@ -557,8 +564,8 @@ landing:
         Bases for Amazon Bedrock のベクトルデータベースを参照することが可能です。
       title: Agent チャット
     agent_core:
-      description: AIエージェントチャットは Bedrock AgentCore で作成したさまざまな AIエージェント を利用する機能です
-      title: AIエージェント
+      description: AgentCore チャットは Bedrock AgentCore で作成したさまざまな Agent を利用する機能です
+      title: AgentCore
     chat:
       description: >-
         LLM
@@ -711,7 +718,16 @@ meetingMinutes:
   no_transcript: 文字起こしがありません
   option: オプション
   partial_indicator: (...)
+  prompt_title_placeholder: プロンプトの名前を入力してください...
   record_transcribe: 音声認識
+  save_as_prompt: カスタムプロンプトとして保存
+  saved_prompt_body: プロンプト内容
+  saved_prompt_created: カスタムプロンプトを保存しました
+  saved_prompt_delete_confirm: このプロンプトを削除しますか？
+  saved_prompt_deleted: カスタムプロンプトを削除しました
+  saved_prompt_prefix: ★
+  saved_prompt_title: プロンプトタイトル
+  saved_prompt_updated: カスタムプロンプトを更新しました
   screen_audio_error: スクリーン音声エラー
   settings: 設定
   speech_recognition: 音声認識
@@ -737,6 +753,7 @@ meetingMinutes:
 model:
   parameters:
     reasoning_budget: 深く考えるトークン数上限
+    reasoning_effort: 思考の深さ (Effort)
 navigation:
   agentChat: Agent チャット
   chat: チャット
@@ -792,6 +809,18 @@ rag:
   please_refer: をご参照ください。
   retrieving: Kendra から参考ドキュメントを取得しています...
   title: RAG チャット
+research:
+  description: 業種・業界問わず様々なリサーチタスクを Web 検索を駆使して実施し、詳細な調査レポートを作成します。
+  general_research: 一般調査
+  general_research_desc: 幅広い分野の情報を調査し、総合的な分析を提供します
+  label: リサーチ
+  mini_research: クイック調査
+  mini_research_desc: 短時間で要点を調査し、簡潔な回答を提供します
+  select_mode: モードを選択してください
+  start_conversation: リサーチエージェントと会話を開始
+  technical_research: 技術調査
+  technical_research_desc: 詳細な技術調査と分析を実施します
+  title: リサーチ
 setting:
   ai_items:
     agent_name: Agent 名
@@ -859,6 +888,15 @@ summarize:
   result_placeholder: 要約された文章がここに表示されます
   text_to_summarize: 要約したい文章
   title: 要約
+svg:
+  download_as_png: PNGとしてダウンロード
+  download_as_svg: SVGとしてダウンロード
+  invalid_syntax: 無効なSVG構文
+  png_error: 'PNG出力エラー: '
+  preview_alt: SVGプレビュー
+  show_code: コードを表示
+  show_preview: プレビューを表示
+  svg_error: 'SVG出力エラー: '
 transcribe:
   detailed_parameters: 詳細なパラメータ
   direct_input: 直接入力

--- a/packages/web/public/locales/translation/ko.yaml
+++ b/packages/web/public/locales/translation/ko.yaml
@@ -2,8 +2,9 @@ agent:
   drop_files: 파일을 드롭하여 업로드
   title: 에이전트 채팅
 agent_core:
-  start_conversation: AgentCore와 대화 시작
-  title: AgentCore
+  no_runtimes_available: 사용 가능한 런타임이 없습니다
+  start_conversation: AI 에이전트와 대화 시작
+  title: AI 에이전트
 auth:
   loading: 로딩 중...
   login: 로그인
@@ -38,6 +39,7 @@ chat:
   title: 채팅
   view_prompt_examples: 프롬프트 예시 보기
 common:
+  back: 뒤로
   cancel: 취소
   clear: 지우기
   close: 닫기
@@ -305,6 +307,12 @@ drawer:
   generative_ai: 생성형 AI
   tools: 도구
   use_cases: 사용 사례
+error:
+  streamingError:
+    ACCESS_DENIED: 선택한 모델이 활성화되어 있지 않습니다. Amazon Bedrock 콘솔에서 모델을 활성화해 주세요.
+    PAYLOAD_TOO_LARGE: 첨부 파일의 크기가 너무 큽니다. 파일 크기 또는 첨부 파일 수를 줄이고 다시 시도해 주세요.
+    THROTTLING: 서버에 트래픽이 집중되고 있습니다. 잠시 후 다시 시도해 주세요.
+    UNKNOWN_ERROR: 오류가 발생했습니다. 다시 시도하거나 관리자에게 문의해 주세요.
 feedback:
   additional_feedback: 추가 피드백이 있으시면 여기에 입력해주세요. (선택사항)
   reason_error: 이유를 선택해주세요.
@@ -448,7 +456,16 @@ meetingMinutes:
   next_generation_in: '다음 생성까지: '
   no_transcript: 전사 없음
   partial_indicator: (...)
+  prompt_title_placeholder: 프롬프트 이름을 입력하세요...
   record_transcribe: 녹음 및 전사
+  save_as_prompt: 사용자 정의 프롬프트로 저장
+  saved_prompt_body: 프롬프트 내용
+  saved_prompt_created: 사용자 정의 프롬프트가 저장되었습니다
+  saved_prompt_delete_confirm: 이 프롬프트를 삭제하시겠습니까?
+  saved_prompt_deleted: 사용자 정의 프롬프트가 삭제되었습니다
+  saved_prompt_prefix: ★
+  saved_prompt_title: 프롬프트 제목
+  saved_prompt_updated: 사용자 정의 프롬프트가 업데이트되었습니다
   screen_audio_error: 화면 오디오 오류
   speech_recognition: 음성 인식
   style: 회의록 스타일
@@ -468,6 +485,7 @@ model:
   parameters:
     reasoning: 추론
     reasoning_budget: 추론 예산
+    reasoning_effort: 사고 깊이
 navigation:
   agentChat: 에이전트 채팅
   chat: 채팅
@@ -537,6 +555,18 @@ rag:
   please_refer: .
   retrieving: Kendra에서 참조 문서를 검색하는 중...
   title: RAG 채팅
+research:
+  description: 웹 검색을 활용하여 산업 전반에 걸친 다양한 연구 작업을 수행하고 상세한 연구 보고서를 작성합니다.
+  general_research: 일반 조사
+  general_research_desc: 광범위한 분야의 정보를 조사하고 종합적인 분석을 제공합니다
+  label: 리서치
+  mini_research: 빠른 조사
+  mini_research_desc: 핵심 사항을 빠르게 조사하고 간결한 답변을 제공합니다
+  select_mode: 모드를 선택하세요
+  start_conversation: 리서치 에이전트와 대화 시작
+  technical_research: 기술 조사
+  technical_research_desc: 상세한 기술 조사 및 분석을 수행합니다
+  title: 리서치
 setting:
   ai_items:
     agent_name: 에이전트 이름
@@ -606,6 +636,15 @@ summarize:
   result_placeholder: 요약된 텍스트가 여기에 표시됩니다
   text_to_summarize: 요약할 텍스트
   title: 요약
+svg:
+  download_as_png: PNG로 다운로드
+  download_as_svg: SVG로 다운로드
+  invalid_syntax: 잘못된 SVG 구문
+  png_error: 'PNG 출력 오류: '
+  preview_alt: SVG 미리보기
+  show_code: 코드 표시
+  show_preview: 미리보기 표시
+  svg_error: 'SVG 출력 오류: '
 transcribe:
   detailed_parameters: 세부 매개변수
   direct_input: 직접 입력

--- a/packages/web/src/App.tsx
+++ b/packages/web/src/App.tsx
@@ -152,7 +152,7 @@ const App: React.FC = () => {
       : null,
     agentBuilderEnabled
       ? {
-          label: 'AIエージェントビルダー',
+          label: t('agent_builder.title'),
           to: '/agent-builder',
           icon: <PiRobot />,
           display: 'usecase' as const,

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -216,7 +216,7 @@ const routes: RouteObject[] = [
     : null,
   agentCoreEnabled
     ? {
-        path: '/agent-core/:agentArn',
+        path: '/agent-core/:agentName',
         element: <AgentCorePage />,
       }
     : null,

--- a/packages/web/src/main.tsx
+++ b/packages/web/src/main.tsx
@@ -31,6 +31,7 @@ import AgentChatPage from './pages/AgentChatPage';
 import FlowChatPage from './pages/FlowChatPage';
 import VoiceChatPage from './pages/VoiceChatPage';
 import McpChatPage from './pages/McpChatPage';
+import AgentCoreListPage from './pages/AgentCoreListPage.tsx';
 import AgentCorePage from './pages/AgentCorePage.tsx';
 import AgentBuilderListPage from './pages/agentBuilder/AgentBuilderListPage.tsx';
 import AgentBuilderEditPage from './pages/agentBuilder/AgentBuilderEditPage';
@@ -210,7 +211,7 @@ const routes: RouteObject[] = [
   agentCoreEnabled
     ? {
         path: '/agent-core',
-        element: <AgentCorePage />,
+        element: <AgentCoreListPage />,
       }
     : null,
   agentCoreEnabled

--- a/packages/web/src/pages/AgentCoreListPage.tsx
+++ b/packages/web/src/pages/AgentCoreListPage.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import Card from '../components/Card';
+import { PiRobot as RobotIcon } from 'react-icons/pi';
+import { useAgentCore } from '../hooks/useAgentCore';
+
+const AgentCoreListPage: React.FC = () => {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const { getAllAvailableRuntimes, getGenericRuntime, getExternalRuntimes } =
+    useAgentCore('/agent-core-list');
+
+  const allRuntimes = getAllAvailableRuntimes();
+  const genericRuntime = getGenericRuntime();
+  const externalRuntimes = getExternalRuntimes();
+
+  const handleSelect = (arn: string) => {
+    navigate(`/agent-core/${encodeURIComponent(arn)}`);
+  };
+
+  return (
+    <div className="flex flex-col gap-4 p-4">
+      <div className="flex flex-row items-center justify-center">
+        <div className="text-xl font-semibold">{t('agent_core.title')}</div>
+      </div>
+
+      {allRuntimes.length === 0 ? (
+        <div className="flex flex-col items-center justify-center py-16 text-gray-400">
+          <RobotIcon className="mb-4 h-12 w-12" />
+          <p className="text-sm font-bold">
+            {t('agent_core.no_runtimes_available')}
+          </p>
+        </div>
+      ) : (
+        <Card>
+          {allRuntimes.map((runtime, idx) => {
+            const isGeneric =
+              genericRuntime && runtime.arn === genericRuntime.arn;
+            const isExternal = externalRuntimes.some(
+              (r) => r.arn === runtime.arn
+            );
+            const tag = isGeneric
+              ? 'Generic'
+              : isExternal
+                ? 'External'
+                : undefined;
+
+            return (
+              <div
+                key={runtime.arn}
+                className={`flex cursor-pointer flex-row items-center gap-3 p-3 hover:bg-gray-100 ${idx > 0 ? 'border-t' : ''}`}
+                onClick={() => handleSelect(runtime.arn)}>
+                <RobotIcon className="h-8 w-8 shrink-0 text-gray-400" />
+                <div className="flex flex-1 flex-col">
+                  <div className="mb-1 flex items-center gap-2">
+                    <span className="text-sm font-bold">{runtime.name}</span>
+                    {tag && (
+                      <span className="inline-flex items-center rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-700">
+                        {tag}
+                      </span>
+                    )}
+                  </div>
+                  {runtime.description && (
+                    <span className="line-clamp-2 text-xs font-light text-gray-600">
+                      {runtime.description}
+                    </span>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </Card>
+      )}
+    </div>
+  );
+};
+
+export default AgentCoreListPage;

--- a/packages/web/src/pages/AgentCoreListPage.tsx
+++ b/packages/web/src/pages/AgentCoreListPage.tsx
@@ -16,8 +16,8 @@ const AgentCoreListPage: React.FC = () => {
   const genericRuntime = getGenericRuntime();
   const externalRuntimes = getExternalRuntimes();
 
-  const handleSelect = (arn: string) => {
-    navigate(`/agent-core/${encodeURIComponent(arn)}`);
+  const handleSelect = (name: string) => {
+    navigate(`/agent-core/${encodeURIComponent(name)}`);
   };
 
   return (
@@ -51,7 +51,7 @@ const AgentCoreListPage: React.FC = () => {
               <div
                 key={runtime.arn}
                 className={`flex cursor-pointer flex-row items-center gap-3 p-3 hover:bg-gray-100 ${idx > 0 ? 'border-t' : ''}`}
-                onClick={() => handleSelect(runtime.arn)}>
+                onClick={() => handleSelect(runtime.name)}>
                 <RobotIcon className="h-8 w-8 shrink-0 text-gray-400" />
                 <div className="flex flex-1 flex-col">
                   <div className="mb-1 flex items-center gap-2">

--- a/packages/web/src/pages/AgentCorePage.tsx
+++ b/packages/web/src/pages/AgentCorePage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { useLocation, useParams } from 'react-router-dom';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
 import InputChatContent from '../components/InputChatContent';
 import ChatMessage from '../components/ChatMessage';
 import Select from '../components/Select';
@@ -70,6 +70,7 @@ const AgentCorePage: React.FC = () => {
   const { t } = useTranslation();
   const { agentArn } = useParams<{ agentArn?: string }>();
   const { pathname } = useLocation();
+  const navigate = useNavigate();
   const { content, setContent } = useAgentCorePageState();
 
   const {
@@ -103,18 +104,14 @@ const AgentCorePage: React.FC = () => {
 
   const { clear: clearFiles, uploadFiles, uploadedFiles } = useFiles(pathname);
 
-  // Set the ARN from URL parameter or first available ARN as default
+  // Set the ARN from URL parameter
   useEffect(() => {
     if (agentArn) {
-      // If agentArn is provided in URL, use it
       const decodedArn = decodeURIComponent(agentArn);
       setSelectedArn(decodedArn);
-    } else if (allAvailableRuntimes.length > 0 && !selectedArn) {
-      // Otherwise, use the first available ARN
-      setSelectedArn(allAvailableRuntimes[0].arn);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [agentArn, allAvailableRuntimes]);
+     
+  }, [agentArn]);
 
   // Initialize system context and model ID only once on mount
   useEffect(() => {
@@ -214,40 +211,21 @@ const AgentCorePage: React.FC = () => {
     }
   };
 
-  // Prepare runtime options
+  // Prepare runtime options (only the selected runtime)
   const runtimeOptions = useMemo(() => {
-    // If agentArn is provided, only show that specific runtime
-    if (agentArn) {
-      const decodedArn = decodeURIComponent(agentArn);
-      const runtime = allAvailableRuntimes.find((r) => r.arn === decodedArn);
-      if (runtime) {
-        const isGeneric = genericRuntime && runtime.arn === genericRuntime.arn;
-        const isExternal = externalRuntimes.some((r) => r.arn === runtime.arn);
-        return [
-          {
-            value: runtime.arn,
-            label: runtime.name,
-            tags: isGeneric
-              ? ['Generic']
-              : isExternal
-                ? ['External']
-                : undefined,
-          },
-        ];
-      }
-      return [];
-    }
-
-    // Otherwise, show all available runtimes
-    return allAvailableRuntimes.map((runtime) => {
-      const isGeneric = genericRuntime && runtime.arn === genericRuntime.arn;
-      const isExternal = externalRuntimes.some((r) => r.arn === runtime.arn);
-      return {
+    if (!agentArn) return [];
+    const decodedArn = decodeURIComponent(agentArn);
+    const runtime = allAvailableRuntimes.find((r) => r.arn === decodedArn);
+    if (!runtime) return [];
+    const isGeneric = genericRuntime && runtime.arn === genericRuntime.arn;
+    const isExternal = externalRuntimes.some((r) => r.arn === runtime.arn);
+    return [
+      {
         value: runtime.arn,
         label: runtime.name,
         tags: isGeneric ? ['Generic'] : isExternal ? ['External'] : undefined,
-      };
-    });
+      },
+    ];
   }, [agentArn, allAvailableRuntimes, genericRuntime, externalRuntimes]);
 
   // Prepare model options
@@ -279,7 +257,23 @@ const AgentCorePage: React.FC = () => {
       <div
         onDragOver={fileUpload ? handleDragOver : undefined}
         className={`${!isEmpty ? 'screen:pb-48' : ''} relative`}>
-        <div className="invisible my-0 flex h-0 items-center justify-center text-xl font-semibold lg:visible lg:my-5 lg:h-min print:visible print:my-5 print:h-min">
+        {agentArn && (
+          <div className="flex items-center px-4 py-2 lg:hidden print:hidden">
+            <button
+              className="text-sm font-normal text-gray-500 hover:text-gray-800"
+              onClick={() => navigate('/agent-core')}>
+              {t('common.back')}
+            </button>
+          </div>
+        )}
+        <div className="invisible my-0 flex h-0 items-center justify-center gap-4 text-xl font-semibold lg:visible lg:my-5 lg:h-min print:visible print:my-5 print:h-min">
+          {agentArn && (
+            <button
+              className="text-sm font-normal text-gray-500 hover:text-gray-800"
+              onClick={() => navigate('/agent-core')}>
+              {t('common.back')}
+            </button>
+          )}
           {pageTitle}
         </div>
 
@@ -299,19 +293,6 @@ const AgentCorePage: React.FC = () => {
 
         {/* Selection Controls */}
         <div className="my-2 flex w-full flex-col items-center justify-center gap-x-2 md:flex-row print:hidden">
-          {/* AgentCore Runtime Selection - Hide if specific agent is selected */}
-          {!agentArn && (
-            <div className="w-4/5 sm:w-1/2 md:w-fit">
-              <Select
-                value={selectedArn}
-                onChange={setSelectedArn}
-                options={runtimeOptions}
-                label={t('agent_core.runtime')}
-                fullWidth
-                showTags
-              />
-            </div>
-          )}
           {/* Model Selection */}
           <div className="w-4/5 sm:w-1/2 md:w-fit">
             <Select

--- a/packages/web/src/pages/AgentCorePage.tsx
+++ b/packages/web/src/pages/AgentCorePage.tsx
@@ -68,7 +68,7 @@ const useAgentCorePageState = create<StateType>((set) => {
 
 const AgentCorePage: React.FC = () => {
   const { t } = useTranslation();
-  const { agentArn } = useParams<{ agentArn?: string }>();
+  const { agentName } = useParams<{ agentName?: string }>();
   const { pathname } = useLocation();
   const navigate = useNavigate();
   const { content, setContent } = useAgentCorePageState();
@@ -104,14 +104,16 @@ const AgentCorePage: React.FC = () => {
 
   const { clear: clearFiles, uploadFiles, uploadedFiles } = useFiles(pathname);
 
-  // Set the ARN from URL parameter
+  // Set the ARN from URL parameter (look up by name)
   useEffect(() => {
-    if (agentArn) {
-      const decodedArn = decodeURIComponent(agentArn);
-      setSelectedArn(decodedArn);
+    if (agentName && allAvailableRuntimes.length > 0) {
+      const decodedName = decodeURIComponent(agentName);
+      const runtime = allAvailableRuntimes.find((r) => r.name === decodedName);
+      if (runtime) {
+        setSelectedArn(runtime.arn);
+      }
     }
-     
-  }, [agentArn]);
+  }, [agentName, allAvailableRuntimes]);
 
   // Initialize system context and model ID only once on mount
   useEffect(() => {
@@ -213,9 +215,9 @@ const AgentCorePage: React.FC = () => {
 
   // Prepare runtime options (only the selected runtime)
   const runtimeOptions = useMemo(() => {
-    if (!agentArn) return [];
-    const decodedArn = decodeURIComponent(agentArn);
-    const runtime = allAvailableRuntimes.find((r) => r.arn === decodedArn);
+    if (!agentName) return [];
+    const decodedName = decodeURIComponent(agentName);
+    const runtime = allAvailableRuntimes.find((r) => r.name === decodedName);
     if (!runtime) return [];
     const isGeneric = genericRuntime && runtime.arn === genericRuntime.arn;
     const isExternal = externalRuntimes.some((r) => r.arn === runtime.arn);
@@ -226,7 +228,7 @@ const AgentCorePage: React.FC = () => {
         tags: isGeneric ? ['Generic'] : isExternal ? ['External'] : undefined,
       },
     ];
-  }, [agentArn, allAvailableRuntimes, genericRuntime, externalRuntimes]);
+  }, [agentName, allAvailableRuntimes, genericRuntime, externalRuntimes]);
 
   // Prepare model options
   const modelOptions = useMemo(() => {
@@ -238,15 +240,11 @@ const AgentCorePage: React.FC = () => {
 
   // Calculate page title from runtime options
   const pageTitle = useMemo(() => {
-    if (agentArn && runtimeOptions.length > 0) {
-      // Find the runtime name from runtimeOptions
-      const runtime = runtimeOptions.find(
-        (option) => option.value === decodeURIComponent(agentArn)
-      );
-      return runtime ? runtime.label : t('agent_core.title', 'AgentCore');
+    if (agentName && runtimeOptions.length > 0) {
+      return runtimeOptions[0].label;
     }
     return t('agent_core.title', 'AgentCore');
-  }, [agentArn, runtimeOptions, t]);
+  }, [agentName, runtimeOptions, t]);
 
   const showingMessages = useMemo(() => {
     return messages;
@@ -257,7 +255,7 @@ const AgentCorePage: React.FC = () => {
       <div
         onDragOver={fileUpload ? handleDragOver : undefined}
         className={`${!isEmpty ? 'screen:pb-48' : ''} relative`}>
-        {agentArn && (
+        {agentName && (
           <div className="flex items-center px-4 py-2 lg:hidden print:hidden">
             <button
               className="text-sm font-normal text-gray-500 hover:text-gray-800"
@@ -267,7 +265,7 @@ const AgentCorePage: React.FC = () => {
           </div>
         )}
         <div className="invisible my-0 flex h-0 items-center justify-center gap-4 text-xl font-semibold lg:visible lg:my-5 lg:h-min print:visible print:my-5 print:h-min">
-          {agentArn && (
+          {agentName && (
             <button
               className="text-sm font-normal text-gray-500 hover:text-gray-800"
               onClick={() => navigate('/agent-core')}>


### PR DESCRIPTION
## 概要

AgentCore ページにランタイム一覧画面を追加し、AgentBuilder と同様に
一覧 → チャット画面の遷移フローに変更しました。

## 変更内容

### 新規
- `AgentCoreListPage.tsx` を追加
  - 利用可能なランタイム（Generic / External）をカード形式で一覧表示
  - ランタイムをクリックするとチャット画面へ遷移
  - ランタイムが0件の場合は空状態を表示

### 変更
- `/agent-core` のルートを `AgentCorePage` から `AgentCoreListPage` に変更
- `AgentCorePage` に戻るボタンを追加（`agentArn` がある場合のみ表示）
- 翻訳ファイル（ja / en / ko）に `agent_core.no_runtimes_available` キーを追加

## 変更前後の遷移フロー

**変更前**
/agent-core → チャット画面（ドロップダウンでランタイム選択）



**変更後**
/agent-core → 一覧画面（ランタイム選択）
↓ クリック
/agent-core/:agentArn → チャット画面
↓ 戻るボタン
/agent-core → 一覧画面