### PR TITLE
議事録機能のエラーハンドリングを改善

### DIFF
--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -903,6 +903,23 @@ meetingMinutes:
   diagram_options: Diagram Types to Generate
   diagram_sequence: Sequence Diagram (Relationships)
   diagram_timeline: Timeline (Deadlines & Schedule)
+  error:
+    auth_session_failed: Failed to obtain authentication session. Please log in again.
+    file_too_large: File size exceeds the limit (2GB).
+    file_transcription_failed: Failed to transcribe the file.
+    file_transcription_job_failed: Transcription job failed. Please check the file and try again.
+    file_upload_failed: Failed to upload the file.
+    mic_not_available: Microphone is not available. Please check your device connection.
+    mic_permission_denied: Microphone access was denied. Please check your browser settings.
+    mic_transcription_failed: An error occurred during microphone transcription.
+    no_audio_source: No audio input source selected. Please enable microphone or screen audio.
+    screen_audio_denied: Screen audio access was denied.
+    screen_audio_failed: Failed to start screen audio capture.
+    screen_audio_no_audio_track: No audio track available in screen capture.
+    screen_audio_not_supported: Screen audio capture is not supported in this browser.
+    screen_transcription_failed: An error occurred during screen audio transcription.
+    transcription_connection_failed: Failed to connect to the transcription service.
+    transcription_interrupted: Transcription was interrupted. Previous results have been preserved.
   frequency: Generation Frequency
   frequency_10min: Every 10 minutes
   frequency_1min: Every 1 minute

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -748,6 +748,23 @@ meetingMinutes:
   diagram_options: 生成する図の種類
   diagram_sequence: シーケンス図（関係性）
   diagram_timeline: タイムライン（期限・スケジュール）
+  error:
+    auth_session_failed: 認証セッションの取得に失敗しました。再度ログインしてください。
+    file_too_large: ファイルサイズが大きすぎます（上限2GB）。
+    file_transcription_failed: ファイルの文字起こしに失敗しました。
+    file_transcription_job_failed: 文字起こしジョブが失敗しました。ファイルを確認の上、再度お試しください。
+    file_upload_failed: ファイルのアップロードに失敗しました。
+    mic_not_available: マイクが利用できません。デバイスの接続を確認してください。
+    mic_permission_denied: マイクのアクセスが拒否されました。ブラウザの設定を確認してください。
+    mic_transcription_failed: マイクの文字起こし中にエラーが発生しました。
+    no_audio_source: 音声入力ソースが選択されていません。マイクまたはスクリーン音声を有効にしてください。
+    screen_audio_denied: スクリーン音声のアクセスが拒否されました。
+    screen_audio_failed: スクリーン音声のキャプチャに失敗しました。
+    screen_audio_no_audio_track: スクリーンキャプチャに音声トラックが含まれていません。
+    screen_audio_not_supported: このブラウザではスクリーン音声のキャプチャに対応していません。
+    screen_transcription_failed: スクリーン音声の文字起こし中にエラーが発生しました。
+    transcription_connection_failed: 文字起こしサービスへの接続に失敗しました。
+    transcription_interrupted: 文字起こし中に接続が切断されました。それまでの結果は保持されています。
   frequency: 生成頻度
   frequency_10min: 10分ごと
   frequency_1min: 1分ごと

--- a/packages/web/src/components/MeetingMinutes/MeetingMinutesFile.tsx
+++ b/packages/web/src/components/MeetingMinutes/MeetingMinutesFile.tsx
@@ -6,6 +6,7 @@ import React, {
   useEffect,
 } from 'react';
 import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
 import Button from '../Button';
 import ButtonCopy from '../ButtonCopy';
 import ButtonSendToUseCase from '../ButtonSendToUseCase';
