### PR TITLE
feat: スケジューラにSendGridメール通知機能を追加

### DIFF
--- a/packages/cdk/cdk.json
+++ b/packages/cdk/cdk.json
@@ -63,6 +63,8 @@
     "searchAgentEnabled": false,
     "searchEngine": "Brave",
     "searchApiKey": "",
+    "schedulerSendgridApiKey": "",
+    "schedulerMailFrom": "",
     "agents": [],
     "inlineAgents": false,
     "mcpEnabled": false,

--- a/packages/cdk/lambda/executeScheduledTask.ts
+++ b/packages/cdk/lambda/executeScheduledTask.ts
@@ -12,7 +12,7 @@
  * 5. Invoke AgentCore runtime
  * 6. Buffer stream response
  * 7. Save result to DynamoDB
- * 8. Send SNS notification
+ * 8. Send email notification via SendGrid
  */
 
 import {
@@ -24,13 +24,13 @@ import {
   getTask,
   createExecution,
   updateExecutionStatus,
-  getUserNotificationInfo,
 } from './scheduler/repository';
 import { collectStreamResponse } from './scheduler/utils/stream-utils';
 import {
   sendSuccessNotification,
   sendErrorNotification,
-  ensureUserNotificationTopic,
+  getUserEmail,
+  isNotificationConfigured,
 } from './scheduler/utils/notification-utils';
 
 const MODEL_REGION = process.env.MODEL_REGION || 'us-east-1';
@@ -102,18 +102,14 @@ export const handler = async (event: SchedulerEventPayload): Promise<void> => {
     return;
   }
 
-  // 5. Get notification info
-  let snsTopicArn = task.snsTopicArn;
-  if (!snsTopicArn) {
+  // 5. Resolve recipient email (best-effort). Skipped when notifications are
+  //    not configured (e.g. closed-network mode).
+  let recipientEmail: string | undefined;
+  if (isNotificationConfigured()) {
     try {
-      const info = await getUserNotificationInfo(userId);
-      snsTopicArn = info?.snsTopicArn;
-      if (!snsTopicArn) {
-        const result = await ensureUserNotificationTopic(userId);
-        snsTopicArn = result.topicArn;
-      }
+      recipientEmail = await getUserEmail(userId);
     } catch (error) {
-      console.error('Failed to get notification info:', error);
+      console.error('Failed to resolve recipient email:', error);
     }
   }
 
@@ -192,10 +188,10 @@ export const handler = async (event: SchedulerEventPayload): Promise<void> => {
 
     // 9. Send success notification
     let emailSent = false;
-    if (snsTopicArn) {
+    if (recipientEmail) {
       try {
         await sendSuccessNotification(
-          snsTopicArn,
+          recipientEmail,
           task.taskName,
           streamResult.text,
           now,
@@ -239,10 +235,10 @@ export const handler = async (event: SchedulerEventPayload): Promise<void> => {
     }
 
     // Send error notification
-    if (snsTopicArn) {
+    if (recipientEmail) {
       try {
         await sendErrorNotification(
-          snsTopicArn,
+          recipientEmail,
           task.taskName,
           errorMessage,
           now

--- a/packages/cdk/lambda/scheduler/handlers/task-handlers.ts
+++ b/packages/cdk/lambda/scheduler/handlers/task-handlers.ts
@@ -27,11 +27,6 @@ import {
   toCronExpression,
   validateScheduleConfig,
 } from '../utils/schedule-utils';
-import { ensureUserNotificationTopic } from '../utils/notification-utils';
-import {
-  saveUserNotificationInfo,
-  getUserNotificationInfo,
-} from '../repository';
 import { successResponse, errorResponse } from '../utils/response-utils';
 
 const MAX_TASKS_PER_USER = 20;
@@ -91,25 +86,6 @@ export async function handleCreateTask(
   const scheduleName = `gaixer-task-${taskId}`;
   const cronExpression = toCronExpression(body.schedule);
 
-  // Ensure user has an SNS topic for notifications
-  let snsTopicArn: string;
-  try {
-    const existingInfo = await getUserNotificationInfo(userId);
-    if (existingInfo) {
-      snsTopicArn = existingInfo.snsTopicArn;
-    } else {
-      const { topicArn, email } = await ensureUserNotificationTopic(userId);
-      snsTopicArn = topicArn;
-      await saveUserNotificationInfo(userId, { snsTopicArn: topicArn, email });
-    }
-  } catch (error) {
-    console.error('Failed to setup SNS notification:', error);
-    return errorResponse(
-      'Failed to setup notification. Please try again.',
-      500
-    );
-  }
-
   // Create EventBridge Schedule first (design principle: Scheduler before DB)
   try {
     await schedulerClient.send(
@@ -157,7 +133,6 @@ export async function handleCreateTask(
     enabled: true,
     deleted: false,
     userId,
-    snsTopicArn,
     updatedAt: now,
   };
 

--- a/packages/cdk/lambda/scheduler/repository.ts
+++ b/packages/cdk/lambda/scheduler/repository.ts
@@ -13,11 +13,6 @@
  *    - SK: {executionId}  ({taskId}#{scheduledTime})
  *    - Purpose: Store execution logs per task
  *
- * 3. User Notification Info:
- *    - PK: userNotification#{userId}
- *    - SK: info
- *    - Purpose: Store user's SNS topic ARN
- *
  * GSI (UserExecutionIndex):
  *    - GSI PK: userExecution#{userId}
  *    - GSI SK: {startedAt}
@@ -38,7 +33,6 @@ import {
   ScheduledTaskResponse,
   TaskExecutionSummary,
   TaskExecutionDetail,
-  UserNotificationInfo,
 } from './types';
 
 const TABLE_NAME: string = process.env.SCHEDULER_TABLE_NAME!;
@@ -410,38 +404,5 @@ export const listExecutionsByUser = async (
   );
   return (result.Items || []).map((item) =>
     toExecutionSummary(item as TaskExecution)
-  );
-};
-
-// --- User Notification Info ---
-
-export const getUserNotificationInfo = async (
-  userId: string
-): Promise<UserNotificationInfo | null> => {
-  const result = await dynamoDbDocument.send(
-    new GetCommand({
-      TableName: TABLE_NAME,
-      Key: {
-        pk: `userNotification#${userId}`,
-        sk: 'info',
-      },
-    })
-  );
-  return result.Item ? (result.Item as UserNotificationInfo) : null;
-};
-
-export const saveUserNotificationInfo = async (
-  userId: string,
-  info: UserNotificationInfo
-): Promise<void> => {
-  await dynamoDbDocument.send(
-    new PutCommand({
-      TableName: TABLE_NAME,
-      Item: {
-        pk: `userNotification#${userId}`,
-        sk: 'info',
-        ...info,
-      },
-    })
   );
 };

--- a/packages/cdk/lambda/scheduler/types.ts
+++ b/packages/cdk/lambda/scheduler/types.ts
@@ -28,7 +28,6 @@ export interface ScheduledTask {
   enabled: boolean;
   deleted: boolean;
   userId: string;
-  snsTopicArn?: string;
   updatedAt: string;
 }
 
@@ -107,11 +106,4 @@ export interface SchedulerEventPayload {
   taskId: string;
   userId: string;
   scheduledTime: string;
-}
-
-// --- SNS Notification User Info ---
-
-export interface UserNotificationInfo {
-  snsTopicArn: string;
-  email: string;
 }

--- a/packages/cdk/lambda/scheduler/utils/notification-utils.ts
+++ b/packages/cdk/lambda/scheduler/utils/notification-utils.ts
@@ -4,27 +4,25 @@
  *
  * Sends execution result notifications via the SendGrid Mail Send API.
  *
- * Configuration is provided through two SSM parameters whose names are passed
- * as env vars:
- *   - SENDGRID_API_KEY_PARAM: SSM SecureString holding the SendGrid API key
- *   - MAIL_FROM_PARAM:        SSM String holding the authenticated sender address
+ * Configuration is provided directly through two env vars (set from cdk.json):
+ *   - SENDGRID_API_KEY: the SendGrid API key
+ *   - MAIL_FROM:        the authenticated sender address
  *
- * When either parameter name is unset (e.g. closed-network mode, or the feature
- * has not been configured yet), notifications are treated as disabled. The
- * recipient address is resolved per-execution from Cognito.
+ * When either value is unset (e.g. closed-network mode, or the feature has not
+ * been configured yet), notifications are treated as disabled. The recipient
+ * address is resolved per-execution from Cognito.
  */
 
 import {
   CognitoIdentityProviderClient,
   AdminGetUserCommand,
 } from '@aws-sdk/client-cognito-identity-provider';
-import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
 import { TokenUsage } from '../types';
 
 const region = process.env.AWS_REGION!;
 const userPoolId = process.env.USER_POOL_ID!;
-const SENDGRID_API_KEY_PARAM = process.env.SENDGRID_API_KEY_PARAM;
-const MAIL_FROM_PARAM = process.env.MAIL_FROM_PARAM;
+const SENDGRID_API_KEY = process.env.SENDGRID_API_KEY;
+const MAIL_FROM = process.env.MAIL_FROM;
 
 const SENDGRID_ENDPOINT = 'https://api.sendgrid.com/v3/mail/send';
 
@@ -34,42 +32,6 @@ const MAX_BODY_SIZE = 256 * 1024;
 
 const cognito = new CognitoIdentityProviderClient({ region });
 
-// --- SSM value resolution (cached in module scope across warm invocations) ---
-
-const SSM_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
-
-let ssmClient: SSMClient | undefined;
-const getSsmClient = (): SSMClient => {
-  if (!ssmClient) ssmClient = new SSMClient({ region });
-  return ssmClient;
-};
-
-interface CachedParam {
-  value: string;
-  expiresAt: number;
-}
-const paramCache: Record<string, CachedParam> = {};
-
-async function getSsmParameter(
-  name: string,
-  withDecryption: boolean
-): Promise<string> {
-  const now = Date.now();
-  const cached = paramCache[name];
-  if (cached && now < cached.expiresAt) {
-    return cached.value;
-  }
-  const res = await getSsmClient().send(
-    new GetParameterCommand({ Name: name, WithDecryption: withDecryption })
-  );
-  const value = res.Parameter?.Value;
-  if (!value) {
-    throw new Error(`SSM parameter "${name}" is empty`);
-  }
-  paramCache[name] = { value, expiresAt: now + SSM_CACHE_TTL_MS };
-  return value;
-}
-
 /**
  * Whether email notifications are configured. False in closed-network mode or
  * before the SendGrid parameters have been set, in which case callers should
@@ -77,10 +39,10 @@ async function getSsmParameter(
  */
 export function isNotificationConfigured(): boolean {
   return (
-    !!SENDGRID_API_KEY_PARAM &&
-    SENDGRID_API_KEY_PARAM.length > 0 &&
-    !!MAIL_FROM_PARAM &&
-    MAIL_FROM_PARAM.length > 0
+    !!SENDGRID_API_KEY &&
+    SENDGRID_API_KEY.length > 0 &&
+    !!MAIL_FROM &&
+    MAIL_FROM.length > 0
   );
 }
 
@@ -115,20 +77,15 @@ async function sendViaSendGrid(
     throw new Error('SendGrid notification is not configured');
   }
 
-  const [apiKey, mailFrom] = await Promise.all([
-    getSsmParameter(SENDGRID_API_KEY_PARAM!, true),
-    getSsmParameter(MAIL_FROM_PARAM!, false),
-  ]);
-
   const res = await fetch(SENDGRID_ENDPOINT, {
     method: 'POST',
     headers: {
-      Authorization: `Bearer ${apiKey}`,
+      Authorization: `Bearer ${SENDGRID_API_KEY}`,
       'Content-Type': 'application/json',
     },
     body: JSON.stringify({
       personalizations: [{ to: [{ email: toEmail }] }],
-      from: { email: mailFrom },
+      from: { email: MAIL_FROM },
       subject: subject.substring(0, 998), // RFC 5322 subject length guard
       content: [{ type: 'text/plain', value: body }],
     }),

--- a/packages/cdk/lambda/scheduler/utils/notification-utils.ts
+++ b/packages/cdk/lambda/scheduler/utils/notification-utils.ts
@@ -1,42 +1,93 @@
 /* eslint-disable i18nhelper/no-jp-string */
 /**
- * SNS Notification Utilities
+ * SendGrid Notification Utilities
  *
- * Manages per-user SNS topics and sends execution result notifications.
+ * Sends execution result notifications via the SendGrid Mail Send API.
+ *
+ * Configuration is provided through two SSM parameters whose names are passed
+ * as env vars:
+ *   - SENDGRID_API_KEY_PARAM: SSM SecureString holding the SendGrid API key
+ *   - MAIL_FROM_PARAM:        SSM String holding the authenticated sender address
+ *
+ * When either parameter name is unset (e.g. closed-network mode, or the feature
+ * has not been configured yet), notifications are treated as disabled. The
+ * recipient address is resolved per-execution from Cognito.
  */
 
-import {
-  SNSClient,
-  CreateTopicCommand,
-  SubscribeCommand,
-  ListSubscriptionsByTopicCommand,
-  PublishCommand,
-} from '@aws-sdk/client-sns';
 import {
   CognitoIdentityProviderClient,
   AdminGetUserCommand,
 } from '@aws-sdk/client-cognito-identity-provider';
+import { SSMClient, GetParameterCommand } from '@aws-sdk/client-ssm';
 import { TokenUsage } from '../types';
 
 const region = process.env.AWS_REGION!;
 const userPoolId = process.env.USER_POOL_ID!;
+const SENDGRID_API_KEY_PARAM = process.env.SENDGRID_API_KEY_PARAM;
+const MAIL_FROM_PARAM = process.env.MAIL_FROM_PARAM;
 
-const sns = new SNSClient({ region });
+const SENDGRID_ENDPOINT = 'https://api.sendgrid.com/v3/mail/send';
+
+// Generous body cap so a runaway agent result cannot produce a multi-MB email.
+// (SendGrid's own limit is ~30MB; this is a UX/safety bound, not a hard API one.)
+const MAX_BODY_SIZE = 256 * 1024;
+
 const cognito = new CognitoIdentityProviderClient({ region });
 
-// SNS message size limit (256KB). Reserve space for subject/metadata.
-const MAX_MESSAGE_SIZE = 250 * 1024;
+// --- SSM value resolution (cached in module scope across warm invocations) ---
+
+const SSM_CACHE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+
+let ssmClient: SSMClient | undefined;
+const getSsmClient = (): SSMClient => {
+  if (!ssmClient) ssmClient = new SSMClient({ region });
+  return ssmClient;
+};
+
+interface CachedParam {
+  value: string;
+  expiresAt: number;
+}
+const paramCache: Record<string, CachedParam> = {};
+
+async function getSsmParameter(
+  name: string,
+  withDecryption: boolean
+): Promise<string> {
+  const now = Date.now();
+  const cached = paramCache[name];
+  if (cached && now < cached.expiresAt) {
+    return cached.value;
+  }
+  const res = await getSsmClient().send(
+    new GetParameterCommand({ Name: name, WithDecryption: withDecryption })
+  );
+  const value = res.Parameter?.Value;
+  if (!value) {
+    throw new Error(`SSM parameter "${name}" is empty`);
+  }
+  paramCache[name] = { value, expiresAt: now + SSM_CACHE_TTL_MS };
+  return value;
+}
 
 /**
- * Ensure SNS topic exists for the user and email is subscribed.
- * Returns the topic ARN.
- *
- * CreateTopic is idempotent: if the topic already exists, it returns the existing ARN.
+ * Whether email notifications are configured. False in closed-network mode or
+ * before the SendGrid parameters have been set, in which case callers should
+ * skip notification and record emailSent=false.
  */
-export async function ensureUserNotificationTopic(
-  userId: string
-): Promise<{ topicArn: string; email: string }> {
-  // Get user email from Cognito
+export function isNotificationConfigured(): boolean {
+  return (
+    !!SENDGRID_API_KEY_PARAM &&
+    SENDGRID_API_KEY_PARAM.length > 0 &&
+    !!MAIL_FROM_PARAM &&
+    MAIL_FROM_PARAM.length > 0
+  );
+}
+
+/**
+ * Resolve the user's email address from Cognito.
+ */
+export async function getUserEmail(userId: string): Promise<string> {
   const userResponse = await cognito.send(
     new AdminGetUserCommand({
       UserPoolId: userPoolId,
@@ -49,42 +100,51 @@ export async function ensureUserNotificationTopic(
   if (!email) {
     throw new Error(`Email not found for user ${userId}`);
   }
-
-  // Create or get existing topic (idempotent)
-  const sanitizedUserId = userId.replace(/[^a-zA-Z0-9_-]/g, '_');
-  const topicName = `gaixer-notification-${sanitizedUserId}`;
-  const topicResult = await sns.send(
-    new CreateTopicCommand({ Name: topicName })
-  );
-  const topicArn = topicResult.TopicArn!;
-
-  // Check if email is already subscribed
-  const subscriptions = await sns.send(
-    new ListSubscriptionsByTopicCommand({ TopicArn: topicArn })
-  );
-  const isSubscribed = subscriptions.Subscriptions?.some(
-    (sub: { Protocol?: string; Endpoint?: string }) =>
-      sub.Protocol === 'email' && sub.Endpoint === email
-  );
-
-  if (!isSubscribed) {
-    await sns.send(
-      new SubscribeCommand({
-        TopicArn: topicArn,
-        Protocol: 'email',
-        Endpoint: email,
-      })
-    );
-  }
-
-  return { topicArn, email };
+  return email;
 }
 
 /**
- * Send success notification
+ * Send a plaintext email through the SendGrid Mail Send API.
+ */
+async function sendViaSendGrid(
+  toEmail: string,
+  subject: string,
+  body: string
+): Promise<void> {
+  if (!isNotificationConfigured()) {
+    throw new Error('SendGrid notification is not configured');
+  }
+
+  const [apiKey, mailFrom] = await Promise.all([
+    getSsmParameter(SENDGRID_API_KEY_PARAM!, true),
+    getSsmParameter(MAIL_FROM_PARAM!, false),
+  ]);
+
+  const res = await fetch(SENDGRID_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      personalizations: [{ to: [{ email: toEmail }] }],
+      from: { email: mailFrom },
+      subject: subject.substring(0, 998), // RFC 5322 subject length guard
+      content: [{ type: 'text/plain', value: body }],
+    }),
+  });
+
+  if (res.status >= 400) {
+    const detail = await res.text().catch(() => '');
+    throw new Error(`SendGrid request failed: ${res.status} ${detail}`);
+  }
+}
+
+/**
+ * Send success notification to the given recipient.
  */
 export async function sendSuccessNotification(
-  topicArn: string,
+  toEmail: string,
   taskName: string,
   resultText: string,
   executionTime: string,
@@ -94,43 +154,26 @@ export async function sendSuccessNotification(
     ? `\nトークン消費: 入力 ${tokenUsage.inputTokens.toLocaleString()} / 出力 ${tokenUsage.outputTokens.toLocaleString()}`
     : '';
 
-  let body = `タスク「${taskName}」の実行が完了しました。
+  const safeResult = capResultText(resultText);
+
+  const body = `タスク「${taskName}」の実行が完了しました。
 
 ■ 実行結果
-${resultText}
+${safeResult}
 
 ■ 実行情報
 実行日時: ${formatJstDateTime(executionTime)}${tokenInfo}
 
 詳細はGaiXerのスケジューラ画面からご確認いただけます。`;
 
-  // Truncate if exceeds SNS limit
-  if (Buffer.byteLength(body, 'utf-8') > MAX_MESSAGE_SIZE) {
-    const truncationNote =
-      '\n\n[メール本文が上限を超えたため省略されました。続きはGaiXerの画面でご確認ください。]';
-    // Calculate available space for resultText
-    const overhead = Buffer.byteLength(body.replace(resultText, ''), 'utf-8');
-    const availableBytes =
-      MAX_MESSAGE_SIZE - overhead - Buffer.byteLength(truncationNote, 'utf-8');
-    const truncatedResult =
-      truncateUtf8(resultText, availableBytes) + truncationNote;
-    body = body.replace(resultText, truncatedResult);
-  }
-
-  await sns.send(
-    new PublishCommand({
-      TopicArn: topicArn,
-      Subject: `[GaiXer] タスク実行完了: ${taskName}`.substring(0, 100),
-      Message: body,
-    })
-  );
+  await sendViaSendGrid(toEmail, `[GaiXer] タスク実行完了: ${taskName}`, body);
 }
 
 /**
- * Send error notification
+ * Send error notification to the given recipient.
  */
 export async function sendErrorNotification(
-  topicArn: string,
+  toEmail: string,
   taskName: string,
   errorMessage: string,
   executionTime: string
@@ -145,13 +188,25 @@ ${errorMessage}
 
 タスクの設定をご確認ください。`;
 
-  await sns.send(
-    new PublishCommand({
-      TopicArn: topicArn,
-      Subject: `[GaiXer] タスク実行エラー: ${taskName}`.substring(0, 100),
-      Message: body,
-    })
+  await sendViaSendGrid(
+    toEmail,
+    `[GaiXer] タスク実行エラー: ${taskName}`,
+    body
   );
+}
+
+/**
+ * Cap result text to a generous byte limit, appending a notice when truncated.
+ */
+function capResultText(resultText: string): string {
+  if (Buffer.byteLength(resultText, 'utf-8') <= MAX_BODY_SIZE) {
+    return resultText;
+  }
+  const truncationNote =
+    '\n\n[メール本文が上限を超えたため省略されました。続きはGaiXerの画面でご確認ください。]';
+  const availableBytes =
+    MAX_BODY_SIZE - Buffer.byteLength(truncationNote, 'utf-8');
+  return truncateUtf8(resultText, availableBytes) + truncationNote;
 }
 
 /**

--- a/packages/cdk/lib/construct/scheduler.ts
+++ b/packages/cdk/lib/construct/scheduler.ts
@@ -36,10 +36,11 @@ export interface SchedulerProps {
   readonly agentNameToArnMap: Record<string, string>;
   readonly modelRegion: string;
   readonly agentCoreRegion?: string;
-  // SendGrid email notification (SSM parameter names). When unset, or in
+  // SendGrid email notification. The API key and sender address are passed
+  // through directly (configured in cdk.json). When unset, or in
   // closed-network mode, email notifications are disabled.
-  readonly sendgridApiKeySsmParameterName?: string | null;
-  readonly mailFromSsmParameterName?: string | null;
+  readonly sendgridApiKey?: string | null;
+  readonly mailFrom?: string | null;
   // Closed network
   readonly closedNetworkMode?: boolean;
   readonly vpc?: IVpc;
@@ -56,19 +57,11 @@ export class Scheduler extends Construct {
     const region = Stack.of(this).region;
     const account = Stack.of(this).account;
 
-    // Email notifications via SendGrid are enabled only when both SSM parameter
-    // names are provided and we are not in closed-network mode (no internet
-    // egress to the SendGrid API).
+    // Email notifications via SendGrid are enabled only when both the API key
+    // and sender address are provided and we are not in closed-network mode
+    // (no internet egress to the SendGrid API).
     const notificationsEnabled =
-      !props.closedNetworkMode &&
-      !!props.sendgridApiKeySsmParameterName &&
-      !!props.mailFromSsmParameterName;
-
-    // Normalize an SSM parameter name (with or without leading slash) to its ARN.
-    const ssmParameterArn = (name: string): string => {
-      const normalized = name.startsWith('/') ? name.slice(1) : name;
-      return `arn:aws:ssm:${region}:${account}:parameter/${normalized}`;
-    };
+      !props.closedNetworkMode && !!props.sendgridApiKey && !!props.mailFrom;
 
     // --- DynamoDB Table ---
     const schedulerTable = new ddb.Table(this, 'SchedulerTable', {
@@ -139,15 +132,14 @@ export class Scheduler extends Construct {
         ...(agentCoreRegion ? { AGENT_CORE_REGION: agentCoreRegion } : {}),
         ...(notificationsEnabled
           ? {
-              SENDGRID_API_KEY_PARAM: props.sendgridApiKeySsmParameterName!,
-              MAIL_FROM_PARAM: props.mailFromSsmParameterName!,
+              SENDGRID_API_KEY: props.sendgridApiKey!,
+              MAIL_FROM: props.mailFrom!,
             }
           : {}),
       },
       bundling: {
         nodeModules: [
           '@aws-sdk/client-bedrock-agentcore',
-          '@aws-sdk/client-ssm',
           '@aws-sdk/client-cognito-identity-provider',
         ],
       },
@@ -165,34 +157,6 @@ export class Scheduler extends Construct {
           effect: iam.Effect.ALLOW,
           actions: ['bedrock-agentcore:InvokeAgentRuntime'],
           resources: agentRuntimeArns.map((arn) => arn + '*'),
-        })
-      );
-    }
-
-    // Grant SSM read for SendGrid config (API key + sender address) when enabled
-    if (notificationsEnabled) {
-      executeFunction.addToRolePolicy(
-        new iam.PolicyStatement({
-          effect: iam.Effect.ALLOW,
-          actions: ['ssm:GetParameter'],
-          resources: [
-            ssmParameterArn(props.sendgridApiKeySsmParameterName!),
-            ssmParameterArn(props.mailFromSsmParameterName!),
-          ],
-        })
-      );
-      // SecureString decryption uses the AWS-managed key by default; allow
-      // Decrypt against any KMS key in the account scoped via ViaService.
-      executeFunction.addToRolePolicy(
-        new iam.PolicyStatement({
-          effect: iam.Effect.ALLOW,
-          actions: ['kms:Decrypt'],
-          resources: ['*'],
-          conditions: {
-            StringEquals: {
-              'kms:ViaService': `ssm.${region}.amazonaws.com`,
-            },
-          },
         })
       );
     }

--- a/packages/cdk/lib/construct/scheduler.ts
+++ b/packages/cdk/lib/construct/scheduler.ts
@@ -36,7 +36,12 @@ export interface SchedulerProps {
   readonly agentNameToArnMap: Record<string, string>;
   readonly modelRegion: string;
   readonly agentCoreRegion?: string;
+  // SendGrid email notification (SSM parameter names). When unset, or in
+  // closed-network mode, email notifications are disabled.
+  readonly sendgridApiKeySsmParameterName?: string | null;
+  readonly mailFromSsmParameterName?: string | null;
   // Closed network
+  readonly closedNetworkMode?: boolean;
   readonly vpc?: IVpc;
   readonly securityGroups?: ISecurityGroup[];
 }
@@ -50,6 +55,20 @@ export class Scheduler extends Construct {
 
     const region = Stack.of(this).region;
     const account = Stack.of(this).account;
+
+    // Email notifications via SendGrid are enabled only when both SSM parameter
+    // names are provided and we are not in closed-network mode (no internet
+    // egress to the SendGrid API).
+    const notificationsEnabled =
+      !props.closedNetworkMode &&
+      !!props.sendgridApiKeySsmParameterName &&
+      !!props.mailFromSsmParameterName;
+
+    // Normalize an SSM parameter name (with or without leading slash) to its ARN.
+    const ssmParameterArn = (name: string): string => {
+      const normalized = name.startsWith('/') ? name.slice(1) : name;
+      return `arn:aws:ssm:${region}:${account}:parameter/${normalized}`;
+    };
 
     // --- DynamoDB Table ---
     const schedulerTable = new ddb.Table(this, 'SchedulerTable', {
@@ -118,11 +137,17 @@ export class Scheduler extends Construct {
         AGENT_NAME_TO_ARN_MAP: JSON.stringify(agentNameToArnMap),
         USER_POOL_ID: userPool.userPoolId,
         ...(agentCoreRegion ? { AGENT_CORE_REGION: agentCoreRegion } : {}),
+        ...(notificationsEnabled
+          ? {
+              SENDGRID_API_KEY_PARAM: props.sendgridApiKeySsmParameterName!,
+              MAIL_FROM_PARAM: props.mailFromSsmParameterName!,
+            }
+          : {}),
       },
       bundling: {
         nodeModules: [
           '@aws-sdk/client-bedrock-agentcore',
-          '@aws-sdk/client-sns',
+          '@aws-sdk/client-ssm',
           '@aws-sdk/client-cognito-identity-provider',
         ],
       },
@@ -144,19 +169,33 @@ export class Scheduler extends Construct {
       );
     }
 
-    // Grant SNS publish permissions
-    executeFunction.addToRolePolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: [
-          'sns:Publish',
-          'sns:CreateTopic',
-          'sns:Subscribe',
-          'sns:ListSubscriptionsByTopic',
-        ],
-        resources: [`arn:aws:sns:${region}:${account}:gaixer-notification-*`],
-      })
-    );
+    // Grant SSM read for SendGrid config (API key + sender address) when enabled
+    if (notificationsEnabled) {
+      executeFunction.addToRolePolicy(
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: ['ssm:GetParameter'],
+          resources: [
+            ssmParameterArn(props.sendgridApiKeySsmParameterName!),
+            ssmParameterArn(props.mailFromSsmParameterName!),
+          ],
+        })
+      );
+      // SecureString decryption uses the AWS-managed key by default; allow
+      // Decrypt against any KMS key in the account scoped via ViaService.
+      executeFunction.addToRolePolicy(
+        new iam.PolicyStatement({
+          effect: iam.Effect.ALLOW,
+          actions: ['kms:Decrypt'],
+          resources: ['*'],
+          conditions: {
+            StringEquals: {
+              'kms:ViaService': `ssm.${region}.amazonaws.com`,
+            },
+          },
+        })
+      );
+    }
 
     // Grant Cognito permissions (for getting user email)
     executeFunction.addToRolePolicy(
@@ -198,14 +237,9 @@ export class Scheduler extends Construct {
         SCHEDULER_ROLE_ARN: schedulerExecutionRole.roleArn,
         DLQ_ARN: dlq.queueArn,
         AGENT_NAME_TO_ARN_MAP: JSON.stringify(agentNameToArnMap),
-        USER_POOL_ID: userPool.userPoolId,
       },
       bundling: {
-        nodeModules: [
-          '@aws-sdk/client-scheduler',
-          '@aws-sdk/client-sns',
-          '@aws-sdk/client-cognito-identity-provider',
-        ],
+        nodeModules: ['@aws-sdk/client-scheduler'],
       },
       vpc: props.vpc,
       securityGroups: props.securityGroups,
@@ -241,28 +275,6 @@ export class Scheduler extends Construct {
         effect: iam.Effect.ALLOW,
         actions: ['iam:PassRole'],
         resources: [schedulerExecutionRole.roleArn],
-      })
-    );
-
-    // Grant SNS topic management
-    schedulerApiFunction.addToRolePolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: [
-          'sns:CreateTopic',
-          'sns:Subscribe',
-          'sns:ListSubscriptionsByTopic',
-        ],
-        resources: [`arn:aws:sns:${region}:${account}:gaixer-notification-*`],
-      })
-    );
-
-    // Grant Cognito permissions
-    schedulerApiFunction.addToRolePolicy(
-      new iam.PolicyStatement({
-        effect: iam.Effect.ALLOW,
-        actions: ['cognito-idp:AdminGetUser'],
-        resources: [userPool.userPoolArn],
       })
     );
 

--- a/packages/cdk/lib/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/generative-ai-use-cases-stack.ts
@@ -466,6 +466,10 @@ export class GenerativeAiUseCasesStack extends Stack {
         agentNameToArnMap,
         modelRegion: params.modelRegion,
         agentCoreRegion: params.agentCoreRegion,
+        sendgridApiKeySsmParameterName:
+          params.schedulerSendgridApiKeySsmParameterName,
+        mailFromSsmParameterName: params.schedulerMailFromSsmParameterName,
+        closedNetworkMode: params.closedNetworkMode,
         vpc: props.vpc,
         securityGroups,
       });

--- a/packages/cdk/lib/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/generative-ai-use-cases-stack.ts
@@ -466,9 +466,8 @@ export class GenerativeAiUseCasesStack extends Stack {
         agentNameToArnMap,
         modelRegion: params.modelRegion,
         agentCoreRegion: params.agentCoreRegion,
-        sendgridApiKeySsmParameterName:
-          params.schedulerSendgridApiKeySsmParameterName,
-        mailFromSsmParameterName: params.schedulerMailFromSsmParameterName,
+        sendgridApiKey: params.schedulerSendgridApiKey,
+        mailFrom: params.schedulerMailFrom,
         closedNetworkMode: params.closedNetworkMode,
         vpc: props.vpc,
         securityGroups,

--- a/packages/cdk/lib/stack-input.ts
+++ b/packages/cdk/lib/stack-input.ts
@@ -185,11 +185,12 @@ const baseStackInputSchema = z.object({
     )
     .default([]),
   // Scheduler email notification (SendGrid)
-  // SSM parameter names: the API key (SecureString) and the authenticated
-  // sender address (String). When either is unset, or in closed-network mode,
-  // scheduler email notifications are disabled (tasks still run; emailSent=false).
-  schedulerSendgridApiKeySsmParameterName: z.string().nullish(),
-  schedulerMailFromSsmParameterName: z.string().nullish(),
+  // The API key and the authenticated sender address are configured directly
+  // in cdk.json (mirrors searchApiKey). When either is unset, or in
+  // closed-network mode, scheduler email notifications are disabled (tasks
+  // still run; emailSent=false).
+  schedulerSendgridApiKey: z.string().nullish(),
+  schedulerMailFrom: z.string().nullish(),
   // MCP
   mcpEnabled: z.boolean().default(false),
   // Guardrail

--- a/packages/cdk/lib/stack-input.ts
+++ b/packages/cdk/lib/stack-input.ts
@@ -184,6 +184,12 @@ const baseStackInputSchema = z.object({
       })
     )
     .default([]),
+  // Scheduler email notification (SendGrid)
+  // SSM parameter names: the API key (SecureString) and the authenticated
+  // sender address (String). When either is unset, or in closed-network mode,
+  // scheduler email notifications are disabled (tasks still run; emailSent=false).
+  schedulerSendgridApiKeySsmParameterName: z.string().nullish(),
+  schedulerMailFromSsmParameterName: z.string().nullish(),
   // MCP
   mcpEnabled: z.boolean().default(false),
   // Guardrail

--- a/packages/cdk/package.json
+++ b/packages/cdk/package.json
@@ -39,7 +39,6 @@
     "@aws-sdk/client-s3": "^3.755.0",
     "@aws-sdk/client-sagemaker-runtime": "^3.755.0",
     "@aws-sdk/client-scheduler": "^3.1047.0",
-    "@aws-sdk/client-sns": "^3.1047.0",
     "@aws-sdk/client-sqs": "^3.1047.0",
     "@aws-sdk/client-ssm": "^3.755.0",
     "@aws-sdk/client-transcribe": "^3.755.0",

--- a/packages/web/src/components/ButtonToggle.tsx
+++ b/packages/web/src/components/ButtonToggle.tsx
@@ -12,10 +12,10 @@ const ButtonToggle: React.FC<Props> = (props) => {
     <button
       className={`${
         props.className ?? ''
-      } flex items-center justify-center rounded-xl border bg-white p-2 text-xl ${
+      } flex items-center justify-center rounded-xl border p-2 text-xl ${
         props.isEnabled
-          ? 'text-aws-smile border-aws-smile'
-          : 'border-gray-400 text-gray-400'
+          ? 'bg-aws-smile border-aws-smile text-white'
+          : 'border-gray-400 bg-white text-gray-400'
       }`}
       onClick={props.onSwitch}>
       {props.icon}

--- a/packages/web/src/components/InputChatContent.tsx
+++ b/packages/web/src/components/InputChatContent.tsx
@@ -231,7 +231,13 @@ const InputChatContent: React.FC<Props> = (props) => {
                       value={[]}
                     />
                     <div
-                      className={`${uploading ? 'bg-gray-300' : 'cursor-pointer bg-white '} ${uploadedFiles.length > 0 ? 'text-aws-smile border-aws-smile' : 'border-gray-400 text-gray-400'} flex items-center justify-center rounded-xl border p-2 align-bottom text-xl`}>
+                      className={`${
+                        uploading
+                          ? 'border-gray-400 bg-gray-300 text-gray-400'
+                          : uploadedFiles.length > 0
+                            ? 'bg-aws-smile border-aws-smile cursor-pointer text-white'
+                            : 'cursor-pointer border-gray-400 bg-white text-gray-400'
+                      } flex items-center justify-center rounded-xl border p-2 align-bottom text-xl`}>
                       {uploading ? (
                         <PiSpinnerGap className="animate-spin" />
                       ) : (

--- a/packages/web/src/pages/scheduler/SchedulerTaskDetailPage.tsx
+++ b/packages/web/src/pages/scheduler/SchedulerTaskDetailPage.tsx
@@ -14,6 +14,7 @@ import {
   PiClock,
 } from 'react-icons/pi';
 import useSchedulerApi from '../../hooks/useSchedulerApi';
+import { useAgentCore } from '../../hooks/useAgentCore';
 import { formatScheduleLabel } from './schedulerUtils';
 import Button from '../../components/Button';
 import Card from '../../components/Card';
@@ -29,6 +30,9 @@ const SchedulerTaskDetailPage: React.FC = () => {
   const api = useSchedulerApi();
   const { data: taskData, mutate: mutateTask } = api.getTask(taskId ?? null);
   const { data: execData } = api.listExecutions(taskId ?? null, 20);
+
+  const { getAllAvailableRuntimes } = useAgentCore('/scheduler-detail');
+  const runtimes = getAllAvailableRuntimes();
 
   const task = taskData?.task;
   const executions = execData?.executions ?? [];
@@ -166,7 +170,10 @@ const SchedulerTaskDetailPage: React.FC = () => {
                 <div className="text-xs text-gray-400">
                   {t('scheduler.agent')}
                 </div>
-                <div className="text-sm">{task.agentName}</div>
+                <div className="text-sm">
+                  {runtimes.find((r) => r.name === task.agentName)
+                    ?.displayName ?? task.agentName}
+                </div>
               </div>
             </div>
             <div className="flex items-start gap-2">


### PR DESCRIPTION
## 変更内容
スケジューラのタスク実行結果メールは現在 **Amazon SNS のEメール購読**で送信していたため、SNSメールは大量送信を想定しておらずスロットリング等の制約があり「1日あたりの送信数が頭打ち」になる。
送信上限を引き上げ、到達率・拡張性を確保するため、メール配信を **SendGrid** に移行を行った。