### PR TITLE
feat: cdk.jsonのmfaRequiredパラメータによるTOTP 2段階認証の制御を追加

### DIFF
--- a/packages/cdk/lambda/admin/resetMfa.ts
+++ b/packages/cdk/lambda/admin/resetMfa.ts
@@ -1,0 +1,40 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import {
+  CognitoIdentityProviderClient,
+  AdminSetUserMFAPreferenceCommand,
+} from '@aws-sdk/client-cognito-identity-provider';
+import { isAdmin, successResponse, errorResponse } from './utils';
+
+const client = new CognitoIdentityProviderClient({});
+const USER_POOL_ID = process.env.USER_POOL_ID!;
+
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    if (!isAdmin(event)) {
+      return errorResponse(403, 'Admin access required');
+    }
+
+    const username = event.pathParameters!.username!;
+
+    await client.send(
+      new AdminSetUserMFAPreferenceCommand({
+        UserPoolId: USER_POOL_ID,
+        Username: username,
+        SoftwareTokenMfaSettings: {
+          Enabled: false,
+          PreferredMfa: false,
+        },
+      })
+    );
+
+    return successResponse({ message: 'MFA reset successfully' });
+  } catch (error) {
+    console.log(error);
+    if ((error as { name?: string }).name === 'UserNotFoundException') {
+      return errorResponse(404, 'User not found');
+    }
+    return errorResponse(500, 'Internal Server Error');
+  }
+};

--- a/packages/cdk/lib/construct/admin-api.ts
+++ b/packages/cdk/lib/construct/admin-api.ts
@@ -51,6 +51,7 @@ export class AdminApi extends Construct {
         'cognito-idp:AdminListGroupsForUser',
         'cognito-idp:DescribeUserPool',
         'cognito-idp:UpdateUserPool',
+        'cognito-idp:AdminSetUserMFAPreference',
       ],
       resources: [userPool.userPoolArn],
     });
@@ -136,6 +137,19 @@ export class AdminApi extends Construct {
     );
     updateUserGroupsFunction.addToRolePolicy(cognitoAdminPolicy);
 