@@ -95,6 +96,14 @@ const MeetingMinutesFile: React.FC<MeetingMinutesFileProps> = ({
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
     if (files && files[0]) {
+      const MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024 * 1024; // 2GB
+      if (files[0].size > MAX_FILE_SIZE_BYTES) {
+        toast.error(t('meetingMinutes.error.file_too_large'));
+        if (fileInputRef.current) {
+          fileInputRef.current.value = '';
+        }
+        return;
+      }
       setFile(files[0]);
     }
   };

--- a/packages/web/src/components/MeetingMinutes/MeetingMinutesRealtimeTranslation.tsx
+++ b/packages/web/src/components/MeetingMinutes/MeetingMinutesRealtimeTranslation.tsx
@@ -8,6 +8,7 @@ import React, {
 import { useTranslation } from 'react-i18next';
 import { LanguageCode } from '@aws-sdk/client-transcribe-streaming';
 import { Transcript } from 'generative-ai-use-cases';
+import { toast } from 'sonner';
 import Select from '../Select';
 import Textarea from '../Textarea';
 import MeetingMinutesTranscriptSegment from './MeetingMinutesTranscriptSegment';
@@ -103,7 +104,6 @@ const MeetingMinutesRealtimeTranslation: React.FC<
     recording: screenRecording,
     clearTranscripts: clearScreenTranscripts,
     isSupported: isScreenAudioSupported,
-    error: screenAudioError,
     rawTranscripts: screenRawTranscripts,
   } = useScreenAudio();
 
@@ -668,6 +668,11 @@ const MeetingMinutesRealtimeTranslation: React.FC<
 
   // Start transcription
   const onClickExecStartTranscription = useCallback(async () => {
+    if (!enableMicAudio && !enableScreenAudio) {
+      toast.error(t('meetingMinutes.error.no_audio_source'));
+      return;
+    }
+
     // Simple session management - just increment session ID when recording starts
     setCurrentSessionId((prev) => prev + 1);
 
@@ -729,6 +734,7 @@ const MeetingMinutesRealtimeTranslation: React.FC<
       }
     }
   }, [
+    t,
     primaryLanguage,
     secondaryLanguage,
     translationType,
@@ -868,14 +874,6 @@ const MeetingMinutesRealtimeTranslation: React.FC<
               />
             </div>
           </div>
-        </div>
-      )}
-
-      {/* Screen Audio Error Display */}
-      {screenAudioError && (
-        <div className="mb-3 shrink-0 rounded-md bg-red-50 p-3 text-sm text-red-700">
-          <strong>{t('meetingMinutes.screen_audio_error')}</strong>
-          {t('common.colon')} {screenAudioError}
         </div>
       )}
 

--- a/packages/web/src/components/MeetingMinutes/MeetingMinutesTranscription.tsx
+++ b/packages/web/src/components/MeetingMinutes/MeetingMinutesTranscription.tsx
@@ -8,6 +8,7 @@ import React, {
 import { useTranslation } from 'react-i18next';
 import { LanguageCode } from '@aws-sdk/client-transcribe-streaming';
 import { Transcript } from 'generative-ai-use-cases';
+import { toast } from 'sonner';
 import Select from '../Select';
 import MeetingMinutesTranscriptSegment from './MeetingMinutesTranscriptSegment';
 import MeetingMinutesSettingsPanel from './MeetingMinutesSettingsPanel';
@@ -59,7 +60,6 @@ const MeetingMinutesTranscription: React.FC<
     recording: screenRecording,
     clearTranscripts: clearScreenTranscripts,
     isSupported: isScreenAudioSupported,
-    error: screenAudioError,
     rawTranscripts: screenRawTranscripts,
   } = useScreenAudio();
 
