### PR TITLE
fix: AgentCoreのリセット時にsessionIdを再生成してバックエンドの会話記憶を消去

### DIFF
--- a/packages/web/src/components/agentBuilder/AgentChatUnified.tsx
+++ b/packages/web/src/components/agentBuilder/AgentChatUnified.tsx
@@ -77,7 +77,9 @@ const AgentChatUnified: React.FC<AgentChatProps> = ({
 
   // Generate session ID if not provided
   const { pathname } = useLocation();
-  const [sessionId] = useState(() => providedSessionId || uuidv4());
+  const [sessionId, setSessionId] = useState(
+    () => providedSessionId || uuidv4()
+  );
   const { scrollableContainer, setFollowing } = useFollow();
 
   // AgentCore for chat functionality
@@ -233,6 +235,7 @@ Please respond as this agent with the specified behavior and personality.`;
     clearChat();
     setChatContent('');
     clearFiles();
+    setSessionId(uuidv4());
   }, [clearChat, clearFiles]);
 
   // Handle drag and drop for files

--- a/packages/web/src/pages/AgentCorePage.tsx
+++ b/packages/web/src/pages/AgentCorePage.tsx
@@ -98,7 +98,7 @@ const AgentCorePage: React.FC = () => {
   const modelId = getModelId();
 
   const [selectedArn, setSelectedArn] = useState('');
-  const [sessionId] = useState(uuidv4());
+  const [sessionId, setSessionId] = useState(uuidv4());
   const [isOver, setIsOver] = useState(false);
   const [writing, setWriting] = useState(false);
 
@@ -186,6 +186,7 @@ const AgentCorePage: React.FC = () => {
     clear();
     setContent('');
     clearFiles();
+    setSessionId(uuidv4());
   }, [clear, clearFiles, setContent]);
 
   // Handle stop generation


### PR DESCRIPTION
## 概要

AgentCoreのチャット画面で「最初からやり直す」ボタンを押しても、バックエンドの会話記憶が引き継がれる不具合を修正

## 原因

`sessionId` はコンポーネントのマウント時に一度だけ生成され、リセット時に再生成されていなかった。

リセットボタンを押すとローカルのチャット履歴（Zustand）はクリアされるが、`sessionId` が変わらないため、次回送信時に同じ `runtimeSessionId` が AWS BedrockAgentCore に渡され、バックエンドが以前の会話記憶を保持したまま応答していた。
ページリロードではコンポーネントが再マウントされて新しい UUID が生成されるため記憶がリセットされており、症状と一致する。

## 修正内容

リセット時に `setSessionId(uuidv4())` を呼び出し、新しいセッション ID を生成するようにした。

| ファイル | 変更箇所 |
|---|---|
| `AgentCorePage.tsx` | `onReset` に `setSessionId(uuidv4())` を追加 |
| `AgentChatUnified.tsx` | `handleResetChat` に `setSessionId(uuidv4())` を追加 |

## 確認手順

1. AgentCore チャット画面を開く
2. 会話を数往復行う
3. 「最初からやり直す」ボタンをクリック
4. 「さっき何の話をしていましたか？」など直前の会話を参照する質問をする
5. バックエンドが以前の会話を知らない旨を回答することを確認する
6. AgentBuilder のチャット画面でも同様に確認する