+    const resetMfaFunction = new NodejsFunction(this, 'ResetMfa', {
+      runtime: LAMBDA_RUNTIME_NODEJS,
+      entry: './lambda/admin/resetMfa.ts',
+      timeout: Duration.minutes(1),
+      environment: commonEnv,
+      bundling: {
+        nodeModules: ['@aws-sdk/client-cognito-identity-provider'],
+      },
+      vpc,
+      securityGroups,
+    });
+    resetMfaFunction.addToRolePolicy(cognitoAdminPolicy);
+
     const getPasswordPolicyFunction = new NodejsFunction(
       this,
       'GetPasswordPolicy',
@@ -218,6 +232,16 @@ export class AdminApi extends Construct {
     enableResource.addMethod(
       'POST',
       new LambdaIntegration(enableUserFunction),
+      commonAuthorizerProps
+    );
+
+    // /admin/users/{username}/reset-mfa
+    const resetMfaResource = userResource.addResource('reset-mfa');
+
+    // POST /admin/users/{username}/reset-mfa
+    resetMfaResource.addMethod(
+      'POST',
+      new LambdaIntegration(resetMfaFunction),
       commonAuthorizerProps
     );
 

--- a/packages/cdk/lib/construct/auth.ts
+++ b/packages/cdk/lib/construct/auth.ts
@@ -1,6 +1,7 @@
 import { Duration } from 'aws-cdk-lib';
 import {
   CfnUserPoolGroup,
+  Mfa,
   UserPool,
   UserPoolClient,
   UserPoolOperation,
@@ -19,6 +20,7 @@ export interface AuthProps {
   readonly allowedIpV4AddressRanges?: string[] | null;
   readonly allowedIpV6AddressRanges?: string[] | null;
   readonly allowedSignUpEmailDomains?: string[] | null;
+  readonly mfaRequired: boolean;
   readonly samlAuthEnabled: boolean;
 }
 
@@ -44,6 +46,11 @@ export class Auth extends Construct {
         requireSymbols: true,
         requireDigits: true,
         minLength: 8,
+      },
+      mfa: props.mfaRequired ? Mfa.REQUIRED : Mfa.OFF,
+      mfaSecondFactor: {
+        sms: false,
+        otp: true,
       },
     });
 

--- a/packages/cdk/lib/construct/auth.ts
+++ b/packages/cdk/lib/construct/auth.ts
@@ -47,7 +47,10 @@ export class Auth extends Construct {
         requireDigits: true,
         minLength: 8,
       },
-      mfa: props.mfaRequired ? Mfa.REQUIRED : Mfa.OFF,
+      // Use Mfa.OPTIONAL and enforce MFA at the application level.
+      // Mfa.REQUIRED causes AdminSetUserMFAPreference to be ignored,
+      // so we use OPTIONAL and force setup on the frontend when MFA is not configured.
+      mfa: props.mfaRequired ? Mfa.OPTIONAL : Mfa.OFF,
       mfaSecondFactor: {
         sms: false,
         otp: true,

--- a/packages/cdk/lib/construct/web.ts
+++ b/packages/cdk/lib/construct/web.ts
@@ -71,6 +71,7 @@ export interface WebProps {
   readonly agentCoreAgentBuilderRuntime?: AgentCoreConfiguration;
   readonly agentCoreExternalRuntimes: AgentCoreConfiguration[];
   readonly agentCoreRegion?: string;
+  readonly mfaRequired: boolean;
   readonly schedulerEnabled: boolean;
   readonly brandingConfig?: {
     logoPath?: string;
@@ -286,6 +287,7 @@ export class Web extends Construct {
         VITE_APP_FLOW_STREAM_FUNCTION_ARN: props.flowStreamFunctionArn,
         VITE_APP_OPTIMIZE_PROMPT_FUNCTION_ARN: props.optimizePromptFunctionArn,
         VITE_APP_SELF_SIGN_UP_ENABLED: props.selfSignUpEnabled.toString(),
+        VITE_APP_MFA_REQUIRED: props.mfaRequired.toString(),
         VITE_APP_MODEL_REGION: props.modelRegion,
         VITE_APP_MODEL_IDS: JSON.stringify(props.modelIds),
         VITE_APP_IMAGE_MODEL_IDS: JSON.stringify(props.imageGenerationModelIds),

--- a/packages/cdk/lib/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/generative-ai-use-cases-stack.ts
@@ -142,6 +142,7 @@ export class GenerativeAiUseCasesStack extends Stack {
       allowedIpV4AddressRanges: params.allowedIpV4AddressRanges,
       allowedIpV6AddressRanges: params.allowedIpV6AddressRanges,
       allowedSignUpEmailDomains: params.allowedSignUpEmailDomains,
+      mfaRequired: params.mfaRequired,
       samlAuthEnabled: params.samlAuthEnabled,
     });
 

--- a/packages/cdk/lib/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/generative-ai-use-cases-stack.ts
@@ -276,6 +276,7 @@ export class GenerativeAiUseCasesStack extends Stack {
       userPoolClientId: auth.client.userPoolClientId,
       idPoolId: auth.idPool.identityPoolId,
       selfSignUpEnabled: params.selfSignUpEnabled,
+      mfaRequired: params.mfaRequired,
       samlAuthEnabled: params.samlAuthEnabled,
       samlCognitoDomainName: params.samlCognitoDomainName,
       samlCognitoFederatedIdentityProviderName:

--- a/packages/cdk/lib/stack-input.ts
+++ b/packages/cdk/lib/stack-input.ts
@@ -10,6 +10,7 @@ const baseStackInputSchema = z.object({
   // Auth
   selfSignUpEnabled: z.boolean().default(true),
   allowedSignUpEmailDomains: z.array(z.string()).nullish(),
+  mfaRequired: z.boolean().default(false),
   samlAuthEnabled: z.boolean().default(false),
   samlCognitoDomainName: z.string().nullish(),
   samlCognitoFederatedIdentityProviderName: z.string().nullish(),

--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -40,6 +40,10 @@ admin:
     enabled_yes: Enabled
     grant_admin: Grant admin role
     groups_error: Failed to update role.
+    reset_mfa: Reset MFA
+    reset_mfa_confirm: 'Are you sure you want to reset MFA for {{email}}? They will need to set up MFA again on next login.'
+    reset_mfa_confirm_title: Confirm MFA Reset
+    reset_mfa_error: Failed to reset MFA.
     role: Role
     role_admin: Admin
     role_user: User

--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -177,6 +177,13 @@ agent_dashboard: {}
 auth:
   loading: Loading...
   login: Login
+  mfa:
+    confirm_description: Enter the 6-digit code displayed in your authenticator app.
+    confirm_title: Enter Authentication Code
+    setup_description: Enhance your account security using an authenticator app.
+    setup_step1: Scan the QR code with your authenticator app
+    setup_step2: Enter the 6-digit code displayed in your app below
+    setup_title: Set Up Two-Factor Authentication
   title: Generative AI Use Cases on AWS
 chat:
   advanced_options: Advanced Options

--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -41,7 +41,7 @@ admin:
     grant_admin: Grant admin role
     groups_error: Failed to update role.
     reset_mfa: Reset MFA
-    reset_mfa_confirm: 'Are you sure you want to reset MFA for {{email}}? They will need to set up MFA again on next login.'
+    reset_mfa_confirm: "Are you sure you want to reset MFA for {{email}}? They will be required to set up two-factor authentication again on next login. Until the setup is complete, this user's account will not be protected by two-factor authentication."
     reset_mfa_confirm_title: Confirm MFA Reset
     reset_mfa_error: Failed to reset MFA.
     role: Role
@@ -184,10 +184,15 @@ auth:
   mfa:
     confirm_description: Enter the 6-digit code displayed in your authenticator app.
     confirm_title: Enter Authentication Code
+    force_setup_description: For security, you need to set up two-factor authentication. Please complete the setup using your authenticator app.
+    force_setup_title: Two-Factor Authentication Required
+    setup_complete: Two-factor authentication setup is complete.
     setup_description: Enhance your account security using an authenticator app.
     setup_step1: Scan the QR code with your authenticator app
     setup_step2: Enter the 6-digit code displayed in your app below
     setup_title: Set Up Two-Factor Authentication
+    verify_button: Verify
+    verify_error: Failed to verify code. Please enter the correct code.
   title: Generative AI Use Cases on AWS
 chat:
   advanced_options: Advanced Options

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -40,6 +40,10 @@ admin:
     enabled_yes: 有効
     grant_admin: 管理者権限を付与
     groups_error: ロールの更新に失敗しました。
+    reset_mfa: MFAリセット
+    reset_mfa_confirm: '{{email}} のMFA設定をリセットしてもよろしいですか？次回ログイン時に再設定が必要になります。'
+    reset_mfa_confirm_title: MFAリセットの確認
+    reset_mfa_error: MFAのリセットに失敗しました。
     role: ロール
     role_admin: Admin
     role_user: User

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -168,6 +168,13 @@ agent_dashboard: {}
 auth:
   loading: 読み込み中...
   login: ログイン
+  mfa:
+    confirm_description: 認証アプリに表示されている6桁のコードを入力してください。
+    confirm_title: 認証コードの入力
+    setup_description: 認証アプリを使用してアカウントのセキュリティを強化します。
+    setup_step1: お使いの認証アプリでQRコードをスキャンしてください
+    setup_step2: アプリに表示される6桁のコードを下の入力欄に入力してください
+    setup_title: 2段階認証のセットアップ
   title: Generative AI Use Cases on AWS
 chat:
   advanced_options: 高度なオプション

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -41,7 +41,7 @@ admin:
     grant_admin: 管理者権限を付与
     groups_error: ロールの更新に失敗しました。
     reset_mfa: MFAリセット
-    reset_mfa_confirm: '{{email}} のMFA設定をリセットしてもよろしいですか？次回ログイン時に再設定が必要になります。'
+    reset_mfa_confirm: '{{email}} のMFA設定をリセットしてもよろしいですか？次回ログイン時に2段階認証の再設定が求められます。再設定が完了するまでの間、このユーザーのアカウントは2段階認証による保護がない状態となります。'
     reset_mfa_confirm_title: MFAリセットの確認
     reset_mfa_error: MFAのリセットに失敗しました。
     role: ロール
@@ -175,10 +175,15 @@ auth:
   mfa:
     confirm_description: 認証アプリに表示されている6桁のコードを入力してください。
     confirm_title: 認証コードの入力
+    force_setup_description: セキュリティのため、2段階認証の設定が必要です。認証アプリを使用してセットアップを完了してください。
+    force_setup_title: 2段階認証の設定が必要です
+    setup_complete: 2段階認証のセットアップが完了しました。
     setup_description: 認証アプリを使用してアカウントのセキュリティを強化します。
     setup_step1: お使いの認証アプリでQRコードをスキャンしてください
     setup_step2: アプリに表示される6桁のコードを下の入力欄に入力してください
     setup_title: 2段階認証のセットアップ
+    verify_button: 確認
+    verify_error: コードの検証に失敗しました。正しいコードを入力してください。
   title: Generative AI Use Cases on AWS
 chat:
   advanced_options: 高度なオプション

--- a/packages/web/src/@types/qrcode.d.ts
+++ b/packages/web/src/@types/qrcode.d.ts
@@ -1,0 +1,17 @@
+declare module 'qrcode' {
+  interface QRCodeToDataURLOptions {
+    width?: number;
+    margin?: number;
+    color?: {
+      dark?: string;
+      light?: string;
+    };
+  }
+
+  function toDataURL(
+    text: string,
+    options?: QRCodeToDataURLOptions
+  ): Promise<string>;
+
+  export default { toDataURL };
+}

--- a/packages/web/src/components/AuthWithUserpool.tsx
+++ b/packages/web/src/components/AuthWithUserpool.tsx
@@ -3,6 +3,7 @@ import { Authenticator, translations } from '@aws-amplify/ui-react';
 import { I18n } from 'aws-amplify/utils';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
+import MfaSetupEnforcer from './MfaSetupEnforcer';
 
 const selfSignUpEnabled: boolean =
   import.meta.env.VITE_APP_SELF_SIGN_UP_ENABLED === 'true';
@@ -95,7 +96,7 @@ const AuthWithUserpool: React.FC<Props> = (props) => {
           },
         },
       }}>
-      {props.children}
+      <MfaSetupEnforcer>{props.children}</MfaSetupEnforcer>
     </Authenticator>
   );
 };

--- a/packages/web/src/components/AuthWithUserpool.tsx
+++ b/packages/web/src/components/AuthWithUserpool.tsx
@@ -49,12 +49,51 @@ const AuthWithUserpool: React.FC<Props> = (props) => {
   return (
     <Authenticator
       hideSignUp={!selfSignUpEnabled}
+      formFields={{
+        setupTotp: {
+          QR: {
+            totpIssuer: 'GaiXer',
+          },
+        },
+      }}
       components={{
         Header: () => (
           <div className="text-aws-font-color mb-5 mt-10 flex justify-center text-3xl">
             {t('auth.title')}
           </div>
         ),
+        SetupTotp: {
+          Header() {
+            return (
+              <div className="mb-4 text-center">
+                <h2 className="text-aws-font-color text-lg font-semibold">
+                  {t('auth.mfa.setup_title')}
+                </h2>
+                <p className="mt-2 text-sm text-gray-600">
+                  {t('auth.mfa.setup_description')}
+                </p>
+                <ol className="marker:text-aws-sky mt-3 list-inside list-decimal space-y-1 text-left text-sm text-gray-700 marker:font-semibold">
+                  <li>{t('auth.mfa.setup_step1')}</li>
+                  <li>{t('auth.mfa.setup_step2')}</li>
+                </ol>
+              </div>
+            );
+          },
+        },
+        ConfirmSignIn: {
+          Header() {
+            return (
+              <div className="mb-4 text-center">
+                <h2 className="text-aws-font-color text-lg font-semibold">
+                  {t('auth.mfa.confirm_title')}
+                </h2>
+                <p className="mt-2 text-sm text-gray-600">
+                  {t('auth.mfa.confirm_description')}
+                </p>
+              </div>
+            );
+          },
+        },
       }}>
       {props.children}
     </Authenticator>

--- a/packages/web/src/components/MfaSetupEnforcer.tsx
+++ b/packages/web/src/components/MfaSetupEnforcer.tsx
@@ -1,0 +1,160 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  fetchMFAPreference,
+  setUpTOTP,
+  verifyTOTPSetup,
+  updateMFAPreference,
+} from 'aws-amplify/auth';
+import QRCode from 'qrcode';
+import Button from './Button';
+
+const mfaRequired: boolean = import.meta.env.VITE_APP_MFA_REQUIRED === 'true';
+
+type Props = {
+  children: React.ReactNode;
+};
+
+const MfaSetupEnforcer: React.FC<Props> = ({ children }) => {
+  const { t } = useTranslation();
+  const [checking, setChecking] = useState(true);
+  const [needsSetup, setNeedsSetup] = useState(false);
+  const [qrDataUrl, setQrDataUrl] = useState('');
+  const [verifyCode, setVerifyCode] = useState('');
+  const [verifying, setVerifying] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (!mfaRequired) {
+      setChecking(false);
+      return;
+    }
+
+    fetchMFAPreference()
+      .then((pref) => {
+        // TOTP is not set up if neither preferred nor enabled
+        if (!pref.preferred && !pref.enabled) {
+          setNeedsSetup(true);
+        } else if (
+          pref.preferred !== 'TOTP' &&
+          !(pref.enabled && pref.enabled.includes('TOTP'))
+        ) {
+          setNeedsSetup(true);
+        }
+      })
+      .catch(() => {
+        // Require setup if fetching MFA preference fails
+        setNeedsSetup(true);
+      })
+      .finally(() => setChecking(false));
+  }, []);
+
+  useEffect(() => {
+    if (!needsSetup) return;
+
+    setUpTOTP()
+      .then(async (totpSetupDetails) => {
+        const uri = totpSetupDetails.getSetupUri('GaiXer');
+        const dataUrl = await QRCode.toDataURL(uri.toString(), {
+          width: 200,
+          margin: 2,
+        });
+        setQrDataUrl(dataUrl);
+      })
+      .catch(() => {
+        setError('Failed to initialize TOTP setup.');
+      });
+  }, [needsSetup]);
+
+  const handleVerify = useCallback(async () => {
+    if (!verifyCode.trim()) return;
+    setVerifying(true);
+    setError('');
+    try {
+      await verifyTOTPSetup({ code: verifyCode.trim() });
+      await updateMFAPreference({ totp: 'PREFERRED' });
+      setNeedsSetup(false);
+    } catch {
+      setError(t('auth.mfa.verify_error'));
+    } finally {
+      setVerifying(false);
+    }
+  }, [verifyCode, t]);
+
+  if (checking) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <div className="text-gray-500">{t('auth.loading')}</div>
+      </div>
+    );
+  }
+
+  if (!needsSetup) {
+    return <>{children}</>;
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-gray-50">
+      <div className="w-full max-w-md rounded-lg bg-white p-8 shadow-md">
+        <div className="mb-6 text-center">
+          <h2 className="text-aws-font-color text-xl font-semibold">
+            {t('auth.mfa.force_setup_title')}
+          </h2>
+          <p className="mt-2 text-sm text-gray-600">
+            {t('auth.mfa.force_setup_description')}
+          </p>
+        </div>
+
+        <div className="space-y-6">
+          <ol className="marker:text-aws-sky list-inside list-decimal space-y-1 text-sm text-gray-700 marker:font-semibold">
+            <li>{t('auth.mfa.setup_step1')}</li>
+            <li>{t('auth.mfa.setup_step2')}</li>
+          </ol>
+
+          {qrDataUrl && (
+            <div className="flex justify-center">
+              <img
+                src={qrDataUrl}
+                alt={t('auth.mfa.setup_step1')}
+                className="h-48 w-48"
+              />
+            </div>
+          )}
+
+          <div>
+            {/* eslint-disable-next-line @shopify/jsx-no-hardcoded-content */}
+            <input
+              type="text"
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              maxLength={6}
+              className="w-full rounded border border-gray-300 px-3 py-2 text-center text-lg tracking-widest focus:border-gray-400 focus:outline-none focus:ring-0"
+              placeholder="000000"
+              value={verifyCode}
+              onChange={(e) => setVerifyCode(e.target.value.replace(/\D/g, ''))}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') handleVerify();
+              }}
+            />
+          </div>
+
+          {error && (
+            <div className="rounded bg-red-50 p-3 text-sm text-red-600">
+              {error}
+            </div>
+          )}
+
+          <Button
+            className="w-full"
+            onClick={handleVerify}
+            loading={verifying}
+            disabled={verifyCode.length !== 6}>
+            {t('auth.mfa.verify_button')}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default MfaSetupEnforcer;