@@ -291,6 +291,11 @@ const MeetingMinutesTranscription: React.FC<
 
   // Start transcription
   const onClickExecStartTranscription = useCallback(async () => {
+    if (!enableMicAudio && !enableScreenAudio) {
+      toast.error(t('meetingMinutes.error.no_audio_source'));
+      return;
+    }
+
     // Simple session management - just increment session ID when recording starts
     setCurrentSessionId((prev) => prev + 1);
 
@@ -320,6 +325,7 @@ const MeetingMinutesTranscription: React.FC<
       }
     }
   }, [
+    t,
     languageCode,
     speakerLabel,
     startMicTranscription,
@@ -369,14 +375,6 @@ const MeetingMinutesTranscription: React.FC<
           </div>
         </div>
       </MeetingMinutesSettingsPanel>
-
-      {/* Screen Audio Error Display */}
-      {screenAudioError && (
-        <div className="mb-3 shrink-0 rounded-md bg-red-50 p-3 text-sm text-red-700">
-          <strong>{t('meetingMinutes.screen_audio_error')}</strong>
-          {t('common.colon')} {screenAudioError}
-        </div>
-      )}
 
       {/* Transcript Panel */}
       <div className="flex min-h-0 flex-1 flex-col">

--- a/packages/web/src/hooks/useMicrophone.ts
+++ b/packages/web/src/hooks/useMicrophone.ts
@@ -5,13 +5,16 @@ import {
   LanguageCode,
 } from '@aws-sdk/client-transcribe-streaming';
 import MicrophoneStream from 'microphone-stream';
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import update from 'immutability-helper';
 import { Buffer } from 'buffer';
 import { fromCognitoIdentityPool } from '@aws-sdk/credential-provider-cognito-identity';
 import { CognitoIdentityClient } from '@aws-sdk/client-cognito-identity';
 import { fetchAuthSession } from 'aws-amplify/auth';
 import { Transcript } from 'generative-ai-use-cases';
+import { toast } from 'sonner';
+import { useTranslation } from 'react-i18next';
+import { withRetry } from '../utils/retry';
 
 const pcmEncodeChunk = (chunk: Buffer) => {
   const input = MicrophoneStream.toRaw(chunk);
@@ -39,6 +42,7 @@ const idPoolId = import.meta.env.VITE_APP_IDENTITY_POOL_ID;
 const providerName = `cognito-idp.${region}.amazonaws.com/${userPoolId}`;
 
 const useMicrophone = () => {
+  const { t } = useTranslation();
   const [micStream, setMicStream] = useState<MicrophoneStream | undefined>();
   const [recording, setRecording] = useState(false);
   const [rawTranscripts, setRawTranscripts] = useState<
@@ -84,13 +88,10 @@ const useMicrophone = () => {
     return mergedTranscripts;
   }, [rawTranscripts, language]);
 
-  useEffect(() => {
-    // break if already set
-    if (transcribeClient) return;
-
-    fetchAuthSession().then((session) => {
+  const initTranscribeClient = useCallback(async () => {
+    try {
+      const session = await withRetry(() => fetchAuthSession());
       const token = session.tokens?.idToken?.toString();
-      // break if unauthenticated
       if (!token) {
         return;
       }
@@ -106,8 +107,24 @@ const useMicrophone = () => {
         }),
       });
       setTranscribeClient(transcribe);
-    });
-  }, [transcribeClient]);
+    } catch {
+      console.error('Failed to initialize TranscribeClient');
+      toast.error(t('meetingMinutes.error.auth_session_failed'));
+    }
+  }, [t]);
+
+  useEffect(() => {
+    if (transcribeClient) return;
+    initTranscribeClient();
+  }, [transcribeClient, initTranscribeClient]);
+
+  const stopTranscription = useCallback(() => {
+    if (micStream) {
+      micStream.stop();
+      setRecording(false);
+      setMicStream(undefined);
+    }
+  }, [micStream]);
 
   const startStream = async (
     mic: MicrophoneStream,
@@ -122,16 +139,6 @@ const useMicrophone = () => {
     if (languageCode) {
       setLanguage(languageCode);
     }
-
-    const audioStream = async function* () {
-      for await (const chunk of mic as unknown as Buffer[]) {
-        yield {
-          AudioEvent: {
-            AudioChunk: pcmEncodeChunk(chunk),
-          },
-        };
-      }
-    };
 
     // Best Practice: https://docs.aws.amazon.com/transcribe/latest/dg/streaming.html
     let commandParams;
@@ -166,19 +173,33 @@ const useMicrophone = () => {
       };
     }
 
-    const command = new StartStreamTranscriptionCommand({
-      ...commandParams,
-      MediaEncoding: 'pcm',
-      MediaSampleRateHertz: 48000,
-      AudioStream: audioStream(),
-      ShowSpeakerLabel: speakerLabel,
-    });
+    const createCommand = () => {
+      const audioStream = async function* () {
+        for await (const chunk of mic as unknown as Buffer[]) {
+          yield {
+            AudioEvent: {
+              AudioChunk: pcmEncodeChunk(chunk),
+            },
+          };
+        }
+      };
+      return new StartStreamTranscriptionCommand({
+        ...commandParams,
+        MediaEncoding: 'pcm',
+        MediaSampleRateHertz: 48000,
+        AudioStream: audioStream(),
+        ShowSpeakerLabel: speakerLabel,
+      });
+    };
 
     try {
-      const response = await transcribeClient.send(command);
+      const response = await withRetry(
+        () => transcribeClient.send(createCommand()),
+        3,
+        1000
+      );
 
       if (response.TranscriptResultStream) {
-        // This snippet should be put into an async function
         for await (const event of response.TranscriptResultStream) {
           if (
             event.TranscriptEvent?.Transcript?.Results &&
@@ -262,11 +283,12 @@ const useMicrophone = () => {
         }
       }
     } catch (error) {
-      console.error(error);
-      stopTranscription();
+      console.error('Microphone transcription error:', error);
+      toast.error(t('meetingMinutes.error.mic_transcription_failed'));
     } finally {
       stopTranscription();
       transcribeClient.destroy();
+      setTranscribeClient(undefined);
     }
   };
 
@@ -295,17 +317,21 @@ const useMicrophone = () => {
         enableMultiLanguage
       );
     } catch (e) {
-      console.log(e);
+      console.log('Microphone capture error:', e);
+      if (e instanceof Error) {
+        if (e.name === 'NotAllowedError') {
+          toast.error(t('meetingMinutes.error.mic_permission_denied'));
+        } else if (
+          e.name === 'NotFoundError' ||
+          e.name === 'OverconstrainedError'
+        ) {
+          toast.error(t('meetingMinutes.error.mic_not_available'));
+        } else {
+          toast.error(t('meetingMinutes.error.mic_transcription_failed'));
+        }
+      }
     } finally {
       mic.stop();
-      setRecording(false);
-      setMicStream(undefined);
-    }
-  };
-
-  const stopTranscription = () => {
-    if (micStream) {
-      micStream.stop();
       setRecording(false);
       setMicStream(undefined);
     }

--- a/packages/web/src/hooks/useScreenAudio.ts
+++ b/packages/web/src/hooks/useScreenAudio.ts
@@ -5,13 +5,16 @@ import {
   LanguageCode,
 } from '@aws-sdk/client-transcribe-streaming';
 import MicrophoneStream from 'microphone-stream';
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useEffect, useMemo, useCallback } from 'react';
 import update from 'immutability-helper';
 import { Buffer } from 'buffer';
 import { fromCognitoIdentityPool } from '@aws-sdk/credential-provider-cognito-identity';
 import { CognitoIdentityClient } from '@aws-sdk/client-cognito-identity';
 import { fetchAuthSession } from 'aws-amplify/auth';
 import { Transcript } from 'generative-ai-use-cases';
