### PR TITLE
feat: チャット回答アイコンをロボットアイコンに変更

### DIFF
--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -631,8 +631,8 @@ landing:
         Bases for Amazon Bedrock のベクトルデータベースを参照することが可能です。
       title: Agent チャット
     agent_core:
-      description: AgentCore チャットは Bedrock AgentCore で作成したさまざまな Agent を利用する機能です
-      title: AgentCore
+      description: あらかじめ用意された AI エージェントと対話し、調べ物やタスクの実行を任せられる機能です。
+      title: AIエージェント
     chat:
       description: >-
         LLM

--- a/packages/web/src/components/ChatMessage.tsx
+++ b/packages/web/src/components/ChatMessage.tsx
@@ -18,10 +18,10 @@ import {
   PiNotePencil,
   PiCheck,
   PiX,
+  PiRobotFill,
 } from 'react-icons/pi';
 import { BaseProps } from '../@types/common';
 import { ShownMessage, UpdateFeedbackRequest } from 'generative-ai-use-cases';
-import BedrockIcon from '../assets/bedrock.svg?react';
 import useChat from '../hooks/useChat';
 import useTyping from '../hooks/useTyping';
 import FileCard from './FileCard';
@@ -163,8 +163,8 @@ const ChatMessage: React.FC<Props> = (props) => {
             </div>
           )}
           {chatContent?.role === 'assistant' && (
-            <div className="bg-aws-ml h-min rounded p-1">
-              <BedrockIcon className="size-7 fill-white" />
+            <div className="bg-aws-ml h-min rounded p-2 text-xl text-white">
+              <PiRobotFill />
             </div>
           )}
           {chatContent?.role === 'system' && (


### PR DESCRIPTION
## 変更内容
- チャット回答メッセージのアバターを Bedrock ロゴ(`BedrockIcon`) からロボットアイコン (`PiRobotFill`) に変更