--- a/packages/web/src/hooks/useAdminApi.ts
+++ b/packages/web/src/hooks/useAdminApi.ts
@@ -46,6 +46,13 @@ const useAdminApi = () => {
       await http.delete(`/admin/users/${encodeURIComponent(username)}`);
     },
 
+    resetMfa: async (username: string) => {
+      await http.post(
+        `/admin/users/${encodeURIComponent(username)}/reset-mfa`,
+        {}
+      );
+    },
+
     updateUserGroups: async (username: string, groups: string[]) => {
       const res = await http.put<
         { username: string; groups: string[] },

--- a/packages/web/src/index.css
+++ b/packages/web/src/index.css
@@ -22,6 +22,34 @@ input[type='number'] {
   -moz-appearance: textfield;
 }
 
+/* MFA - Setup TOTP screen */
+[data-amplify-authenticator-setup-totp] {
+  padding: 0.5rem 1.5rem 1.5rem;
+}
+
+[data-amplify-authenticator-setup-totp] [data-amplify-qrcode] {
+  display: block;
+  margin: 1rem auto;
+  border-radius: 8px;
+  padding: 8px;
+  border: 1px solid #e5e7eb;
+  background: #ffffff;
+}
+
+[data-amplify-authenticator-setup-totp] [data-amplify-copy] {
+  font-size: 0.7rem;
+  color: #6b7280;
+  background: #f9fafb;
+  border-radius: 6px;
+  padding: 0.5rem 0.75rem;
+  margin-bottom: 0.5rem;
+}
+
+/* MFA - Confirm Sign In screen */
+[data-amplify-authenticator-confirmsignin] {
+  padding: 0.5rem 1.5rem 1.5rem;
+}
+
 @media print {
   body {
     -webkit-print-color-adjust: exact;

--- a/packages/web/src/pages/admin/UserManagement.tsx
+++ b/packages/web/src/pages/admin/UserManagement.tsx
@@ -6,6 +6,7 @@ import {
   PiProhibit,
   PiCheckCircle,
   PiUserGear,
+  PiShieldSlash,
 } from 'react-icons/pi';
 import useAdminApi from '../../hooks/useAdminApi';
 import useAdmin from '../../hooks/useAdmin';
@@ -23,6 +24,7 @@ const UserManagement: React.FC = () => {
     enableUser,
     deleteUser,
     updateUserGroups,
+    resetMfa,
   } = useAdminApi();
   const { currentUsername } = useAdmin();
 
@@ -47,6 +49,11 @@ const UserManagement: React.FC = () => {
   const [isDeleteOpen, setIsDeleteOpen] = useState(false);
   const [deletingUser, setDeletingUser] = useState<AdminUser | null>(null);
   const [deleteLoading, setDeleteLoading] = useState(false);
+
+  // Reset MFA confirm dialog
+  const [isResetMfaOpen, setIsResetMfaOpen] = useState(false);
+  const [resetMfaUser, setResetMfaUser] = useState<AdminUser | null>(null);
+  const [resetMfaLoading, setResetMfaLoading] = useState(false);
 
   // Action loading state
   const [actionLoading, setActionLoading] = useState<string | null>(null);
@@ -129,6 +136,27 @@ const UserManagement: React.FC = () => {
       setGroupsLoading(false);
     }
   }, [editingUser, editingIsAdmin, updateUserGroups, mutate, t]);
+
+  const handleResetMfa = useCallback(async () => {
+    if (!resetMfaUser) return;
+    setResetMfaLoading(true);
+    setError('');
+    try {
+      await resetMfa(resetMfaUser.username);
+      await mutate();
+      setIsResetMfaOpen(false);
+      setResetMfaUser(null);
+    } catch {
+      setError(t('admin.users.reset_mfa_error'));
+    } finally {
+      setResetMfaLoading(false);
+    }
+  }, [resetMfaUser, resetMfa, mutate, t]);
+
+  const openResetMfaDialog = useCallback((user: AdminUser) => {
+    setResetMfaUser(user);
+    setIsResetMfaOpen(true);
+  }, []);
 
   const openGroupsDialog = useCallback((user: AdminUser) => {
     setEditingUser(user);
@@ -258,6 +286,15 @@ const UserManagement: React.FC = () => {
                       <PiUserGear />
                     </button>
                     <button
+                      className="rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700 disabled:opacity-30"
+                      title={t('admin.users.reset_mfa')}
+                      disabled={
+                        isSelf(user.username) || actionLoading === user.username
+                      }
+                      onClick={() => openResetMfaDialog(user)}>
+                      <PiShieldSlash />
+                    </button>
+                    <button
                       className="rounded p-1 text-gray-500 hover:bg-red-50 hover:text-red-600 disabled:opacity-30"
                       title={t('admin.users.delete')}
                       disabled={isSelf(user.username)}
@@ -378,6 +415,28 @@ const UserManagement: React.FC = () => {
               loading={deleteLoading}
               className="bg-red-500 text-white">
               {t('admin.users.delete')}
+            </Button>
+          </div>
+        </div>
+      </ModalDialog>
+
+      {/* Reset MFA Confirm Dialog */}
+      <ModalDialog
+        isOpen={isResetMfaOpen}
+        title={t('admin.users.reset_mfa_confirm_title')}
+        onClose={() => setIsResetMfaOpen(false)}>
+        <div className="space-y-4">
+          <div className="text-sm">
+            {t('admin.users.reset_mfa_confirm', {
+              email: resetMfaUser?.email,
+            })}
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button outlined onClick={() => setIsResetMfaOpen(false)}>
+              {t('common.cancel')}
+            </Button>
+            <Button onClick={handleResetMfa} loading={resetMfaLoading}>
+              {t('admin.users.reset_mfa')}
             </Button>
           </div>
         </div>


### PR DESCRIPTION
3省2ガイドライン準拠のため、Cognito User PoolにTOTP方式のMFA設定を追加。
cdk.jsonでmfaRequired: trueを設定するとMFAが必須化され、ユーザは初回ログイン時に 認証アプリ（Google Authenticator等）でのTOTPセットアップを求められる。

## Description of Changes

Please explain the changes in detail.
If there is any impact on existing users (compatibility, degradation, breaking changes, etc.), be sure to include it in the explanation.

## Checklist

- [ ] Modified relevant documentation
- [ ] Verified operation in local environment
- [ ] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

Please list related issues as much as possible.