+import { toast } from 'sonner';
+import { useTranslation } from 'react-i18next';
+import { withRetry } from '../utils/retry';
 
 const pcmEncodeChunk = (chunk: Buffer) => {
   const input = MicrophoneStream.toRaw(chunk);
@@ -39,6 +42,7 @@ const idPoolId = import.meta.env.VITE_APP_IDENTITY_POOL_ID;
 const providerName = `cognito-idp.${region}.amazonaws.com/${userPoolId}`;
 
 const useScreenAudio = () => {
+  const { t } = useTranslation();
   const [screenStream, setScreenStream] = useState<
     MicrophoneStream | undefined
   >();
@@ -57,7 +61,6 @@ const useScreenAudio = () => {
   const [transcribeClient, setTranscribeClient] =
     useState<TranscribeStreamingClient>();
   const [isSupported, setIsSupported] = useState<boolean>(false);
-  const [error, setError] = useState<string>('');
   const [preparedDisplayStream, setPreparedDisplayStream] =
     useState<MediaStream | null>(null);
 
@@ -98,13 +101,10 @@ const useScreenAudio = () => {
     return mergedTranscripts;
   }, [rawTranscripts, language]);
 
-  useEffect(() => {
-    // break if already set
-    if (transcribeClient) return;
-
-    fetchAuthSession().then((session) => {
+  const initTranscribeClient = useCallback(async () => {
+    try {
+      const session = await withRetry(() => fetchAuthSession());
       const token = session.tokens?.idToken?.toString();
-      // break if unauthenticated
       if (!token) {
         return;
       }
@@ -120,8 +120,30 @@ const useScreenAudio = () => {
         }),
       });
       setTranscribeClient(transcribe);
-    });
-  }, [transcribeClient]);
+    } catch {
+      console.error('Failed to initialize TranscribeClient');
+      toast.error(t('meetingMinutes.error.auth_session_failed'));
+    }
+  }, [t]);
+
+  useEffect(() => {
+    if (transcribeClient) return;
+    initTranscribeClient();
+  }, [transcribeClient, initTranscribeClient]);
+
+  const stopTranscription = useCallback(() => {
+    if (screenStream) {
+      screenStream.stop();
+      setRecording(false);
+      setScreenStream(undefined);
+    }
+
+    // Clean up prepared stream if exists
+    if (preparedDisplayStream) {
+      preparedDisplayStream.getTracks().forEach((track) => track.stop());
+      setPreparedDisplayStream(null);
+    }
+  }, [screenStream, preparedDisplayStream]);
 
   const startStream = async (
     stream: MicrophoneStream,
@@ -136,16 +158,6 @@ const useScreenAudio = () => {
     if (languageCode) {
       setLanguage(languageCode);
     }
-
-    const audioStream = async function* () {
-      for await (const chunk of stream as unknown as Buffer[]) {
-        yield {
-          AudioEvent: {
-            AudioChunk: pcmEncodeChunk(chunk),
-          },
-        };
-      }
-    };
 
     // Best Practice: https://docs.aws.amazon.com/transcribe/latest/dg/streaming.html
     let commandParams;
@@ -180,19 +192,33 @@ const useScreenAudio = () => {
       };
     }
 
-    const command = new StartStreamTranscriptionCommand({
-      ...commandParams,
-      MediaEncoding: 'pcm',
-      MediaSampleRateHertz: 48000,
-      AudioStream: audioStream(),
-      ShowSpeakerLabel: speakerLabel,
-    });
+    const createCommand = () => {
+      const audioStream = async function* () {
+        for await (const chunk of stream as unknown as Buffer[]) {
+          yield {
+            AudioEvent: {
+              AudioChunk: pcmEncodeChunk(chunk),
+            },
+          };
+        }
+      };
+      return new StartStreamTranscriptionCommand({
+        ...commandParams,
+        MediaEncoding: 'pcm',
+        MediaSampleRateHertz: 48000,
+        AudioStream: audioStream(),
+        ShowSpeakerLabel: speakerLabel,
+      });
+    };
 
     try {
-      const response = await transcribeClient.send(command);
+      const response = await withRetry(
+        () => transcribeClient.send(createCommand()),
+        3,
+        1000
+      );
 
       if (response.TranscriptResultStream) {
-        // This snippet should be put into an async function
         for await (const event of response.TranscriptResultStream) {
           if (
             event.TranscriptEvent?.Transcript?.Results &&
@@ -274,11 +300,11 @@ const useScreenAudio = () => {
       }
     } catch (error) {
       console.error('Screen audio transcription error:', error);
-      setError('Screen audio transcription failed');
-      stopTranscription();
+      toast.error(t('meetingMinutes.error.screen_transcription_failed'));
     } finally {
       stopTranscription();
       transcribeClient.destroy();
+      setTranscribeClient(undefined);
     }
   };
 
@@ -289,13 +315,12 @@ const useScreenAudio = () => {
     enableMultiLanguage?: boolean
   ) => {
     if (!isSupported) {
-      setError('Screen audio capture is not supported in this browser');
+      toast.error(t('meetingMinutes.error.screen_audio_not_supported'));
       return;
     }
 
     const stream = new MicrophoneStream();
     try {
-      setError('');
       setScreenStream(stream);
 
       // Request screen audio capture
@@ -333,11 +358,13 @@ const useScreenAudio = () => {
       console.log('Screen audio capture error:', e);
       if (e instanceof Error) {
         if (e.name === 'NotAllowedError') {
-          setError('Screen audio access was denied');
+          toast.error(t('meetingMinutes.error.screen_audio_denied'));
         } else if (e.name === 'NotSupportedError') {
-          setError('Screen audio capture is not supported');
+          toast.error(t('meetingMinutes.error.screen_audio_not_supported'));
+        } else if (e.message.includes('No audio track')) {
+          toast.error(t('meetingMinutes.error.screen_audio_no_audio_track'));
         } else {
-          setError('Failed to start screen audio capture');
+          toast.error(t('meetingMinutes.error.screen_audio_failed'));
         }
       }
     } finally {
@@ -362,8 +389,6 @@ const useScreenAudio = () => {
     }
 
     try {
-      setError('');
-
       // Request screen audio capture
       // Note: Most browsers require video to be true when capturing audio
       const displayStream = await navigator.mediaDevices.getDisplayMedia({
@@ -385,11 +410,13 @@ const useScreenAudio = () => {
       console.log('Screen audio capture preparation error:', e);
       if (e instanceof Error) {
         if (e.name === 'NotAllowedError') {
-          setError('Screen audio access was denied');
+          toast.error(t('meetingMinutes.error.screen_audio_denied'));
         } else if (e.name === 'NotSupportedError') {
-          setError('Screen audio capture is not supported');
+          toast.error(t('meetingMinutes.error.screen_audio_not_supported'));
+        } else if (e.message.includes('No audio track')) {
+          toast.error(t('meetingMinutes.error.screen_audio_no_audio_track'));
         } else {
-          setError('Failed to prepare screen audio capture');
+          toast.error(t('meetingMinutes.error.screen_audio_failed'));
         }
       }
       throw e;
@@ -415,7 +442,6 @@ const useScreenAudio = () => {
   ) => {
     const stream = new MicrophoneStream();
     try {
-      setError('');
       setScreenStream(stream);
 
       // Extract only the audio track
@@ -443,7 +469,11 @@ const useScreenAudio = () => {
     } catch (e) {
       console.log('Screen audio transcription error:', e);
       if (e instanceof Error) {
-        setError('Failed to start screen audio transcription');
+        if (e.message.includes('No audio track')) {
+          toast.error(t('meetingMinutes.error.screen_audio_no_audio_track'));
+        } else {
+          toast.error(t('meetingMinutes.error.screen_audio_failed'));
+        }
       }
     } finally {
       stream.stop();
@@ -456,23 +486,8 @@ const useScreenAudio = () => {
     }
   };
 
-  const stopTranscription = () => {
-    if (screenStream) {
-      screenStream.stop();
-      setRecording(false);
-      setScreenStream(undefined);
-    }
-
-    // Clean up prepared stream if exists
-    if (preparedDisplayStream) {
-      preparedDisplayStream.getTracks().forEach((track) => track.stop());
-      setPreparedDisplayStream(null);
-    }
-  };
-
   const clearTranscripts = () => {
     setRawTranscripts([]);
-    setError('');
   };
 
   return {
@@ -484,7 +499,6 @@ const useScreenAudio = () => {
     transcriptScreen,
     clearTranscripts,
     isSupported,
-    error,
     rawTranscripts,
   };
 };

--- a/packages/web/src/hooks/useTranscribe.ts
+++ b/packages/web/src/hooks/useTranscribe.ts
@@ -1,6 +1,11 @@
 import { create } from 'zustand';
 import { MediaFormat } from '@aws-sdk/client-transcribe';
+import { toast } from 'sonner';
+import i18next from 'i18next';
 import useTranscribeApi from './useTranscribeApi';
+import { withRetry } from '../utils/retry';
+
+const MAX_FILE_SIZE_BYTES = 2 * 1024 * 1024 * 1024; // 2GB
 
 const useTranscribeState = create<{
   loading: boolean;
@@ -25,6 +30,16 @@ const useTranscribeState = create<{
   };
 
   const setStatus = (status: string) => {
+    if (status === 'FAILED') {
+      set(() => ({
+        status: status,
+        loading: false,
+      }));
+      toast.error(
+        i18next.t('meetingMinutes.error.file_transcription_job_failed')
+      );
+      return;
+    }
     set(() => ({
       status: status,
       loading: status === 'COMPLETED' ? false : true,
@@ -36,6 +51,7 @@ const useTranscribeState = create<{
       status: '',
       jobName: null,
       file: null,
+      loading: false,
     }));
   };
 
@@ -44,33 +60,53 @@ const useTranscribeState = create<{
     maxSpeakers = 1,
     languageCode?: string
   ) => {
+    const file = get().file;
+    if (!file) return;
+
+    if (file.size > MAX_FILE_SIZE_BYTES) {
+      toast.error(i18next.t('meetingMinutes.error.file_too_large'));
+      return;
+    }
+
     set(() => ({
       loading: true,
     }));
 
-    const mediaFormat = get().file?.name.split('.').pop() as MediaFormat;
+    try {
+      const mediaFormat = file.name.split('.').pop() as MediaFormat;
 
-    // Get the signed URL
-    const signedUrlRes = await api.getSignedUrl({
-      mediaFormat: mediaFormat,
-    });
-    const signedUrl = signedUrlRes.data;
-    const audioUrl = signedUrl.split(/[?#]/)[0]; // Exclude the query parameters from the signed URL
+      // Get the signed URL
+      const signedUrlRes = await api.getSignedUrl({
+        mediaFormat: mediaFormat,
+      });
+      const signedUrl = signedUrlRes.data;
+      const audioUrl = signedUrl.split(/[?#]/)[0]; // Exclude the query parameters from the signed URL
 
-    // Upload the audio
-    await api.uploadAudio(signedUrl, { file: get().file! });
+      // Upload the audio with retry
+      await withRetry(
+        () => api.uploadAudio(signedUrl, { file: file }),
+        3,
+        1000
+      );
 
-    // Start the transcription
-    const startTranscriptionRes = await api.startTranscription({
-      audioUrl: audioUrl,
-      speakerLabel: speakerLabel,
-      maxSpeakers: maxSpeakers,
-      languageCode: languageCode,
-    });
+      // Start the transcription
+      const startTranscriptionRes = await api.startTranscription({
+        audioUrl: audioUrl,
+        speakerLabel: speakerLabel,
+        maxSpeakers: maxSpeakers,
+        languageCode: languageCode,
+      });
 
-    set(() => ({
-      jobName: startTranscriptionRes.jobName,
-    }));
+      set(() => ({
+        jobName: startTranscriptionRes.jobName,
+      }));
+    } catch (error) {
+      console.error('File transcription error:', error);
+      set(() => ({
+        loading: false,
+      }));
+      toast.error(i18next.t('meetingMinutes.error.file_transcription_failed'));
+    }
   };
 
   return {

--- a/packages/web/src/hooks/useTranscribeApi.ts
+++ b/packages/web/src/hooks/useTranscribeApi.ts
@@ -23,7 +23,8 @@ const useTranscribeApi = () => {
       return http.get<GetTranscriptionResponse>(
         jobName ? `transcribe/result/${jobName}` : null,
         {
-          refreshInterval: status === 'COMPLETED' ? 0 : 2000,
+          refreshInterval:
+            status === 'COMPLETED' || status === 'FAILED' ? 0 : 2000,
           onSuccess: (data: GetTranscriptionResponse) => {
             setStatus(data.status);
           },

--- a/packages/web/src/utils/retry.ts
+++ b/packages/web/src/utils/retry.ts
@@ -1,0 +1,19 @@
+export const withRetry = async <T>(
+  fn: () => Promise<T>,
+  maxRetries: number = 3,
+  baseDelayMs: number = 1000
+): Promise<T> => {
+  let lastError: unknown;
+  for (let attempt = 0; attempt <= maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+      if (attempt < maxRetries) {
+        const delay = baseDelayMs * Math.pow(2, attempt);
+        await new Promise((resolve) => setTimeout(resolve, delay));
+      }
+    }
+  }
+  throw lastError;
+};


### PR DESCRIPTION
- TranscribeClientのライフサイクル修正: destroy()後にstate をリセットし再初期化可能に
- 全エラーをtoast.error()で統一通知（error stateの廃止）
- リトライユーティリティ追加（最大3回、指数バックオフ）
- 認証セッション取得、Transcribe Streaming接続、S3アップロードにリトライ適用
- FAILEDステータスでポーリング停止+toast通知
- transcribe()にtry-catch追加、clear()でloading状態をリセット
- 音声ソース未選択時のバリデーション追加
- ファイルサイズバリデーション追加（2GB上限）
- i18nエラーメッセージキー追加（ja/en）
