### PR TITLE
feat: 画像生成・動画生成機能のリソース作成をオプショナル化

### DIFF
--- a/packages/cdk/lib/application-inference-profile-stack.ts
+++ b/packages/cdk/lib/application-inference-profile-stack.ts
@@ -60,8 +60,12 @@ export class ApplicationInferenceProfileStack extends Stack {
     };
 
     createInferenceProfiles(params.modelIds);
-    createInferenceProfiles(params.imageGenerationModelIds);
-    createInferenceProfiles(params.videoGenerationModelIds);
+    if (params.imageGenerationEnabled) {
+      createInferenceProfiles(params.imageGenerationModelIds);
+    }
+    if (params.videoGenerationEnabled) {
+      createInferenceProfiles(params.videoGenerationModelIds);
+    }
     if (params.speechToSpeechEnabled) {
       createInferenceProfiles(params.speechToSpeechModelIds);
     }

--- a/packages/cdk/lib/construct/api.ts
+++ b/packages/cdk/lib/construct/api.ts
@@ -301,135 +301,146 @@ export class Api extends Construct {
     });
     table.grantWriteData(predictTitleFunction);
 
-    const generateImageFunction = new NodejsFunction(this, 'GenerateImage', {
-      runtime: LAMBDA_RUNTIME_NODEJS,
-      entry: './lambda/generateImage.ts',
-      timeout: Duration.minutes(15),
-      environment: {
-        MODEL_REGION: modelRegion,
-        MODEL_IDS: JSON.stringify(modelIds),
-        IMAGE_GENERATION_MODEL_IDS: JSON.stringify(imageGenerationModelIds),
-        VIDEO_GENERATION_MODEL_IDS: JSON.stringify(videoGenerationModelIds),
-        CROSS_ACCOUNT_BEDROCK_ROLE_ARN: crossAccountBedrockRoleArn ?? '',
-      },
-      bundling: {
-        nodeModules: ['@aws-sdk/client-bedrock-runtime'],
-      },
-      vpc,
-      securityGroups,
-    });
-
-    const generateVideoFunction = new NodejsFunction(this, 'GenerateVideo', {
-      runtime: LAMBDA_RUNTIME_NODEJS,
-      entry: './lambda/generateVideo.ts',
-      timeout: Duration.minutes(15),
-      environment: {
-        MODEL_REGION: modelRegion,
-        MODEL_IDS: JSON.stringify(modelIds),
-        IMAGE_GENERATION_MODEL_IDS: JSON.stringify(imageGenerationModelIds),
-        VIDEO_GENERATION_MODEL_IDS: JSON.stringify(videoGenerationModelIds),
-        VIDEO_BUCKET_OWNER: Stack.of(this).account,
-        VIDEO_BUCKET_REGION_MAP: JSON.stringify(props.videoBucketRegionMap),
-        CROSS_ACCOUNT_BEDROCK_ROLE_ARN: crossAccountBedrockRoleArn ?? '',
-        BUCKET_NAME: fileBucket.bucketName,
-        TABLE_NAME: table.tableName,
-      },
-      bundling: {
-        nodeModules: ['@aws-sdk/client-bedrock-runtime'],
-      },
-      vpc,
-      securityGroups,
-    });
-    for (const region of Object.keys(props.videoBucketRegionMap)) {
-      const bucketName = props.videoBucketRegionMap[region];
-      generateVideoFunction.role?.addToPrincipalPolicy(
-        new PolicyStatement({
-          effect: Effect.ALLOW,
-          actions: ['s3:PutObject'],
-          resources: [
-            `arn:aws:s3:::${bucketName}`,
-            `arn:aws:s3:::${bucketName}/*`,
-          ],
-        })
-      );
+    // Image generation (conditional)
+    let generateImageFunction: NodejsFunction | undefined;
+    if (imageGenerationModelIds.length > 0) {
+      generateImageFunction = new NodejsFunction(this, 'GenerateImage', {
+        runtime: LAMBDA_RUNTIME_NODEJS,
+        entry: './lambda/generateImage.ts',
+        timeout: Duration.minutes(15),
+        environment: {
+          MODEL_REGION: modelRegion,
+          MODEL_IDS: JSON.stringify(modelIds),
+          IMAGE_GENERATION_MODEL_IDS: JSON.stringify(imageGenerationModelIds),
+          VIDEO_GENERATION_MODEL_IDS: JSON.stringify(videoGenerationModelIds),
+          CROSS_ACCOUNT_BEDROCK_ROLE_ARN: crossAccountBedrockRoleArn ?? '',
+        },
+        bundling: {
+          nodeModules: ['@aws-sdk/client-bedrock-runtime'],
+        },
+        vpc,
+        securityGroups,
+      });
     }
-    table.grantWriteData(generateVideoFunction);
 
-    const copyVideoJob = new NodejsFunction(this, 'CopyVideoJob', {
-      runtime: LAMBDA_RUNTIME_NODEJS,
-      entry: './lambda/copyVideoJob.ts',
-      timeout: Duration.minutes(15),
-      memorySize: 512,
-      environment: {
-        MODEL_REGION: modelRegion,
-        MODEL_IDS: JSON.stringify(modelIds),
-        IMAGE_GENERATION_MODEL_IDS: JSON.stringify(imageGenerationModelIds),
-        VIDEO_GENERATION_MODEL_IDS: JSON.stringify(videoGenerationModelIds),
-        VIDEO_BUCKET_REGION_MAP: JSON.stringify(props.videoBucketRegionMap),
-        CROSS_ACCOUNT_BEDROCK_ROLE_ARN: crossAccountBedrockRoleArn ?? '',
-        BUCKET_NAME: fileBucket.bucketName,
-        TABLE_NAME: table.tableName,
-      },
-      bundling: {
-        nodeModules: ['@aws-sdk/client-bedrock-runtime'],
-      },
-      vpc,
-      securityGroups,
-    });
-    for (const region of Object.keys(props.videoBucketRegionMap)) {
-      const bucketName = props.videoBucketRegionMap[region];
-      copyVideoJob.role?.addToPrincipalPolicy(
-        new PolicyStatement({
-          effect: Effect.ALLOW,
-          actions: ['s3:GetObject', 's3:DeleteObject', 's3:ListBucket'],
-          resources: [
-            `arn:aws:s3:::${bucketName}`,
-            `arn:aws:s3:::${bucketName}/*`,
-          ],
-        })
-      );
+    // Video generation (conditional)
+    let generateVideoFunction: NodejsFunction | undefined;
+    let copyVideoJob: NodejsFunction | undefined;
+    let listVideoJobs: NodejsFunction | undefined;
+    let deleteVideoJob: NodejsFunction | undefined;
+    if (videoGenerationModelIds.length > 0) {
+      generateVideoFunction = new NodejsFunction(this, 'GenerateVideo', {
+        runtime: LAMBDA_RUNTIME_NODEJS,
+        entry: './lambda/generateVideo.ts',
+        timeout: Duration.minutes(15),
+        environment: {
+          MODEL_REGION: modelRegion,
+          MODEL_IDS: JSON.stringify(modelIds),
+          IMAGE_GENERATION_MODEL_IDS: JSON.stringify(imageGenerationModelIds),
+          VIDEO_GENERATION_MODEL_IDS: JSON.stringify(videoGenerationModelIds),
+          VIDEO_BUCKET_OWNER: Stack.of(this).account,
+          VIDEO_BUCKET_REGION_MAP: JSON.stringify(props.videoBucketRegionMap),
+          CROSS_ACCOUNT_BEDROCK_ROLE_ARN: crossAccountBedrockRoleArn ?? '',
+          BUCKET_NAME: fileBucket.bucketName,
+          TABLE_NAME: table.tableName,
+        },
+        bundling: {
+          nodeModules: ['@aws-sdk/client-bedrock-runtime'],
+        },
+        vpc,
+        securityGroups,
+      });
+      for (const region of Object.keys(props.videoBucketRegionMap)) {
+        const bucketName = props.videoBucketRegionMap[region];
+        generateVideoFunction.role?.addToPrincipalPolicy(
+          new PolicyStatement({
+            effect: Effect.ALLOW,
+            actions: ['s3:PutObject'],
+            resources: [
+              `arn:aws:s3:::${bucketName}`,
+              `arn:aws:s3:::${bucketName}/*`,
+            ],
+          })
+        );
+      }
+      table.grantWriteData(generateVideoFunction);
+
+      copyVideoJob = new NodejsFunction(this, 'CopyVideoJob', {
+        runtime: LAMBDA_RUNTIME_NODEJS,
+        entry: './lambda/copyVideoJob.ts',
+        timeout: Duration.minutes(15),
+        memorySize: 512,
+        environment: {
+          MODEL_REGION: modelRegion,
+          MODEL_IDS: JSON.stringify(modelIds),
+          IMAGE_GENERATION_MODEL_IDS: JSON.stringify(imageGenerationModelIds),
+          VIDEO_GENERATION_MODEL_IDS: JSON.stringify(videoGenerationModelIds),
+          VIDEO_BUCKET_REGION_MAP: JSON.stringify(props.videoBucketRegionMap),
+          CROSS_ACCOUNT_BEDROCK_ROLE_ARN: crossAccountBedrockRoleArn ?? '',
+          BUCKET_NAME: fileBucket.bucketName,
+          TABLE_NAME: table.tableName,
+        },
+        bundling: {
+          nodeModules: ['@aws-sdk/client-bedrock-runtime'],
+        },
+        vpc,
+        securityGroups,
+      });
+      for (const region of Object.keys(props.videoBucketRegionMap)) {
+        const bucketName = props.videoBucketRegionMap[region];
+        copyVideoJob.role?.addToPrincipalPolicy(
+          new PolicyStatement({
+            effect: Effect.ALLOW,
+            actions: ['s3:GetObject', 's3:DeleteObject', 's3:ListBucket'],
+            resources: [
+              `arn:aws:s3:::${bucketName}`,
+              `arn:aws:s3:::${bucketName}/*`,
+            ],
+          })
+        );
+      }
+      fileBucket.grantWrite(copyVideoJob);
+      table.grantWriteData(copyVideoJob);
+
+      listVideoJobs = new NodejsFunction(this, 'ListVideoJobs', {
+        runtime: LAMBDA_RUNTIME_NODEJS,
+        entry: './lambda/listVideoJobs.ts',
+        timeout: Duration.minutes(15),
+        environment: {
+          MODEL_REGION: modelRegion,
+          MODEL_IDS: JSON.stringify(modelIds),
+          IMAGE_GENERATION_MODEL_IDS: JSON.stringify(imageGenerationModelIds),
+          VIDEO_GENERATION_MODEL_IDS: JSON.stringify(videoGenerationModelIds),
+          VIDEO_BUCKET_REGION_MAP: JSON.stringify(props.videoBucketRegionMap),
+          CROSS_ACCOUNT_BEDROCK_ROLE_ARN: crossAccountBedrockRoleArn ?? '',
+          BUCKET_NAME: fileBucket.bucketName,
+          TABLE_NAME: table.tableName,
+          COPY_VIDEO_JOB_FUNCTION_ARN: copyVideoJob.functionArn,
+        },
+        bundling: {
+          nodeModules: ['@aws-sdk/client-bedrock-runtime'],
+        },
+        vpc,
+        securityGroups,
+      });
+      table.grantReadWriteData(listVideoJobs);
+      copyVideoJob.grantInvoke(listVideoJobs);
+
+      deleteVideoJob = new NodejsFunction(this, 'DeleteVideoJob', {
+        runtime: LAMBDA_RUNTIME_NODEJS,
+        entry: './lambda/deleteVideoJob.ts',
+        timeout: Duration.minutes(15),
+        environment: {
+          MODEL_IDS: JSON.stringify(modelIds),
+          IMAGE_GENERATION_MODEL_IDS: JSON.stringify(imageGenerationModelIds),
+          VIDEO_GENERATION_MODEL_IDS: JSON.stringify(videoGenerationModelIds),
+          TABLE_NAME: table.tableName,
+        },
+        vpc,
+        securityGroups,
+      });
+      table.grantWriteData(deleteVideoJob);
     }
-    fileBucket.grantWrite(copyVideoJob);
-    table.grantWriteData(copyVideoJob);
-
-    const listVideoJobs = new NodejsFunction(this, 'ListVideoJobs', {
-      runtime: LAMBDA_RUNTIME_NODEJS,
-      entry: './lambda/listVideoJobs.ts',
-      timeout: Duration.minutes(15),
-      environment: {
-        MODEL_REGION: modelRegion,
-        MODEL_IDS: JSON.stringify(modelIds),
-        IMAGE_GENERATION_MODEL_IDS: JSON.stringify(imageGenerationModelIds),
-        VIDEO_GENERATION_MODEL_IDS: JSON.stringify(videoGenerationModelIds),
-        VIDEO_BUCKET_REGION_MAP: JSON.stringify(props.videoBucketRegionMap),
-        CROSS_ACCOUNT_BEDROCK_ROLE_ARN: crossAccountBedrockRoleArn ?? '',
-        BUCKET_NAME: fileBucket.bucketName,
-        TABLE_NAME: table.tableName,
-        COPY_VIDEO_JOB_FUNCTION_ARN: copyVideoJob.functionArn,
-      },
-      bundling: {
-        nodeModules: ['@aws-sdk/client-bedrock-runtime'],
-      },
-      vpc,
-      securityGroups,
-    });
-    table.grantReadWriteData(listVideoJobs);
-    copyVideoJob.grantInvoke(listVideoJobs);
-
-    const deleteVideoJob = new NodejsFunction(this, 'DeleteVideoJob', {
-      runtime: LAMBDA_RUNTIME_NODEJS,
-      entry: './lambda/deleteVideoJob.ts',
-      timeout: Duration.minutes(15),
-      environment: {
-        MODEL_IDS: JSON.stringify(modelIds),
-        IMAGE_GENERATION_MODEL_IDS: JSON.stringify(imageGenerationModelIds),
-        VIDEO_GENERATION_MODEL_IDS: JSON.stringify(videoGenerationModelIds),
-        TABLE_NAME: table.tableName,
-      },
-      vpc,
-      securityGroups,
-    });
-    table.grantWriteData(deleteVideoJob);
 
     const optimizePromptFunction = new NodejsFunction(
       this,
@@ -533,9 +544,9 @@ export class Api extends Construct {
       predictFunction.role?.addToPrincipalPolicy(sagemakerPolicy);
       predictStreamFunction.role?.addToPrincipalPolicy(sagemakerPolicy);
       predictTitleFunction.role?.addToPrincipalPolicy(sagemakerPolicy);
-      generateImageFunction.role?.addToPrincipalPolicy(sagemakerPolicy);
-      generateVideoFunction.role?.addToPrincipalPolicy(sagemakerPolicy);
-      listVideoJobs.role?.addToPrincipalPolicy(sagemakerPolicy);
+      generateImageFunction?.role?.addToPrincipalPolicy(sagemakerPolicy);
+      generateVideoFunction?.role?.addToPrincipalPolicy(sagemakerPolicy);
+      listVideoJobs?.role?.addToPrincipalPolicy(sagemakerPolicy);
       invokeFlowFunction.role?.addToPrincipalPolicy(sagemakerPolicy);
     }
 
@@ -559,9 +570,9 @@ export class Api extends Construct {
       predictStreamFunction.role?.addToPrincipalPolicy(bedrockPolicy);
       predictFunction.role?.addToPrincipalPolicy(bedrockPolicy);
       predictTitleFunction.role?.addToPrincipalPolicy(bedrockPolicy);
-      generateImageFunction.role?.addToPrincipalPolicy(bedrockPolicy);
-      generateVideoFunction.role?.addToPrincipalPolicy(bedrockPolicy);
-      listVideoJobs.role?.addToPrincipalPolicy(bedrockPolicy);
+      generateImageFunction?.role?.addToPrincipalPolicy(bedrockPolicy);
+      generateVideoFunction?.role?.addToPrincipalPolicy(bedrockPolicy);
+      listVideoJobs?.role?.addToPrincipalPolicy(bedrockPolicy);
       invokeFlowFunction.role?.addToPrincipalPolicy(bedrockPolicy);
       optimizePromptFunction.role?.addToPrincipalPolicy(bedrockPolicy);
     } else {
@@ -579,15 +590,15 @@ export class Api extends Construct {
       predictStreamFunction.role?.addToPrincipalPolicy(logsPolicy);
       predictFunction.role?.addToPrincipalPolicy(logsPolicy);
       predictTitleFunction.role?.addToPrincipalPolicy(logsPolicy);
-      generateImageFunction.role?.addToPrincipalPolicy(logsPolicy);
-      generateVideoFunction.role?.addToPrincipalPolicy(logsPolicy);
-      listVideoJobs.role?.addToPrincipalPolicy(logsPolicy);
+      generateImageFunction?.role?.addToPrincipalPolicy(logsPolicy);
+      generateVideoFunction?.role?.addToPrincipalPolicy(logsPolicy);
+      listVideoJobs?.role?.addToPrincipalPolicy(logsPolicy);
       predictStreamFunction.role?.addToPrincipalPolicy(assumeRolePolicy);
       predictFunction.role?.addToPrincipalPolicy(assumeRolePolicy);
       predictTitleFunction.role?.addToPrincipalPolicy(assumeRolePolicy);
-      generateImageFunction.role?.addToPrincipalPolicy(assumeRolePolicy);
-      generateVideoFunction.role?.addToPrincipalPolicy(assumeRolePolicy);
-      listVideoJobs.role?.addToPrincipalPolicy(assumeRolePolicy);
+      generateImageFunction?.role?.addToPrincipalPolicy(assumeRolePolicy);
+      generateVideoFunction?.role?.addToPrincipalPolicy(assumeRolePolicy);
+      listVideoJobs?.role?.addToPrincipalPolicy(assumeRolePolicy);
       // To get pre-signed URL from S3 in different account
       getFileDownloadSignedUrlFunction.role?.addToPrincipalPolicy(
         assumeRolePolicy
@@ -1023,36 +1034,43 @@ export class Api extends Construct {
       commonAuthorizerProps
     );
 
-    const imageResource = api.root.addResource('image');
-    const imageGenerateResource = imageResource.addResource('generate');
-    // POST: /image/generate
-    imageGenerateResource.addMethod(
-      'POST',
-      new LambdaIntegration(generateImageFunction),
-      commonAuthorizerProps
-    );
+    // Image generation API routes (conditional)
+    if (generateImageFunction) {
+      const imageResource = api.root.addResource('image');
+      const imageGenerateResource = imageResource.addResource('generate');
+      // POST: /image/generate
+      imageGenerateResource.addMethod(
+        'POST',
+        new LambdaIntegration(generateImageFunction),
+        commonAuthorizerProps
+      );
+    }
 
-    const videoResource = api.root.addResource('video');
-    const videoGenerateResource = videoResource.addResource('generate');
-    // POST: /video/generate
-    videoGenerateResource.addMethod(
-      'POST',
-      new LambdaIntegration(generateVideoFunction),
-      commonAuthorizerProps
-    );
-    // GET: /video/generate
-    videoGenerateResource.addMethod(
-      'GET',
-      new LambdaIntegration(listVideoJobs),
-      commonAuthorizerProps
-    );
-    const videoJobResource = videoGenerateResource.addResource('{createdDate}');
-    // DELETE: /video/generate/{createdDate}
-    videoJobResource.addMethod(
-      'DELETE',
-      new LambdaIntegration(deleteVideoJob),
-      commonAuthorizerProps
-    );
+    // Video generation API routes (conditional)
+    if (generateVideoFunction && listVideoJobs && deleteVideoJob) {
+      const videoResource = api.root.addResource('video');
+      const videoGenerateResource = videoResource.addResource('generate');
+      // POST: /video/generate
+      videoGenerateResource.addMethod(
+        'POST',
+        new LambdaIntegration(generateVideoFunction),
+        commonAuthorizerProps
+      );
+      // GET: /video/generate
+      videoGenerateResource.addMethod(
+        'GET',
+        new LambdaIntegration(listVideoJobs),
+        commonAuthorizerProps
+      );
+      const videoJobResource =
+        videoGenerateResource.addResource('{createdDate}');
+      // DELETE: /video/generate/{createdDate}
+      videoJobResource.addMethod(
+        'DELETE',
+        new LambdaIntegration(deleteVideoJob),
+        commonAuthorizerProps
+      );
+    }
 
     // Used in the web content extraction use case
     const webTextResource = api.root.addResource('web-text');

--- a/packages/cdk/lib/create-stacks.ts
+++ b/packages/cdk/lib/create-stacks.ts
@@ -56,8 +56,12 @@ export const createStacks = (app: cdk.App, params: ProcessedStackInput) => {
   const modelRegions = [
     ...new Set([
       ...params.modelIds.map((model) => model.region),
-      ...params.imageGenerationModelIds.map((model) => model.region),
-      ...params.videoGenerationModelIds.map((model) => model.region),
+      ...(params.imageGenerationEnabled
+        ? params.imageGenerationModelIds.map((model) => model.region)
+        : []),
+      ...(params.videoGenerationEnabled
+        ? params.videoGenerationModelIds.map((model) => model.region)
+        : []),
       ...(params.speechToSpeechEnabled
         ? params.speechToSpeechModelIds.map((model) => model.region)
         : []),
@@ -90,16 +94,20 @@ export const createStacks = (app: cdk.App, params: ProcessedStackInput) => {
     inferenceProfileStacks,
     app
   );
-  updatedParams.imageGenerationModelIds = mergeModelIdsAndInferenceProfileArn(
-    params.imageGenerationModelIds,
-    inferenceProfileStacks,
-    app
-  );
-  updatedParams.videoGenerationModelIds = mergeModelIdsAndInferenceProfileArn(
-    params.videoGenerationModelIds,
-    inferenceProfileStacks,
-    app
-  );
+  updatedParams.imageGenerationModelIds = params.imageGenerationEnabled
+    ? mergeModelIdsAndInferenceProfileArn(
+        params.imageGenerationModelIds,
+        inferenceProfileStacks,
+        app
+      )
+    : [];
+  updatedParams.videoGenerationModelIds = params.videoGenerationEnabled
+    ? mergeModelIdsAndInferenceProfileArn(
+        params.videoGenerationModelIds,
+        inferenceProfileStacks,
+        app
+      )
+    : [];
   updatedParams.speechToSpeechModelIds = params.speechToSpeechEnabled
     ? mergeModelIdsAndInferenceProfileArn(
         params.speechToSpeechModelIds,
@@ -208,27 +216,30 @@ export const createStacks = (app: cdk.App, params: ProcessedStackInput) => {
 
   // Create S3 Bucket for each unique region for StartAsyncInvoke in video generation
   // because the S3 Bucket must be in the same region as Bedrock Runtime
-  const videoModelRegions = [
-    ...new Set(
-      updatedParams.videoGenerationModelIds.map((model) => model.region)
-    ),
-  ];
   const videoBucketRegionMap: Record<string, string> = {};
 
-  for (const region of videoModelRegions) {
-    const videoTmpBucketStack = new VideoTmpBucketStack(
-      app,
-      `VideoTmpBucketStack${updatedParams.env}${region}`,
-      {
-        env: {
-          account: updatedParams.account,
-          region,
-        },
-        params: updatedParams,
-      }
-    );
+  if (params.videoGenerationEnabled) {
+    const videoModelRegions = [
+      ...new Set(
+        updatedParams.videoGenerationModelIds.map((model) => model.region)
+      ),
+    ];
 
-    videoBucketRegionMap[region] = videoTmpBucketStack.bucketName;
+    for (const region of videoModelRegions) {
+      const videoTmpBucketStack = new VideoTmpBucketStack(
+        app,
+        `VideoTmpBucketStack${updatedParams.env}${region}`,
+        {
+          env: {
+            account: updatedParams.account,
+            region,
+          },
+          params: updatedParams,
+        }
+      );
+
+      videoBucketRegionMap[region] = videoTmpBucketStack.bucketName;
+    }
   }
 
   const generativeAiUseCasesStack = new GenerativeAiUseCasesStack(

--- a/packages/cdk/lib/stack-input.ts
+++ b/packages/cdk/lib/stack-input.ts
@@ -52,6 +52,7 @@ const baseStackInputSchema = z.object({
       'us.amazon.nova-micro-v1:0',
       'us.deepseek.r1-v1:0',
     ]),
+  imageGenerationEnabled: z.boolean().default(true),
   imageGenerationModelIds: z
     .array(
       z.union([
@@ -63,6 +64,7 @@ const baseStackInputSchema = z.object({
       ])
     )
     .default(['amazon.nova-canvas-v1:0']),
+  videoGenerationEnabled: z.boolean().default(true),
   videoGenerationModelIds: z
     .array(
       z.union([


### PR DESCRIPTION
speechToSpeechEnabledと同パターンでimageGenerationEnabled/videoGenerationEnabledトグルを追加。 無効時はLambda関数、API Gatewayルート、S3バケット、推論プロファイル等のバックエンドリソースが作成されなくなり、約30〜35リソースを削減可能。

## Description of Changes

Please explain the changes in detail.
If there is any impact on existing users (compatibility, degradation, breaking changes, etc.), be sure to include it in the explanation.

## Checklist

- [ ] Modified relevant documentation
- [ ] Verified operation in local environment
- [ ] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

Please list related issues as much as possible.
