### PR TITLE
fix: スケジューラのエージェント選択を日本語表示名(displayName)で表示

### DIFF
--- a/packages/web/src/pages/scheduler/SchedulerTaskFormPage.tsx
+++ b/packages/web/src/pages/scheduler/SchedulerTaskFormPage.tsx
@@ -205,7 +205,7 @@ const SchedulerTaskFormPage: React.FC = () => {
 
   const agentOptions = runtimes.map((r) => ({
     value: r.name,
-    label: r.name,
+    label: r.displayName ?? r.name,
   }));
 
   const modelOptions = MODELS.modelIds.map((id) => ({


### PR DESCRIPTION
## 概要

スケジューラ機能のタスク作成/編集フォームにおいて、エージェント選択プルダウンの表示名が内部識別子（アルファベットの `name`）で表示されており、ユーザーに分かりにくい状態でした。これを日本語表示名（`displayName`）優先の表示に修正します。

## 背景

`AgentCoreConfiguration` には日本語表示用の `displayName` フィールドが既に存在し、他画面（`AgentCorePage.tsx` / `AgentCoreListPage.tsx`）では `displayName ?? name` のパターンで日本語表示名を優先表示しています。スケジューラ画面のみこの対応が漏れていました。

## 修正内容

`packages/web/src/pages/scheduler/SchedulerTaskFormPage.tsx` の `agentOptions`:

\`\`\`diff
  const agentOptions = runtimes.map((r) => ({
    value: r.name,
-   label: r.name,
+   label: r.displayName ?? r.name,
  }));
\`\`\`

- `value`（保存・実行に使う内部キー）は `r.name` のまま据え置き、整合性を維持
- `label`（プルダウン表示名）のみ `displayName` 優先に変更。未設定の場合は従来通り `name` にフォールバックするため後方互換も維持

## 影響範囲

- `packages/web/src/pages/scheduler/SchedulerTaskFormPage.tsx` の1ファイル・1箇所のみ

🤖 Generated with [Claude Code](https://claude.com/claude-code)