### PR TITLE
feat(manual-rag): 汎用マニュアルRAGの管理API・前処理Lambda基盤 (B1〜B7)

### DIFF
--- a/docs/naito/documents/manual-cdk-deploy-plan.md
+++ b/docs/naito/documents/manual-cdk-deploy-plan.md
@@ -1,0 +1,251 @@
+# 汎用マニュアルエージェント デプロイ用 CDK 実装計画書（GenU 本体側）
+
+**作成日**: 2026-05-29
+**対象**: GenU 本体リポジトリ（`generative-ai-use-cases`）の CDK 層に、汎用マニュアルエージェント機能のインフラを新規追加するための実装計画
+**位置づけ**: 本書は実装の「正」ではない。設計の正は FIXER.Medical.AgentCore リポジトリの `docs/dev-diary/naito/documents/manual-implementation-plan.md`（以下「本体計画書」）である。本書はその本体計画書のうち **GenU 側 CDK で実装すべきインフラ部分のみ** を、GenU の既存 CDK 構造に合わせて手順化したものである。両者が矛盾した場合は本体計画書を優先する。
+**重要な制約**: 本書は計画のみであり、CDK コード（`.ts`）の生成・既存ファイルの改修は含まない。実装は本体計画書のフェーズ（B1〜B10）順に、各フェーズ着手直前の残課題確定とユーザー確認（y/n）を経て行う。
+
+---
+
+## 0. 本書を書くにあたって確認した GenU 既存構造（事実）
+
+実装方針を GenU の既存パターンに揃えるため、以下を実コードで確認した（2026-05-29 時点）。
+
+| 確認対象 | パス | 要点 |
+|---|---|---|
+| エントリポイント | `packages/cdk/bin/generative-ai-use-cases.ts` | `getParams(app)` で全パラメータを得て `createStacks(app, params)` を呼ぶだけの薄い層 |
+| パラメータ定義 | `packages/cdk/lib/stack-input.ts` | zod スキーマ `baseStackInputSchema`。機能フラグは `xxxEnabled: z.boolean().default(false)` の形で定義（例：`ragKnowledgeBaseEnabled`・`agentBuilderEnabled`・`createGenericAgentCoreRuntime`） |
+| パラメータ解決 | `packages/cdk/parameter.ts` | CDK Context / `envs` から取得し `ProcessedStackInput` へ整形。`agentCoreRegion: params.agentCoreRegion || params.modelRegion` のような既定値補完を行う |
+| スタック配線 | `packages/cdk/lib/create-stacks.ts` | フラグが立つときだけ各スタックを `new` する分岐がある（例：`ragKnowledgeBaseEnabled && !ragKnowledgeBaseId ? new RagKnowledgeBaseStack(...) : null`、`createGenericAgentCoreRuntime || agentBuilderEnabled ? new AgentCoreStack(...) : null`）。本体スタックへ依存を `addDependency` で明示している |
+| AgentCore スタック | `packages/cdk/lib/agent-core-stack.ts` | `params` を受け、`GenericAgentCore` Construct を生成。Runtime ARN・ファイルバケット名を `CfnOutput`（`REMOTE_OUTPUT_KEYS`）で出力し、クロスリージョン参照（`cdk-remote-stack` の `RemoteOutputs`）で本体スタックへ渡す |
+| AgentCore Construct | `packages/cdk/lib/construct/generic-agent-core.ts` | `@aws-cdk/aws-bedrock-agentcore-alpha` の `Runtime` を使用。`AgentRuntimeArtifact.fromAsset(dockerPath)` で Docker イメージをアセット化。実行ロールへ `bedrock:InvokeModel` 等を付与し、`fileBucket.grantWrite(role)` でS3書き込みを許可。`environmentVariables` で `FILE_BUCKET` 等をコンテナへ注入 |
+| DynamoDB Construct | `packages/cdk/lib/construct/database.ts` | `ddb.Table`（`billingMode: PAY_PER_REQUEST`）。パーティションキー＋必要に応じソートキー・GSI。最小限の素直な定義 |
+| 削除ポリシー | `create-stacks.ts` の `DeletionPolicySetter` アスペクト | 本体スタックに `RemovalPolicy.DESTROY` を一括適用するアスペクトがある |
+
+> 注：本体計画書 第10章は改修対象3ファイルを `bin/generative-ai-use-cases.ts` / `lib/stack-input.ts` / `parameter.ts` と短縮表記しているが、GenU 実体での正確なパスはいずれも `packages/cdk/` 配下である。
+
+---
+
+## 1. 本書の対象範囲（GenU CDK 側で作るもの／作らないもの）
+
+### 1.1 GenU CDK 側で作るもの（本書の対象）
+
+本体計画書 第2.1章「構成要素7つ」のうち、**インフラ実体**は GenU 側 CDK で定義する。
+
+| # | 構成要素（本体計画書） | GenU CDK での実装 |
+|---|---|---|
+| 1 | API（API Gateway） | 新スタック内に REST API + Cognito オーサライザ |
+| 2 | マニュアル管理 Lambda | 新スタック内の関数（Node.js or Python） |
+| 3 | チャット中継 Lambda | 新スタック内の関数。AgentCore Runtime を呼ぶ |
+| 4 | 前処理 Lambda（Docker Image） | 新スタック内の Docker イメージ関数（poppler-utils 同梱） |
+| 6 | S3（ファイル保管庫） | 新スタック内のバケット |
+| 7 | DynamoDB（設定保管庫） | 新スタック内の1テーブル |
+
+加えて：
+- IAM ロール／ポリシー（最小権限。各 Lambda・AgentCore 実行ロール）
+- S3 → 前処理 Lambda の起動イベント配線
+- 機能フラグ `manualRagEnabled` の追加（zod スキーマ・既定値・分岐）
+- AgentCore Runtime（構成要素5）の **CDK 上の宣言と配線**（後述 1.3）
+
+### 1.2 GenU CDK 側で作らないもの（本書の対象外）
+
+- **AI 実行環境の実体**（`agent.py`・マニュアル参照ツール7種・システムプロンプト・Dockerfile・`deploy.py`）は、FIXER.Medical.AgentCore リポジトリの `agents/manual-agent`（仮称）側で実装する。本体計画書 第5章・第6章・フェーズ B7・B8 が該当。
+- **フロントエンド**（マニュアル参照モードのUI、管理者向け管理画面）は GenU の `packages/web` 側。本体計画書 第10章後段・フェーズ B3 が該当。本書はインフラに限定するため対象外（ただしフラグ連携の整合のみ 第6章で触れる）。
+- 前処理 Lambda・各 Lambda の**業務ロジック実装**は本書の対象外（本書は CDK によるリソース定義方針のみ）。
+
+### 1.3 AgentCore Runtime の扱い（要・設計判断＝残課題G に連動）
+
+本体計画書 第5.3章により「マニュアル参照ツールを AI 実行環境へどう供給するか（実装言語へ直接組み込むか、外部プロトコル経由か）」は残課題G として未確定。これにより **AgentCore Runtime を GenU CDK 側で `Runtime` Construct として宣言するか、それとも AgentCore 側リポジトリの `deploy.py`（既存 infection-chatbot-toc と同方式）でデプロイし、GenU CDK は ARN を参照するだけにするか** が決まる。
+
+- 既存 GenU の `GenericAgentCore` は前者（CDK の `Runtime` で宣言）。
+- 既存 FIXER.Medical.AgentCore の各エージェントは後者（`bedrock_agentcore` の `deploy.py` / CodeBuild）。
+
+**本書ではこの判断を確定しない。** B7 着手時に残課題G とあわせてユーザー確認する。本書の以降の記述は「どちらに転んでも成立する」よう、Runtime 本体の生成手段は両論併記とし、GenU CDK 側は最低限「Runtime ARN を環境変数としてチャット中継 Lambda へ渡す配線」を持つ前提で書く。
+
+---
+
+## 2. 新規スタック構成
+
+### 2.1 スタックの新設
+
+既存パターン（`RagKnowledgeBaseStack`・`AgentCoreStack` 等が `lib/*.ts` に1ファイル1スタック）に倣い、次を新設する。
+
+| 種別 | ファイル（案） | 内容 |
+|---|---|---|
+| スタック | `packages/cdk/lib/manual-rag-stack.ts` | `ManualRagStack`（仮称）。本機能のインフラを束ねる |
+| Construct 群 | `packages/cdk/lib/construct/manual-rag/` 配下 | リソースを責務単位の Construct に分割（下記 2.2） |
+
+> 命名は実装時に最終決定する（残課題ではなく実装細目）。本書では `ManualRag*` を仮の接頭辞として用いる。
+
+### 2.2 Construct 分割（案）
+
+責務ごとに Construct を分けて見通しを保つ（既存 `construct/` の粒度に合わせる）。
+
+| Construct（案） | 責務 | 主なリソース |
+|---|---|---|
+| `ManualStorage` | 保管庫 | S3 バケット1、DynamoDB テーブル1 |
+| `ManualPreprocess` | 前処理 | 前処理 Lambda（Docker Image）、S3→Lambda イベント、Textract 権限 |
+| `ManualAdminApi` | 管理API | マニュアル管理 Lambda、API Gateway リソース（管理者スコープ） |
+| `ManualChatRelay` | チャット中継 | チャット中継 Lambda、API Gateway リソース（利用者スコープ）、AgentCore 呼び出し権限 |
+| （`ManualRuntime`） | AI実行環境 | 残課題G の判断次第で AgentCore `Runtime` を宣言（1.3 参照） |
+
+### 2.3 スタックの配置リージョン
+
+本体計画書 残課題A の確定値（リージョン＝既存 infection-chatbot-toc と同一の `us-east-1`、モデル＝Sonnet 4.5 のクロスリージョン推論プロファイル `us.anthropic.claude-sonnet-4-5-20250929-v1:0`、Textract・Bedrock とも当該リージョンで利用可）に従う。
+
+- `create-stacks.ts` で `ManualRagStack` を `new` する際の `env.region` は `params.region`（GenU 本体と同一リージョン）を基本とする。
+- AgentCore Runtime を CDK で宣言する場合（残課題G）は、既存 `AgentCoreStack` と同様 `params.agentCoreRegion`（既定は `modelRegion`）を用いる。
+
+---
+
+## 3. 各リソースの CDK 定義方針
+
+### 3.1 S3（ファイル保管庫）
+
+本体計画書 第3.1章のキー構成（`{manual_id}/original.*`・`pages/page_0001.png|.md`・`toc.md|.json`・`page_map.json`）を保存するバケット。
+
+- セキュリティ：既存 `GenericAgentCore.createFileBucket()` に倣い `BlockPublicAccess.BLOCK_ALL` / `BucketEncryption.S3_MANAGED`。
+- ライフサイクル：`removalPolicy` は本機能のデータ性質（マニュアル原本＝再取得可だが運用上は保持したい）に応じて B1 着手時に確定（残課題候補：DESTROY か RETAIN か）。本体計画書には明記がないため**実装仕様として確定が必要**。
+- アップロード方式：本体計画書 第7章の「presigned URL でブラウザから直接 S3 へ」を実現するため、CORS 設定（許可オリジン＝GenU の CloudFront ドメイン）を付与する。許可オリジンの具体値は B2（管理API）着手時に確定。
+- イベント通知：原本保存（`{manual_id}/original.*` の PUT）を契機に前処理 Lambda を起動（3.3 と 3.5）。
+
+### 3.2 DynamoDB（設定保管庫・1テーブル）
+
+本体計画書 第3.2章の通り **1テーブル・属性9個**。既存 `Database` Construct（`PAY_PER_REQUEST`）に倣う。
+
+- パーティションキー：`manual_id`（文字列）。ソートキー：**なし**（1マニュアル＝1アイテム、キー検索のみ）。
+- GSI：本体計画書では一覧取得（`get_all_manuals`／管理一覧）が必要だが、件数は環境内マニュアル数（小規模想定）であり `Scan` で足りる可能性が高い。GSI を設けるか否かは B1 着手時に確定（残課題候補）。本体計画書はGSIに言及していないため、**既定はGSIなし**とし、必要性が出たフェーズで追加を判断する。
+- 属性9個（`title`・`description`・`status`・`error_detail`・`page_count`・`original_filename`・`created_at`・`updated_at`）はスキーマレスのため CDK では宣言不要（キーのみ宣言）。
+- 課金：`PAY_PER_REQUEST`。
+- `removalPolicy`：S3 と同様 B1 着手時に確定。
+
+### 3.3 前処理 Lambda（Docker Image 形式）
+
+本体計画書 第4章・第9章の通り、`poppler-utils`（`pdftoppm`）を同梱する Docker Image 関数。
+
+- 形式：`DockerImageFunction`（`lambda.DockerImageCode.fromImageAsset(...)`）。Dockerfile に `poppler-utils` を `apt-get install` で同梱。テキスト抽出は pypdf(BSD-3)・pdfplumber(MIT)、OCR は Amazon Textract（PyMuPDF は不使用）。
+- メモリ／タイムアウト：PDF のページ画像生成・OCR を伴うため大きめ。具体値は B4/B5 着手時に確定（残課題候補。本体計画書に数値指定なし）。
+- 権限（最小権限）：
+  - S3：当該バケットへの読み取り（原本）と書き込み（成果物）。
+  - DynamoDB：当該テーブルへの更新（`status`・`error_detail`・`page_count`）。
+  - Textract：`textract:DetectDocumentText` 等（閾値未満ページの OCR のみ。第4章ステップ3）。
+- 起動：S3 イベント（3.5）。
+
+### 3.4 マニュアル管理 Lambda／チャット中継 Lambda／API Gateway
+
+- **マニュアル管理 Lambda**（本体計画書 第7章）：アップロード（presigned URL 発行）・一覧・削除・再処理・説明文編集。S3 書き込み（原本／削除時のディレクトリ削除）と DynamoDB 読み書き権限。
+- **チャット中継 Lambda**（本体計画書 第6章）：DynamoDB から全マニュアルの `title`・`description` を読み、システムプロンプトへ併合のうえ AgentCore Runtime を呼び、ストリーミングで返す。DynamoDB 読み取り＋ `bedrock-agentcore:InvokeAgentRuntime`（呼び出し先 Runtime ARN へ限定）権限。
+- **API Gateway**：本体計画書 第8章の認可。Cognito オーサライザ。管理系操作（登録・削除・再処理・説明文編集）は管理者ロール、チャットは全利用者。管理者ロールの判定方法は**残課題B として 2026-06-01 に確定**：既存 `admin` グループを流用し、Cognito オーソライザで認証したうえで管理 Lambda 内で `cognito:groups` に `admin` を含むか検査する（本体計画書 第2.5章）。
+  - 既存 GenU の認可・Cognito 構成（`construct/auth.ts`・`construct/api.ts`）の流儀を踏襲する。`construct/admin-api.ts` は参考候補としていたが、B2 着手時の精査で**当該ファイルは GenU に存在しない**ことを確認した。`admin` グループも GenU の CDK では定義されておらず、User Pool 上に別経路で作成済みのものを参照する（`CfnUserPoolGroup` の新設は不要）。`cognito:groups` の利用は既存 `construct/rag.ts:215`（Kendra ACL）に前例がある。
+  - オーソライザに渡す UserPool の参照方法は第4章の生成順序（案A）を参照。
+
+### 3.5 S3 → 前処理 Lambda のイベント配線
+
+- 方式：S3 バケットのイベント通知（`s3.EventType.OBJECT_CREATED`、プレフィックス／サフィックスで `{manual_id}/original.*` を対象）で前処理 Lambda を起動。
+- 再処理（本体計画書 第7章・残課題C）：**2026-06-01 確定**。再処理は原本を再 PUT しないため S3 イベントは発火しない。よって管理 Lambda から前処理 Lambda を**非同期 invoke（Event）**する経路をとる。起動前のクリア順序は ①DynamoDB を `status=processing` に更新 → ②S3 の `{manual_id}/pages/` 配下・`toc.*`・`page_map.json` を削除 → ③前処理 Lambda を invoke（本体計画書 第2.5章・第7章）。前処理 Lambda の実体は B4 のため、B2 では invoke 先 ARN を環境変数の器として用意し、未配線でも synth が通る形にする。
+
+### 3.6 IAM（最小権限の原則）
+
+本体計画書 第2.2章の依存関係に厳密に従い、各ロールに必要最小限のみ付与する。
+
+| 主体 | 許可する操作（要点） |
+|---|---|
+| 前処理 Lambda | S3 当該バケット R/W、DynamoDB 当該テーブル更新、Textract OCR |
+| マニュアル管理 Lambda | S3 当該バケット R/W・削除、DynamoDB 当該テーブル R/W |
+| チャット中継 Lambda | DynamoDB 当該テーブル読み取り、AgentCore Runtime の Invoke |
+| AI 実行環境（AgentCore 実行ロール） | S3 当該バケット **読み取りのみ**、DynamoDB 当該テーブル **読み取りのみ**（本体計画書 第2.2章「書き込みは行わない」を厳守。既存 `generic-agent-core.ts` は `grantWrite` だが本機能は `grantRead` に絞る） |
+
+---
+
+## 4. 機能フラグ `manualRagEnabled` の連携
+
+本体計画書 第10章の通り、改修は既存3ファイルのみ。**フラグ false で従来挙動を完全維持**する。
+
+| ファイル（GenU 実体パス） | 変更内容 | 既存パターンの参考 |
+|---|---|---|
+| `packages/cdk/lib/stack-input.ts` | `baseStackInputSchema` に `manualRagEnabled: z.boolean().default(false)` を追加 | 既存 `ragKnowledgeBaseEnabled` 等と同形 |
+| `packages/cdk/parameter.ts` | 既定値 `false`（zod の default で吸収されるため、明示追記は任意。`envs` で環境別に上書き可能にする方針のみ確認） | 既存フラグと同様、CDK Context / `envs` 経由 |
+| `packages/cdk/bin/generative-ai-use-cases.ts` | 直接の分岐は不要（薄い層のため）。実際の分岐は `create-stacks.ts` に置く | 既存も `createStacks` 側で分岐 |
+| `packages/cdk/lib/create-stacks.ts`（※本体計画書の3ファイルには明記されないが実務上ここに分岐が必要） | `params.manualRagEnabled ? new ManualRagStack(...) : null` を追加し、本体スタックへ必要な値（API エンドポイント等）を受け渡し、`addDependency` を張る | 既存 `AgentCoreStack`・`RagKnowledgeBaseStack` の分岐と同形 |
+
+> 注意：本体計画書 第10章は改修対象を3ファイルとするが、GenU の実構造ではスタックを実際に `new` する箇所は `create-stacks.ts` である。3ファイル（zod スキーマ／既定値／エントリ）に加え `create-stacks.ts` への分岐追加が技術的に必須になる。この差異は B1 着手時にユーザーへ報告し、本体計画書 第10章へ追記する（本体計画書 14.2 の手順）。
+
+### 4.1 ManualRagStack の生成順序（案A・2026-06-01 確定）
+
+B1 では `ManualRagStack` を `GenerativeAiUseCasesStack`（UserPool を所有）より**前**で生成していた。B2 の管理 API には Cognito オーソライザ（`CognitoUserPoolsAuthorizer`）のため UserPool 参照が必要だが、生成順序が前のままでは `generativeAiUseCasesStack.userPool` を渡せない。
+
+そこで **案A** を採用する（2026-06-01 ユーザー確認）：
+
+- `create-stacks.ts` の `ManualRagStack` 生成を `generativeAiUseCasesStack` 生成より**後ろへ移動**し、`userPool` / `userPoolClient` を props で受け渡す。これは既存 `DashboardStack` が `generativeAiUseCasesStack.userPool` を受け取る確立パターンと同形。
+- `generativeAiUseCasesStack.addDependency(manualRagStack)` ではなく、参照方向に合わせ `ManualRagStack` 側が UserPool に依存するため、生成順序の後置で依存が成立する（必要に応じて明示 `addDependency` を付与）。
+- 移動は追加した if ブロックの位置変更のみで、フラグ false なら従来どおり非生成＝既存無影響を維持する。
+
+---
+
+## 5. AgentCore Runtime との接続点
+
+- チャット中継 Lambda は AgentCore Runtime を呼ぶため、その **Runtime ARN** を環境変数で受け取る。
+- ARN の供給元は残課題G の判断で分岐：
+  - **(a) GenU CDK で Runtime を宣言する場合**：既存 `AgentCoreStack` と同様、`Runtime` の `agentRuntimeArn` を取得して同一スタック内でチャット中継 Lambda の環境変数へ渡す（クロスリージョンなら `CfnOutput` + `RemoteOutputs`）。
+  - **(b) AgentCore 側リポジトリの `deploy.py` でデプロイする場合**：デプロイ済み Runtime の ARN を CDK パラメータ（`stack-input.ts` に `manualAgentRuntimeArn: z.string().nullish()` 等）として受け取り、環境変数へ渡す。既存 `agentCoreExternalRuntimes` パラメータの考え方が参考になる。
+- 本書はどちらかに確定しない（1.3）。B7 着手時に確定し、本体計画書 第5.3章・本書 第2.2/5章へ追記する。
+
+---
+
+## 6. フェーズ対応（本体計画書 B1〜B10 のうち GenU CDK 側の作業）
+
+| フェーズ | GenU CDK 側で行う作業 | 残課題（本体計画書 14.1） |
+|---|---|---|
+| B1 | `ManualRagStack` 骨組み、S3、DynamoDB（1テーブル）、IAM の土台、`manualRagEnabled` フラグ追加、`create-stacks.ts` 分岐 | 残課題A（確定済）＋ S3/DDB の removalPolicy・GSI 要否（本書 3.1/3.2） |
+| B2 | 管理 API（API Gateway + マニュアル管理 Lambda）、presigned URL、CORS、再処理時のクリア順序 | 残課題B（管理者ロール判定）・C（URL発行方式・クリア順序） |
+| B3 | （フロント。CDK 対象外。フラグ連携の整合のみ確認） | なし |
+| B4 | 前処理 Lambda（Docker Image・poppler 同梱）の関数定義、S3 イベント配線、メモリ/タイムアウト確定 | 残課題D（TXT/MD のページ分割値） |
+| B5 | （前処理 PDF 対応は Lambda 内ロジック。CDK 側は B4 で定義済の関数を使用） | 残課題E（page_map 生成方法） |
+| B6 | Textract 権限の付与（B4 の IAM に含めるか、B6 で追加か） | 残課題F（OCR 閾値） |
+| B7 | AgentCore Runtime の宣言／ARN 受け渡し配線（残課題G 次第。本書 1.3/5） | 残課題G（ツール供給方式） |
+| B8 | （ツール実装は AgentCore 側リポジトリ。CDK 対象外） | 残課題G（B7 と共通） |
+| B9 | チャット中継 Lambda の定義、AgentCore Invoke 権限、ストリーミング配線 | なし |
+| B10 | 全体動作確認・権限境界試験・削除整合試験（CDK のデプロイ確認を含む） | なし |
+
+---
+
+## 7. 既存への非影響の担保
+
+- `manualRagEnabled` が `false`（既定）のとき、`create-stacks.ts` は `ManualRagStack` を生成せず、本体スタックにも一切の参照を加えない。→ **従来挙動を完全維持**。
+- 既存 `agentBuilder` 関連（`construct/agent-builder.ts`・`construct/generic-agent-core.ts`）、既存 `AgentCoreStack`、既存 RAG 系（`rag-knowledge-base-stack.ts`・`construct/rag*.ts`）には変更を加えない。新規ファイル追加と、既存4ファイル（zod スキーマ／既定値／エントリ／`create-stacks.ts` 分岐）への**追加のみ**。
+- FIXER.Medical.AgentCore リポジトリ側の既存エージェント（`infection-chatbot-toc` 等）には一切変更を加えない。
+
+---
+
+## 8. 実装仕様の確定状況
+
+設計方針は確定済み。以下は「方式の範囲内で値・手段を1つ選ぶ」レベルの実装仕様。B1 着手時（2026-05-29）にユーザー確認のうえ確定した。
+
+| # | 項目 | 確定値（2026-05-29） |
+|---|---|---|
+| 1 | 新スタック名・Construct 名 | 仮称のまま確定：スタック `ManualRagStack`、Construct は `construct/manual-rag/` 配下（`ManualStorage` 等） |
+| 2 | S3・DynamoDB の `removalPolicy` | **`RETAIN`**（マニュアル原本・メタ情報はユーザー資産。誤削除回避を優先。`autoDeleteObjects` は付けない） |
+| 3 | DynamoDB の GSI 要否 | **なし**（一覧取得は `Scan`。環境内マニュアルは小規模想定） |
+| 4 | 本体計画書 第10章へ `create-stacks.ts` を加える追記 | **追記する**（本体計画書 第10章を更新済み） |
+| 5 | AgentCore Runtime：CDK 宣言（a）か外部 ARN 参照（b）か | **B7 着手時に残課題G とあわせて確定**（B1 では確定不要。ARN を環境変数で受け取る配線のみ前提とする） |
+
+B2 着手時（2026-06-01）に次を確定した。
+
+| # | 項目 | 確定値（2026-06-01） |
+|---|---|---|
+| 6 | 管理者ロール判定（残課題B） | 既存 `admin` グループを流用。Cognito オーソライザで認証 + 管理 Lambda 内で `cognito:groups` に `admin` を含むか検査。`CfnUserPoolGroup` の新設なし、`auth.ts` 非改変 |
+| 7 | アップロード URL（残課題C） | presigned PUT URL、有効期限 **15 分**、許可形式 PDF/TXT/MD のみ、キー `{manual_id}/original.{ext}` |
+| 8 | 再処理の起動経路・クリア順序（残課題C） | 管理 Lambda から前処理 Lambda を非同期 invoke。①status=processing → ②`pages/`・`toc.*`・`page_map.json` 削除 → ③invoke。B2 では invoke 先 ARN は環境変数の器のみ（実体は B4） |
+| 9 | 管理 Lambda 実装言語・配置 | Node.js/TypeScript、ハンドラは `packages/cdk/lambda/manual/` 配下に新規。`NodejsFunction` で定義（既存 GenU 慣習） |
+| 10 | API Gateway | 新スタック内に新規 `RestApi` を作成（既存 `construct/api.ts` は非改変）。Cognito オーソライザは既存 UserPool を参照 |
+| 11 | Construct 分割 | `construct/manual-rag/admin-api.ts` に `ManualAdminApi`（管理 Lambda 5種 + REST API）を新設 |
+| 12 | ManualRagStack 生成順序 | 案A：`generativeAiUseCasesStack` の後ろへ移動し `userPool`/`userPoolClient` を props 受け渡し（第4.1章） |
+
+---
+
+## 9. 参照
+
+- 設計の正：FIXER.Medical.AgentCore `docs/dev-diary/naito/documents/manual-implementation-plan.md`（全14章）
+- レビュー用サマリ：同 `manual.md`
+- 実装スタイル参考（変更しない）：FIXER.Medical.AgentCore `agents/infection-chatbot-toc`（Strands Agent + FastAPI + Docker、`deploy.py`、`.bedrock_agentcore.yaml`）
+- GenU CDK 参考（変更しない）：`packages/cdk/lib/construct/{generic-agent-core,database,auth,api,rag}.ts`、`packages/cdk/lib/{agent-core-stack,create-stacks,stack-input}.ts`、`packages/cdk/lambda/getFileUploadSignedUrl.ts`、`packages/cdk/parameter.ts`（※当初参照していた `construct/admin-api.ts` は GenU に存在しないことを B2 で確認）

--- a/docs/naito/documents/manual-cdk-deploy-plan.md
+++ b/docs/naito/documents/manual-cdk-deploy-plan.md
@@ -62,6 +62,8 @@
 
 **本書ではこの判断を確定しない。** B7 着手時に残課題G とあわせてユーザー確認する。本書の以降の記述は「どちらに転んでも成立する」よう、Runtime 本体の生成手段は両論併記とし、GenU CDK 側は最低限「Runtime ARN を環境変数としてチャット中継 Lambda へ渡す配線」を持つ前提で書く。
 
+**残課題G 確定（2026-06-01・B7 着手時）**：上記2択を**案b（外部 ARN 参照）**で確定する。AgentCore Runtime は AgentCore 側リポジトリ `agents/manual-agent/` の `deploy.py`（既存 infection-chatbot-toc と同方式）でデプロイし、GenU CDK は `Runtime` Construct を宣言しない。ツール7種は実装言語（Python）へ Strands `@tool` で直接組み込む（G-1）。GenU CDK 側は、デプロイ済み Runtime の ARN を CDK パラメータ（`stack-input.ts` に `manualAgentRuntimeArn` 等。具体名は B9 で確定）で受け取り、チャット中継 Lambda（B9）の環境変数へ渡すだけにする。既存 `agentCoreExternalRuntimes` の考え方に整合。本書 第5章もこの確定に従う。
+
 ---
 
 ## 2. 新規スタック構成
@@ -276,6 +278,15 @@ B6 着手時（2026-06-01）に次を確定した（スキャン／画像のみ�
 | 31 | OCR 方式（F-4） | Amazon Textract **`DetectDocumentText`（同期）**。入力は S3 保存済みの `{manual_id}/pages/page_NNNN.png` を **S3Object 参照**で渡す。**PDF のみ**対象（TXT/MD は対象外）、リージョン `us-east-1`。新規 Python ライブラリ追加なし（boto3 同梱） |
 | 32 | 失敗時の扱い（F-5） | 1ページの OCR 失敗はログを残して抽出済みテキストのまま継続し、マニュアル全体を `failed` にしない |
 | 33 | Textract IAM（F-6） | 前処理 Lambda に **`textract:DetectDocumentText`** を追加（`AnalyzeDocument` は付与しない）。S3Object 参照のための当該バケット read は既存 grant で充足 |
+
+B7 着手時（2026-06-01）に次を確定した（AgentCore Runtime コンテナ）。**実体は AgentCore 側リポジトリ `agents/manual-agent/`** にあり、GenU CDK 側の作業は B9（中継 Lambda）まで発生しない。本表は接続点の確定事項を記録する。
+
+| # | 項目 | 確定値（2026-06-01） |
+|---|---|---|
+| 34 | 残課題G（ツール供給方式） | G-1=実装言語（Python）へ **Strands `@tool` で直接組み込み**（MCP 等の外部プロトコルは不採用）。G-2=Runtime は `agents/manual-agent/deploy.py` でデプロイ（**案b**）、GenU CDK は ARN を参照するのみ（`Runtime` Construct 宣言＝案a は不採用） |
+| 35 | 説明文の動的併合 | 中継 Lambda（B9）が DynamoDB から `status=completed` の全マニュアルの `title`/`description` を取得し、質問とあわせてリクエスト payload で Runtime へ渡す。Runtime は固定システムプロンプトへ説明文を併合し**リクエストごとに**プロンプトを組み立てる。AI 実行環境は DynamoDB への直接アクセス権限を持たない（説明文は payload 受領のみ） |
+| 36 | Runtime ARN の GenU への供給 | GenU CDK は CDK パラメータ（`stack-input.ts` の `manualAgentRuntimeArn` 等、具体名は B9 で確定）でデプロイ済み ARN を受け取り、中継 Lambda の環境変数へ渡す。既存 `agentCoreExternalRuntimes` の考え方に整合 |
+| 37 | S3／DynamoDB のキー規約（AI 実行環境が読む対象） | manual-rag の前処理出力に整合：`{manual_id}/pages/page_NNNN.png`・`.md`／`{manual_id}/toc.md`・`toc.json`／`{manual_id}/page_map.json`（既存 infection の `documents/` 接頭辞・`catalog.json` 方式は使わない）。ツールのスコープ確認は DynamoDB を参照（B8） |
 
 ---
 

--- a/docs/naito/documents/manual-cdk-deploy-plan.md
+++ b/docs/naito/documents/manual-cdk-deploy-plan.md
@@ -241,6 +241,18 @@ B2 着手時（2026-06-01）に次を確定した。
 | 11 | Construct 分割 | `construct/manual-rag/admin-api.ts` に `ManualAdminApi`（管理 Lambda 5種 + REST API）を新設 |
 | 12 | ManualRagStack 生成順序 | 案A：`generativeAiUseCasesStack` の後ろへ移動し `userPool`/`userPoolClient` を props 受け渡し（第4.1章） |
 
+B4 着手時（2026-06-01）に次を確定した（前処理 Lambda 骨組み・TXT/MD のページ分割）。
+
+| # | 項目 | 確定値（2026-06-01） |
+|---|---|---|
+| 13 | 残課題D（TXT 上限文字数・Markdown 例外） | D-1=**2,000 文字**／D-2=見出し無し・最初の見出し前は固定文字数分割、見出し分割後の上限超過は固定文字数で再分割／D-3=TXT・MD の `page_map.json` は印刷番号「なし(null)」で生成・`toc.*` 非生成（本体計画書 第4章ステップ3） |
+| 14 | 前処理 Lambda 実装言語・配置 | **Python 3.13 / Docker Image**。ベースは **AWS 公式 Lambda イメージ `public.ecr.aws/lambda/python:3.13`**（Lambda Runtime Interface 同梱）。前処理はイベント駆動（S3 イベント／直接 invoke）であり HTTP 常駐ではないため、`mcp-api` の Lambda Web Adapter＋`uv run` 方式は採らず、`CMD ["app.handler"]` のイベントハンドラ構成とする。依存は **pip**（B4 は標準ライブラリ＋同梱 boto3。pypdf 等は B5 で追記）、`poppler-utils` は **dnf** で同梱（別プロセス呼び出し＝GPL 非伝播は維持）。配置 `packages/cdk/lambda-python/manual-preprocess/`、Construct は `construct/manual-rag/preprocess.ts` |
+| 15 | コンテナ実行条件 | **x86_64 / memorySize 2048MB / timeout 15分**（イベント駆動 Lambda。B5 の画像化を見越した余裕値）。ephemeral storage は PDF 画像化を行う B5 で見直す |
+| 16 | 起動経路 | 1ハンドラで2系統を受ける：(あ) S3 イベント（通常アップロード）／(い) 直接 invoke `{manual_id}`（再処理。既存 `reprocessManual.ts` が送る形式） |
+| 17 | S3 通知フィルタ（自己ループ防止） | suffix フィルタで **`original.txt` / `original.md` のみ**発火（B4 範囲）。`pages/page_0001.md` 等の派生物は後方一致せず再発火しない。ハンドラ側でも `original.` 以外を無視（多重防御）。`original.pdf` の配線は B5 で追加 |
+| 18 | `PREPROCESS_FUNCTION_ARN` 配線 | `ManualAdminApi` から再処理 Lambda を公開し、スタックで前処理 Lambda の ARN を env 注入＋`grantInvoke`（B2 のプレースホルダを実体化） |
+| 19 | CfnOutput（フロント繋ぎ込み用） | `ManualRagStack` に **管理 API URL／バケット名／テーブル名** を出力 |
+
 ---
 
 ## 9. 参照

--- a/docs/naito/documents/manual-cdk-deploy-plan.md
+++ b/docs/naito/documents/manual-cdk-deploy-plan.md
@@ -201,7 +201,7 @@ B1 では `ManualRagStack` を `GenerativeAiUseCasesStack`（UserPool を所有�
 | B3 | （フロント。CDK 対象外。フラグ連携の整合のみ確認） | なし |
 | B4 | 前処理 Lambda（Docker Image・poppler 同梱）の関数定義、S3 イベント配線、メモリ/タイムアウト確定 | 残課題D（TXT/MD のページ分割値） |
 | B5 | （前処理 PDF 対応は Lambda 内ロジック。CDK 側は B4 で定義済の関数を使用） | 残課題E（page_map 生成方法） |
-| B6 | Textract 権限の付与（B4 の IAM に含めるか、B6 で追加か） | 残課題F（OCR 閾値） |
+| B6 | Textract 権限の付与（**B6 で追加**＝`textract:DetectDocumentText`）。OCR 振り分けは Lambda 内ロジック | 残課題F 確定済み（OCR 閾値=500・空白除外・無条件置換） |
 | B7 | AgentCore Runtime の宣言／ARN 受け渡し配線（残課題G 次第。本書 1.3/5） | 残課題G（ツール供給方式） |
 | B8 | （ツール実装は AgentCore 側リポジトリ。CDK 対象外） | 残課題G（B7 と共通） |
 | B9 | チャット中継 Lambda の定義、AgentCore Invoke 権限、ストリーミング配線 | なし |
@@ -266,6 +266,16 @@ B5 着手時（2026-06-01）に次を確定した（前処理 Lambda の PDF 対
 | 26 | S3 通知フィルタ追加 | `original.pdf` の suffix 通知を**追加**配線（B4 で保留した分）。これで PDF アップロードが前処理を起動 |
 | 27 | 依存追加 | `requirements.txt` に **pypdf・pdfplumber** を追加 |
 | 28 | Textract IAM | **B5 では付与しない**。OCR 実装は B6 のため、`textract:*` 権限も B6 で追加（最小権限） |
+
+B6 着手時（2026-06-01）に次を確定した（スキャン／画像のみページの OCR 対応）。CDK 側の変更は前処理 Lambda への Textract 権限追加に限られ、振り分けロジックは Lambda 内に実装する。
+
+| # | 項目 | 確定値（2026-06-01） |
+|---|---|---|
+| 29 | 残課題F（OCR 閾値・数え方） | F-1=**500 文字**／F-2=**空白・改行を除いた文字数**（`len(re.sub(r"\s", "", text))`）。改行だけ・スペースだけのページを「テキストあり」と誤判定しないため（本体計画書 第4章ステップ3） |
+| 30 | 振り分け処理（F-3） | 閾値未満のページは OCR を実行し、結果で当該ページのテキストを**無条件に置換**（案③-b）。born-digital の正テキストが OCR 結果で上書きされうる点は了承のうえ確定 |
+| 31 | OCR 方式（F-4） | Amazon Textract **`DetectDocumentText`（同期）**。入力は S3 保存済みの `{manual_id}/pages/page_NNNN.png` を **S3Object 参照**で渡す。**PDF のみ**対象（TXT/MD は対象外）、リージョン `us-east-1`。新規 Python ライブラリ追加なし（boto3 同梱） |
+| 32 | 失敗時の扱い（F-5） | 1ページの OCR 失敗はログを残して抽出済みテキストのまま継続し、マニュアル全体を `failed` にしない |
+| 33 | Textract IAM（F-6） | 前処理 Lambda に **`textract:DetectDocumentText`** を追加（`AnalyzeDocument` は付与しない）。S3Object 参照のための当該バケット read は既存 grant で充足 |
 
 ---
 

--- a/docs/naito/documents/manual-cdk-deploy-plan.md
+++ b/docs/naito/documents/manual-cdk-deploy-plan.md
@@ -253,6 +253,20 @@ B4 着手時（2026-06-01）に次を確定した（前処理 Lambda 骨組み�
 | 18 | `PREPROCESS_FUNCTION_ARN` 配線 | `ManualAdminApi` から再処理 Lambda を公開し、スタックで前処理 Lambda の ARN を env 注入＋`grantInvoke`（B2 のプレースホルダを実体化） |
 | 19 | CfnOutput（フロント繋ぎ込み用） | `ManualRagStack` に **管理 API URL／バケット名／テーブル名** を出力 |
 
+B5 着手時（2026-06-01）に次を確定した（前処理 Lambda の PDF 対応）。CDK 側はほぼ B4 で定義済みの関数を流用し、変更は依存追加・S3 トリガ追加に限られる。
+
+| # | 項目 | 確定値（2026-06-01） |
+|---|---|---|
+| 20 | 残課題E（`page_map.json` 生成方法） | **案ア＝フッター読み取り方式**。pdfplumber で各物理ページ下部のテキストから印刷番号（アラビア数字・ローマ数字）を読み、読めなければ `null`。PDF のみ適用、TXT・MD は全ページ `null`（本体計画書 第4章ステップ4）。案イ（一定ずれ量検出）は途中リセット等に弱く不採用 |
+| 21 | ページ画像生成 | `pdftoppm -png -r 150`（**150 DPI / PNG**）で `pages/page_0001.png` 連番。/tmp へ生成→S3 アップロード→/tmp から削除し ephemeral storage を逐次解放 |
+| 22 | テキスト抽出ライブラリ | **pypdf**（各ページ本文抽出＋しおり/outline 取得）、**pdfplumber**（フッター数字の位置読み取り＝案ア）。PyMuPDF は不使用（本体計画書 第9章） |
+| 23 | OCR 振り分け | **B5 では行わない**。全ページを画像化し、抽出テキストで `page_0001.md` を書く。テキストが取れない／極小ページは短い・空の `.md` のまま。閾値判定と Textract 呼び出しは **B6**（残課題F） |
+| 24 | toc 生成 | pypdf でしおり（outline）があれば `toc.json`/`toc.md` 生成、無ければ生成しない（本体計画書 第4章ステップ5） |
+| 25 | コンテナ実行条件（B5 据え置き） | **memory 2048MB / ephemeral 2048MB / timeout 15分** を維持。ページ単位で画像を逐次 S3 アップロード後に /tmp 削除するため据え置きで足りる |
+| 26 | S3 通知フィルタ追加 | `original.pdf` の suffix 通知を**追加**配線（B4 で保留した分）。これで PDF アップロードが前処理を起動 |
+| 27 | 依存追加 | `requirements.txt` に **pypdf・pdfplumber** を追加 |
+| 28 | Textract IAM | **B5 では付与しない**。OCR 実装は B6 のため、`textract:*` 権限も B6 で追加（最小権限） |
+
 ---
 
 ## 9. 参照

--- a/packages/cdk/lambda-python/manual-preprocess/.dockerignore
+++ b/packages/cdk/lambda-python/manual-preprocess/.dockerignore
@@ -1,0 +1,3 @@
+**/__pycache__
+**/*.pyc
+.pytest_cache

--- a/packages/cdk/lambda-python/manual-preprocess/Dockerfile
+++ b/packages/cdk/lambda-python/manual-preprocess/Dockerfile
@@ -1,0 +1,16 @@
+FROM public.ecr.aws/lambda/python:3.13
+
+# poppler-utils provides pdftoppm, used in phase B5 to rasterize PDF pages.
+# It is invoked as a separate process (not linked), so its GPL license does not
+# propagate to this function's code (design doc section 9). Installed here so the
+# image is ready for B5; unused in B4.
+RUN dnf install -y poppler-utils && dnf clean all
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt -t "${LAMBDA_TASK_ROOT}"
+
+COPY app.py ./
+COPY src ./src
+
+# Event-driven handler (S3 event / direct invoke). Not an HTTP server.
+CMD ["app.handler"]

--- a/packages/cdk/lambda-python/manual-preprocess/app.py
+++ b/packages/cdk/lambda-python/manual-preprocess/app.py
@@ -12,9 +12,14 @@ PDF, phase B5 (src/pdf.py):
 - Builds page_map.json by reading the printed number from each page footer
   (pdfplumber; null where unreadable). Generates toc.* from PDF bookmarks if present.
 
+OCR, phase B6 (src/ocr.py):
+- PDF pages whose extractable text has fewer than OCR_TEXT_THRESHOLD visible
+  (non-whitespace) characters are read from their PNG via Amazon Textract
+  (DetectDocumentText) and the result replaces the extracted text. A single
+  page's OCR failure is logged and skipped without failing the whole manual.
+
 In all cases DynamoDB is updated: page_count and status (completed / failed +
-error_detail). OCR for pages with little/no extractable text (Amazon Textract) is
-added in phase B6; in B5 such pages keep a short/empty page text.
+error_detail).
 
 Two entry points, handled by a single handler:
   (a) S3 ObjectCreated event for {manual_id}/original.txt|md|pdf (normal upload)
@@ -32,7 +37,7 @@ from typing import List, Optional
 
 import boto3
 
-from src import pdf
+from src import ocr, pdf
 from src.splitter import split_pages
 
 s3 = boto3.client("s3")
@@ -40,6 +45,16 @@ ddb = boto3.resource("dynamodb")
 
 BUCKET_NAME = os.environ.get("BUCKET_NAME", "")
 TABLE_NAME = os.environ.get("TABLE_NAME", "")
+
+# OCR routing threshold (residual task F). A PDF page whose extractable text has
+# fewer than this many visible (non-whitespace) characters is sent to Amazon
+# Textract and its result replaces the extracted text unconditionally (plan B-b).
+OCR_TEXT_THRESHOLD = 500
+
+
+def _visible_len(text: str) -> int:
+    """Character count excluding all whitespace (residual task F-2)."""
+    return len(re.sub(r"\s", "", text))
 
 # Text-origin formats (B4).
 SUPPORTED_TEXT_EXT = {"txt", "md"}
@@ -202,6 +217,19 @@ def _process_pdf(manual_id: str, key: str) -> None:
                 ExtraArgs={"ContentType": "image/png"},
             )
             os.remove(png_path)
+
+        # OCR routing (phase B6): pages with little/no extractable text are read
+        # from their PNG via Amazon Textract and the result replaces the text
+        # unconditionally (residual task F = plan B-b). A single page's OCR
+        # failure is logged and skipped; it does not fail the whole manual.
+        for index, text in enumerate(page_texts):
+            if _visible_len(text) >= OCR_TEXT_THRESHOLD:
+                continue
+            page_key = f"{manual_id}/pages/page_{index + 1:04d}.png"
+            try:
+                page_texts[index] = ocr.detect_document_text(BUCKET_NAME, page_key)
+            except Exception as e:  # noqa: BLE001 - one page must not abort all
+                print(f"OCR failed for {manual_id} page {index + 1}: {e}")
 
         _write_pages(manual_id, page_texts)
 

--- a/packages/cdk/lambda-python/manual-preprocess/app.py
+++ b/packages/cdk/lambda-python/manual-preprocess/app.py
@@ -1,31 +1,38 @@
-"""Preprocessing Lambda for the Manual RAG feature (phase B4).
+"""Preprocessing Lambda for the Manual RAG feature (phases B4/B5).
 
-Scope of B4: TXT / Markdown only.
+Text-origin formats (TXT / Markdown), phase B4:
 - Splits the original into pages (src/splitter.py) and stores them as
   {manual_id}/pages/page_0001.md ... (no page images for text-origin manuals).
 - Generates {manual_id}/page_map.json with printed page number = null
   (text-origin manuals have no printed page numbers). toc.* is not generated.
-- Updates DynamoDB: page_count and status (completed / failed + error_detail).
 
-PDF support (page images, pypdf/pdfplumber extraction, page_map offset detection,
-toc from bookmarks) and OCR are added in later phases (B5 / B6). PDFs are not wired
-to the S3 trigger in B4; if a PDF reaches this handler (e.g. via reprocess) it is
-marked failed with an explanatory error_detail.
+PDF, phase B5 (src/pdf.py):
+- Rasterizes each physical page to {manual_id}/pages/page_0001.png with pdftoppm.
+- Extracts per-page text (pypdf) into page_0001.md ...
+- Builds page_map.json by reading the printed number from each page footer
+  (pdfplumber; null where unreadable). Generates toc.* from PDF bookmarks if present.
+
+In all cases DynamoDB is updated: page_count and status (completed / failed +
+error_detail). OCR for pages with little/no extractable text (Amazon Textract) is
+added in phase B6; in B5 such pages keep a short/empty page text.
 
 Two entry points, handled by a single handler:
-  (a) S3 ObjectCreated event for {manual_id}/original.txt|md (normal upload)
+  (a) S3 ObjectCreated event for {manual_id}/original.txt|md|pdf (normal upload)
   (b) Direct invoke with {"manual_id": "..."} (reprocess; see reprocessManual.ts)
 """
 
 import json
 import os
 import re
+import shutil
+import tempfile
 import urllib.parse
 from datetime import datetime, timezone
 from typing import List, Optional
 
 import boto3
 
+from src import pdf
 from src.splitter import split_pages
 
 s3 = boto3.client("s3")
@@ -34,10 +41,8 @@ ddb = boto3.resource("dynamodb")
 BUCKET_NAME = os.environ.get("BUCKET_NAME", "")
 TABLE_NAME = os.environ.get("TABLE_NAME", "")
 
-# B4 handles text-origin formats only.
+# Text-origin formats (B4).
 SUPPORTED_TEXT_EXT = {"txt", "md"}
-# Recognized overall, but processed in a later phase.
-DEFERRED_EXT = {"pdf"}
 
 # An original object key looks like "{manual_id}/original.{ext}".
 _ORIGINAL_KEY_RE = re.compile(r"^(?P<manual_id>[^/]+)/original\.(?P<ext>[A-Za-z0-9]+)$")
@@ -105,6 +110,8 @@ def _mime_conflicts(content_type: str, ext: str) -> bool:
     ct = content_type.split(";")[0].strip().lower()
     if ext in SUPPORTED_TEXT_EXT:
         return ct.startswith("image/") or ct == "application/pdf"
+    if ext == "pdf":
+        return ct.startswith("text/") or ct.startswith("image/")
     return False
 
 
@@ -119,11 +126,16 @@ def _write_pages(manual_id: str, pages: List[str]) -> None:
         )
 
 
-def _write_page_map(manual_id: str, page_count: int) -> None:
-    # Text-origin manuals have no printed page numbers: printed = null.
+def _write_page_map(manual_id: str, printed: List[Optional[str]]) -> None:
+    """Write page_map.json from a per-physical-page list of printed numbers.
+
+    Text-origin manuals pass all-None (no printed numbers). PDFs pass the values
+    read from page footers (None where unreadable).
+    """
     page_map = {
         "pages": [
-            {"physical": n, "printed": None} for n in range(1, page_count + 1)
+            {"physical": n, "printed": printed[n - 1]}
+            for n in range(1, len(printed) + 1)
         ]
     }
     s3.put_object(
@@ -132,6 +144,84 @@ def _write_page_map(manual_id: str, page_count: int) -> None:
         Body=json.dumps(page_map, ensure_ascii=False).encode("utf-8"),
         ContentType="application/json",
     )
+
+
+def _write_toc(manual_id: str, toc_json: dict, toc_md: str) -> None:
+    s3.put_object(
+        Bucket=BUCKET_NAME,
+        Key=f"{manual_id}/toc.json",
+        Body=json.dumps(toc_json, ensure_ascii=False).encode("utf-8"),
+        ContentType="application/json",
+    )
+    s3.put_object(
+        Bucket=BUCKET_NAME,
+        Key=f"{manual_id}/toc.md",
+        Body=toc_md.encode("utf-8"),
+        ContentType="text/markdown; charset=utf-8",
+    )
+
+
+def _process_pdf(manual_id: str, key: str) -> None:
+    """Process a PDF original (phase B5): page images, page texts, page_map, toc.
+
+    Pages are rasterized one at a time and uploaded, then the local PNG is removed,
+    so ephemeral /tmp usage stays bounded regardless of page count.
+    """
+    head = s3.head_object(Bucket=BUCKET_NAME, Key=key)
+    content_type = head.get("ContentType", "")
+    if _mime_conflicts(content_type, "pdf"):
+        _update_status(
+            manual_id,
+            "failed",
+            error_detail=f"Extension/MIME mismatch: .pdf vs {content_type}",
+        )
+        return
+
+    workdir = tempfile.mkdtemp(prefix="manual_preprocess_")
+    local_pdf = os.path.join(workdir, "original.pdf")
+    try:
+        s3.download_file(BUCKET_NAME, key, local_pdf)
+
+        page_texts = pdf.extract_page_texts(local_pdf)
+        page_count = len(page_texts)
+        if page_count == 0:
+            _update_status(
+                manual_id,
+                "failed",
+                error_detail="PDF has no pages or could not be read",
+            )
+            return
+
+        # Rasterize page-by-page: generate -> upload -> delete to free /tmp.
+        for page_num in range(1, page_count + 1):
+            png_path = pdf.rasterize_page(local_pdf, page_num, workdir)
+            s3.upload_file(
+                png_path,
+                BUCKET_NAME,
+                f"{manual_id}/pages/page_{page_num:04d}.png",
+                ExtraArgs={"ContentType": "image/png"},
+            )
+            os.remove(png_path)
+
+        _write_pages(manual_id, page_texts)
+
+        # Residual task E = plan A: printed numbers read from page footers.
+        printed = pdf.build_page_map(local_pdf, page_count)
+        _write_page_map(manual_id, printed)
+
+        # toc.* only when the PDF carries bookmarks (design doc step 5).
+        entries = pdf.extract_toc(local_pdf)
+        if entries:
+            toc_json, toc_md = pdf.build_toc_documents(entries, printed, page_count)
+            _write_toc(manual_id, toc_json, toc_md)
+
+        _update_status(manual_id, "completed", page_count=page_count)
+        print(
+            f"Processed PDF manual {manual_id}: {page_count} page(s), "
+            f"toc={'yes' if entries else 'no'}"
+        )
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
 
 
 def _process_one(manual_id: str, key: str) -> None:
@@ -145,15 +235,8 @@ def _process_one(manual_id: str, key: str) -> None:
     ext = match.group("ext").lower()
 
     try:
-        if ext in DEFERRED_EXT:
-            _update_status(
-                manual_id,
-                "failed",
-                error_detail=(
-                    f"Format '{ext}' is recognized but processed in a later phase "
-                    f"(B5/B6); not supported by this preprocessing build."
-                ),
-            )
+        if ext == "pdf":
+            _process_pdf(manual_id, key)
             return
 
         if ext not in SUPPORTED_TEXT_EXT:
@@ -179,7 +262,8 @@ def _process_one(manual_id: str, key: str) -> None:
         page_count = len(pages)
 
         _write_pages(manual_id, pages)
-        _write_page_map(manual_id, page_count)
+        # Text-origin manuals have no printed page numbers (all null).
+        _write_page_map(manual_id, [None] * page_count)
         _update_status(manual_id, "completed", page_count=page_count)
         print(f"Processed manual {manual_id}: {page_count} page(s)")
     except Exception as e:  # noqa: BLE001 - record the failure on the manual item

--- a/packages/cdk/lambda-python/manual-preprocess/app.py
+++ b/packages/cdk/lambda-python/manual-preprocess/app.py
@@ -36,6 +36,7 @@ from datetime import datetime, timezone
 from typing import List, Optional
 
 import boto3
+from botocore.exceptions import ClientError
 
 from src import ocr, pdf
 from src.splitter import split_pages
@@ -50,6 +51,14 @@ TABLE_NAME = os.environ.get("TABLE_NAME", "")
 # fewer than this many visible (non-whitespace) characters is sent to Amazon
 # Textract and its result replaces the extracted text unconditionally (plan B-b).
 OCR_TEXT_THRESHOLD = 500
+
+# Per-manual processing lock TTL. The S3 event path and the reprocess Event invoke
+# can fire for the same manual_id concurrently, interleaving writes to the same
+# keys; a conditional DynamoDB lock serializes processing of one manual (other
+# manuals still run in parallel). The TTL matches the function timeout so a hard
+# failure (timeout / OOM) that never releases the lock cannot wedge a manual
+# permanently — once the deadline passes, the next invocation re-acquires it.
+LOCK_TTL_SECONDS = 15 * 60
 
 
 def _visible_len(text: str) -> int:
@@ -67,8 +76,64 @@ def _now() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _epoch_now() -> int:
+    return int(datetime.now(timezone.utc).timestamp())
+
+
 def _table():
     return ddb.Table(TABLE_NAME)
+
+
+def _acquire_lock(manual_id: str, owner: str) -> bool:
+    """Try to take the per-manual processing lock.
+
+    Succeeds when no lock is held, the caller already holds it (async retries reuse
+    the same request id), or the existing lock has expired. Returns False when
+    another live invocation holds it, in which case the caller must skip.
+    """
+    now_epoch = _epoch_now()
+    try:
+        _table().update_item(
+            Key={"manual_id": manual_id},
+            UpdateExpression=(
+                "SET lock_owner = :owner, lock_expires_at = :deadline, "
+                "#status = :processing, updated_at = :now"
+            ),
+            ConditionExpression=(
+                "attribute_exists(manual_id) AND ("
+                "attribute_not_exists(lock_owner) OR lock_owner = :owner "
+                "OR lock_expires_at < :now_epoch)"
+            ),
+            ExpressionAttributeNames={"#status": "status"},
+            ExpressionAttributeValues={
+                ":owner": owner,
+                ":deadline": now_epoch + LOCK_TTL_SECONDS,
+                ":now_epoch": now_epoch,
+                ":processing": "processing",
+                ":now": _now(),
+            },
+        )
+        return True
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
+            return False
+        raise
+
+
+def _release_lock(manual_id: str, owner: str) -> None:
+    """Release the lock, but only if this invocation still owns it."""
+    try:
+        _table().update_item(
+            Key={"manual_id": manual_id},
+            UpdateExpression="REMOVE lock_owner, lock_expires_at",
+            ConditionExpression="lock_owner = :owner",
+            ExpressionAttributeValues={":owner": owner},
+        )
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "ConditionalCheckFailedException":
+            # Lock was taken over after its TTL expired, or already released.
+            return
+        raise
 
 
 def _update_status(
@@ -252,12 +317,20 @@ def _process_pdf(manual_id: str, key: str) -> None:
         shutil.rmtree(workdir, ignore_errors=True)
 
 
-def _process_one(manual_id: str, key: str) -> None:
+def _process_one(manual_id: str, key: str, owner: str) -> None:
     """Process a single manual original object."""
     match = _ORIGINAL_KEY_RE.match(key)
     if not match:
         # Defense in depth: ignore derived artifacts (pages/, toc.*, page_map.json).
         print(f"Skipping non-original key: {key}")
+        return
+
+    # Serialize concurrent processing of the same manual (S3 event vs reprocess).
+    if not _acquire_lock(manual_id, owner):
+        print(
+            f"Manual {manual_id} is being processed by another invocation; "
+            f"skipping {key}"
+        )
         return
 
     ext = match.group("ext").lower()
@@ -297,6 +370,8 @@ def _process_one(manual_id: str, key: str) -> None:
     except Exception as e:  # noqa: BLE001 - record the failure on the manual item
         print(f"Failed to process manual {manual_id}: {e}")
         _update_status(manual_id, "failed", error_detail=str(e)[:1024])
+    finally:
+        _release_lock(manual_id, owner)
 
 
 def _targets_from_event(event: dict) -> List[tuple]:
@@ -329,7 +404,10 @@ def _targets_from_event(event: dict) -> List[tuple]:
 
 
 def handler(event, context):  # noqa: ANN001 - Lambda signature
+    # aws_request_id stays stable across async retries, so a retry re-acquires its
+    # own lock rather than being blocked by it.
+    owner = getattr(context, "aws_request_id", "") or "unknown"
     targets = _targets_from_event(event)
     for manual_id, key in targets:
-        _process_one(manual_id, key)
+        _process_one(manual_id, key, owner)
     return {"processed": len(targets)}

--- a/packages/cdk/lambda-python/manual-preprocess/app.py
+++ b/packages/cdk/lambda-python/manual-preprocess/app.py
@@ -1,0 +1,223 @@
+"""Preprocessing Lambda for the Manual RAG feature (phase B4).
+
+Scope of B4: TXT / Markdown only.
+- Splits the original into pages (src/splitter.py) and stores them as
+  {manual_id}/pages/page_0001.md ... (no page images for text-origin manuals).
+- Generates {manual_id}/page_map.json with printed page number = null
+  (text-origin manuals have no printed page numbers). toc.* is not generated.
+- Updates DynamoDB: page_count and status (completed / failed + error_detail).
+
+PDF support (page images, pypdf/pdfplumber extraction, page_map offset detection,
+toc from bookmarks) and OCR are added in later phases (B5 / B6). PDFs are not wired
+to the S3 trigger in B4; if a PDF reaches this handler (e.g. via reprocess) it is
+marked failed with an explanatory error_detail.
+
+Two entry points, handled by a single handler:
+  (a) S3 ObjectCreated event for {manual_id}/original.txt|md (normal upload)
+  (b) Direct invoke with {"manual_id": "..."} (reprocess; see reprocessManual.ts)
+"""
+
+import json
+import os
+import re
+import urllib.parse
+from datetime import datetime, timezone
+from typing import List, Optional
+
+import boto3
+
+from src.splitter import split_pages
+
+s3 = boto3.client("s3")
+ddb = boto3.resource("dynamodb")
+
+BUCKET_NAME = os.environ.get("BUCKET_NAME", "")
+TABLE_NAME = os.environ.get("TABLE_NAME", "")
+
+# B4 handles text-origin formats only.
+SUPPORTED_TEXT_EXT = {"txt", "md"}
+# Recognized overall, but processed in a later phase.
+DEFERRED_EXT = {"pdf"}
+
+# An original object key looks like "{manual_id}/original.{ext}".
+_ORIGINAL_KEY_RE = re.compile(r"^(?P<manual_id>[^/]+)/original\.(?P<ext>[A-Za-z0-9]+)$")
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _table():
+    return ddb.Table(TABLE_NAME)
+
+
+def _update_status(
+    manual_id: str,
+    status: str,
+    page_count: Optional[int] = None,
+    error_detail: str = "",
+) -> None:
+    expr = ["#status = :status", "error_detail = :error_detail", "updated_at = :now"]
+    values = {
+        ":status": status,
+        ":error_detail": error_detail,
+        ":now": _now(),
+    }
+    if page_count is not None:
+        expr.append("page_count = :page_count")
+        values[":page_count"] = page_count
+    _table().update_item(
+        Key={"manual_id": manual_id},
+        UpdateExpression="SET " + ", ".join(expr),
+        ExpressionAttributeNames={"#status": "status"},
+        ExpressionAttributeValues=values,
+    )
+
+
+def _find_original_key(manual_id: str) -> Optional[str]:
+    """Locate {manual_id}/original.* in S3 (used by the reprocess path)."""
+    listed = s3.list_objects_v2(Bucket=BUCKET_NAME, Prefix=f"{manual_id}/original.")
+    for obj in listed.get("Contents", []):
+        key = obj["Key"]
+        if _ORIGINAL_KEY_RE.match(key):
+            return key
+    return None
+
+
+def _decode(body: bytes) -> str:
+    """Decode an uploaded text file, tolerating non-UTF-8 bytes."""
+    for encoding in ("utf-8", "utf-8-sig", "cp932"):
+        try:
+            return body.decode(encoding)
+        except UnicodeDecodeError:
+            continue
+    return body.decode("utf-8", errors="replace")
+
+
+def _mime_conflicts(content_type: str, ext: str) -> bool:
+    """Detect an obvious extension/MIME mismatch (design doc step 1).
+
+    We are lenient: browsers often send application/octet-stream for .txt/.md.
+    Only a clearly contradictory binary content type is treated as a conflict.
+    """
+    if not content_type:
+        return False
+    ct = content_type.split(";")[0].strip().lower()
+    if ext in SUPPORTED_TEXT_EXT:
+        return ct.startswith("image/") or ct == "application/pdf"
+    return False
+
+
+def _write_pages(manual_id: str, pages: List[str]) -> None:
+    for index, page in enumerate(pages, start=1):
+        key = f"{manual_id}/pages/page_{index:04d}.md"
+        s3.put_object(
+            Bucket=BUCKET_NAME,
+            Key=key,
+            Body=page.encode("utf-8"),
+            ContentType="text/markdown; charset=utf-8",
+        )
+
+
+def _write_page_map(manual_id: str, page_count: int) -> None:
+    # Text-origin manuals have no printed page numbers: printed = null.
+    page_map = {
+        "pages": [
+            {"physical": n, "printed": None} for n in range(1, page_count + 1)
+        ]
+    }
+    s3.put_object(
+        Bucket=BUCKET_NAME,
+        Key=f"{manual_id}/page_map.json",
+        Body=json.dumps(page_map, ensure_ascii=False).encode("utf-8"),
+        ContentType="application/json",
+    )
+
+
+def _process_one(manual_id: str, key: str) -> None:
+    """Process a single manual original object."""
+    match = _ORIGINAL_KEY_RE.match(key)
+    if not match:
+        # Defense in depth: ignore derived artifacts (pages/, toc.*, page_map.json).
+        print(f"Skipping non-original key: {key}")
+        return
+
+    ext = match.group("ext").lower()
+
+    try:
+        if ext in DEFERRED_EXT:
+            _update_status(
+                manual_id,
+                "failed",
+                error_detail=(
+                    f"Format '{ext}' is recognized but processed in a later phase "
+                    f"(B5/B6); not supported by this preprocessing build."
+                ),
+            )
+            return
+
+        if ext not in SUPPORTED_TEXT_EXT:
+            _update_status(
+                manual_id,
+                "failed",
+                error_detail=f"Unsupported format: .{ext} (only PDF/TXT/Markdown are allowed)",
+            )
+            return
+
+        obj = s3.get_object(Bucket=BUCKET_NAME, Key=key)
+        content_type = obj.get("ContentType", "")
+        if _mime_conflicts(content_type, ext):
+            _update_status(
+                manual_id,
+                "failed",
+                error_detail=f"Extension/MIME mismatch: .{ext} vs {content_type}",
+            )
+            return
+
+        text = _decode(obj["Body"].read())
+        pages = split_pages(text, ext)
+        page_count = len(pages)
+
+        _write_pages(manual_id, pages)
+        _write_page_map(manual_id, page_count)
+        _update_status(manual_id, "completed", page_count=page_count)
+        print(f"Processed manual {manual_id}: {page_count} page(s)")
+    except Exception as e:  # noqa: BLE001 - record the failure on the manual item
+        print(f"Failed to process manual {manual_id}: {e}")
+        _update_status(manual_id, "failed", error_detail=str(e)[:1024])
+
+
+def _targets_from_event(event: dict) -> List[tuple]:
+    """Return a list of (manual_id, key) pairs to process from the event."""
+    # (b) Direct invoke for reprocess: {"manual_id": "..."}
+    manual_id = event.get("manual_id")
+    if manual_id:
+        key = _find_original_key(manual_id)
+        if not key:
+            _update_status(
+                manual_id,
+                "failed",
+                error_detail="Original file not found for reprocess",
+            )
+            return []
+        return [(manual_id, key)]
+
+    # (a) S3 ObjectCreated event.
+    targets: List[tuple] = []
+    for record in event.get("Records", []):
+        s3_info = record.get("s3", {})
+        key = s3_info.get("object", {}).get("key", "")
+        key = urllib.parse.unquote_plus(key)
+        match = _ORIGINAL_KEY_RE.match(key)
+        if match:
+            targets.append((match.group("manual_id"), key))
+        else:
+            print(f"Ignoring S3 event for non-original key: {key}")
+    return targets
+
+
+def handler(event, context):  # noqa: ANN001 - Lambda signature
+    targets = _targets_from_event(event)
+    for manual_id, key in targets:
+        _process_one(manual_id, key)
+    return {"processed": len(targets)}

--- a/packages/cdk/lambda-python/manual-preprocess/requirements.txt
+++ b/packages/cdk/lambda-python/manual-preprocess/requirements.txt
@@ -1,0 +1,4 @@
+# Manual preprocessing Lambda dependencies.
+# B4 (TXT/Markdown) uses only the standard library and the boto3 that ships with
+# the AWS Lambda Python base image, so no extra packages are required here.
+# PDF dependencies (pypdf, pdfplumber) are added in phase B5.

--- a/packages/cdk/lambda-python/manual-preprocess/requirements.txt
+++ b/packages/cdk/lambda-python/manual-preprocess/requirements.txt
@@ -1,4 +1,9 @@
 # Manual preprocessing Lambda dependencies.
-# B4 (TXT/Markdown) uses only the standard library and the boto3 that ships with
-# the AWS Lambda Python base image, so no extra packages are required here.
-# PDF dependencies (pypdf, pdfplumber) are added in phase B5.
+# TXT/Markdown (B4) use only the standard library and the boto3 that ships with
+# the AWS Lambda Python base image.
+# PDF (B5): pypdf for text extraction and bookmarks (BSD-3), pdfplumber for
+# reading printed page numbers from footers (MIT). PyMuPDF (AGPL) is NOT used.
+# Page rasterization uses the poppler-utils `pdftoppm` binary (see Dockerfile),
+# invoked as a separate process, so no Python imaging dependency is required.
+pypdf==5.1.0
+pdfplumber==0.11.4

--- a/packages/cdk/lambda-python/manual-preprocess/src/ocr.py
+++ b/packages/cdk/lambda-python/manual-preprocess/src/ocr.py
@@ -1,0 +1,33 @@
+"""OCR for image-only / low-text PDF pages (phase B6).
+
+Pages whose extractable text falls below the threshold are sent to Amazon
+Textract `DetectDocumentText` (synchronous) by S3Object reference. The page PNGs
+are already in S3 (written in phase B5), so no image bytes are passed inline and
+the synchronous 5 MB inline limit is irrelevant.
+
+Only plain text is needed (no table/form structure), so DetectDocumentText is
+used rather than AnalyzeDocument. Calls run in the same region as the function
+(residual task A: us-east-1). boto3 ships with the Lambda base image, so no extra
+dependency is required.
+"""
+
+import boto3
+
+textract = boto3.client("textract")
+
+
+def detect_document_text(bucket: str, key: str) -> str:
+    """Run Textract DetectDocumentText on an S3 object and return its text.
+
+    Lines are joined with newlines in Textract's reading order. Raises on an API
+    failure; the caller decides how to handle a single-page OCR failure.
+    """
+    response = textract.detect_document_text(
+        Document={"S3Object": {"Bucket": bucket, "Name": key}}
+    )
+    lines = [
+        block.get("Text", "")
+        for block in response.get("Blocks", [])
+        if block.get("BlockType") == "LINE"
+    ]
+    return "\n".join(line for line in lines if line)

--- a/packages/cdk/lambda-python/manual-preprocess/src/pdf.py
+++ b/packages/cdk/lambda-python/manual-preprocess/src/pdf.py
@@ -1,0 +1,249 @@
+"""PDF handling for the Manual RAG preprocessing Lambda (phase B5).
+
+Responsibilities (design doc section 4 steps 2/4/5, section 9):
+- Rasterize each physical page to PNG with poppler-utils `pdftoppm`, invoked as a
+  separate process so its GPL license does not propagate to this code.
+- Extract per-page text with pypdf (BSD-3). PyMuPDF (AGPL) is intentionally unused.
+- Build page_map: read the printed page number from each page footer with pdfplumber
+  (MIT). Pages where no number can be read map to null (residual task E = plan A).
+- Extract a table of contents from the PDF outline (bookmarks) with pypdf, if present.
+
+OCR routing for pages with little/no extractable text (Amazon Textract) is NOT done
+here; it is added in phase B6. In B5 such pages simply keep a short/empty page text.
+"""
+
+import os
+import re
+import subprocess
+from typing import Dict, List, Optional, Tuple
+
+DEFAULT_DPI = 150
+
+# A canonical Roman numeral (i, ii, iii, iv, ...). Used to recognize front-matter
+# page numbers (cover/preface) that are printed as Roman numerals.
+_ROMAN_RE = re.compile(
+    r"(?i)^m{0,3}(cm|cd|d?c{0,3})(xc|xl|l?x{0,3})(ix|iv|v?i{0,3})$"
+)
+
+# Tokens that commonly decorate a page-number footer ("Page 12 of 340", "- 12 -",
+# "12 / 340", Japanese "ページ"/"頁"). A line is treated as a page-number line when
+# nothing but these tokens and digits remain.
+_PAGE_DECOR_RE = re.compile(
+    r"(?i)(page|ページ|頁|p\.?|of|/|\-|–|—|\[|\]|\(|\)|\s)"
+)
+
+
+def _is_roman(token: str) -> bool:
+    return bool(token) and bool(_ROMAN_RE.fullmatch(token))
+
+
+def _arabic_in_pagelike_line(line: str) -> Optional[str]:
+    """Return the page number if `line` is essentially just an Arabic number."""
+    residue = _PAGE_DECOR_RE.sub("", line)
+    residue = re.sub(r"\d+", "", residue)
+    if residue:  # other text present -> not a bare page-number line
+        return None
+    match = re.search(r"\d{1,4}", line)
+    return match.group(0) if match else None
+
+
+def _roman_in_pagelike_line(line: str) -> Optional[str]:
+    """Return the Roman page number if `line` is essentially just a Roman numeral."""
+    match = re.fullmatch(
+        r"[\s\-–—\(\[]*([ivxlcdm]{1,7})[\s\-–—\)\]]*",
+        line,
+        re.I,
+    )
+    if match and _is_roman(match.group(1)):
+        return match.group(1).lower()
+    return None
+
+
+def parse_printed_number(footer_text: str) -> Optional[str]:
+    """Read a printed page number from footer text, or None if none is found.
+
+    Looks at the bottom-most few lines and accepts a line only when it is
+    essentially just a page number (Arabic preferred, then Roman). This keeps
+    incidental numbers (e.g. a copyright year inside a sentence) from being
+    mistaken for the page number. page_map is citation-only and does not carry
+    routing precision, so "read it if clear, else null" is sufficient.
+    """
+    if not footer_text:
+        return None
+    lines = [ln.strip() for ln in footer_text.splitlines() if ln.strip()]
+    tail = lines[-3:]
+    for line in reversed(tail):
+        arabic = _arabic_in_pagelike_line(line)
+        if arabic:
+            return arabic
+    for line in reversed(tail):
+        roman = _roman_in_pagelike_line(line)
+        if roman:
+            return roman
+    return None
+
+
+def extract_page_texts(pdf_path: str) -> List[str]:
+    """Extract text for every physical page with pypdf (one string per page)."""
+    from pypdf import PdfReader
+
+    reader = PdfReader(pdf_path)
+    texts: List[str] = []
+    for page in reader.pages:
+        try:
+            texts.append(page.extract_text() or "")
+        except Exception as e:  # noqa: BLE001 - a single bad page must not abort all
+            print(f"pypdf: failed to extract a page: {e}")
+            texts.append("")
+    return texts
+
+
+def rasterize_page(
+    pdf_path: str, page_num: int, out_dir: str, dpi: int = DEFAULT_DPI
+) -> str:
+    """Rasterize one physical page to PNG via pdftoppm; return the output path.
+
+    pdftoppm runs as a separate process (GPL does not propagate). `-singlefile`
+    writes exactly `{prefix}.png` without a page-number suffix.
+    """
+    prefix = os.path.join(out_dir, f"page_{page_num:04d}")
+    result = subprocess.run(
+        [
+            "pdftoppm",
+            "-png",
+            "-r",
+            str(dpi),
+            "-f",
+            str(page_num),
+            "-l",
+            str(page_num),
+            "-singlefile",
+            pdf_path,
+            prefix,
+        ],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"pdftoppm failed for page {page_num}: {result.stderr.strip()}"
+        )
+    out_path = prefix + ".png"
+    if not os.path.exists(out_path):
+        raise RuntimeError(f"pdftoppm produced no output for page {page_num}")
+    return out_path
+
+
+def build_page_map(pdf_path: str, page_count: int) -> List[Optional[str]]:
+    """Read the printed page number of each physical page from its footer.
+
+    Residual task E = plan A (footer reading). Returns a list aligned to physical
+    pages 1..page_count; each entry is the printed number string or None.
+    """
+    printed: List[Optional[str]] = [None] * page_count
+    try:
+        import pdfplumber
+
+        with pdfplumber.open(pdf_path) as doc:
+            for index, page in enumerate(doc.pages):
+                if index >= page_count:
+                    break
+                try:
+                    height = page.height
+                    width = page.width
+                    footer = page.crop((0, height * 0.85, width, height))
+                    text = footer.extract_text() or ""
+                except Exception as e:  # noqa: BLE001 - keep null on a bad page
+                    print(f"pdfplumber: footer crop failed on page {index + 1}: {e}")
+                    text = ""
+                printed[index] = parse_printed_number(text)
+    except Exception as e:  # noqa: BLE001 - degrade to all-null page_map
+        print(f"page_map: footer reading failed, leaving all null: {e}")
+    return printed
+
+
+def extract_toc(pdf_path: str) -> Optional[List[Dict]]:
+    """Extract a flat, ordered outline from PDF bookmarks, or None if absent.
+
+    Each entry: {title, level, start_page} where start_page is a 1-based physical
+    page number. end_page / printed_pages are derived later in build_toc_documents.
+    """
+    from pypdf import PdfReader
+
+    reader = PdfReader(pdf_path)
+    try:
+        outline = reader.outline
+    except Exception as e:  # noqa: BLE001 - treat unreadable outline as absent
+        print(f"pypdf: outline unreadable: {e}")
+        return None
+    if not outline:
+        return None
+
+    entries: List[Dict] = []
+
+    def walk(items, level: int) -> None:
+        # pypdf represents children as a nested list following their parent item.
+        for item in items:
+            if isinstance(item, list):
+                walk(item, level + 1)
+                continue
+            try:
+                page_index = reader.get_destination_page_number(item)
+            except Exception:  # noqa: BLE001 - skip entries without a resolvable page
+                continue
+            title = (getattr(item, "title", "") or "").strip()
+            if title and page_index is not None:
+                entries.append(
+                    {"title": title, "level": level, "start_page": page_index + 1}
+                )
+
+    walk(outline, 1)
+    return entries or None
+
+
+def build_toc_documents(
+    entries: List[Dict], printed: List[Optional[str]], page_count: int
+) -> Tuple[Dict, str]:
+    """Derive end_page / printed_pages and render toc.json and toc.md.
+
+    end_page = (start_page of the next entry whose level <= this level) - 1,
+    or the last page if there is no such following entry (design doc section 3.3).
+    """
+    count = len(entries)
+    for i, entry in enumerate(entries):
+        end = page_count
+        level = entry["level"]
+        for j in range(i + 1, count):
+            if entries[j]["level"] <= level:
+                end = entries[j]["start_page"] - 1
+                break
+        entry["end_page"] = max(entry["start_page"], end)
+
+    def printed_label(start: int, end: int) -> str:
+        start_label = printed[start - 1] if 1 <= start <= len(printed) else None
+        end_label = printed[end - 1] if 1 <= end <= len(printed) else None
+        if start_label and end_label and start_label != end_label:
+            return f"{start_label}-{end_label}"
+        if start_label:
+            return start_label
+        return ""
+
+    toc_entries = [
+        {
+            "title": entry["title"],
+            "level": entry["level"],
+            "start_page": entry["start_page"],
+            "end_page": entry["end_page"],
+            "printed_pages": printed_label(entry["start_page"], entry["end_page"]),
+        }
+        for entry in entries
+    ]
+
+    lines = ["# 目次", ""]
+    for entry in toc_entries:
+        indent = "  " * (entry["level"] - 1)
+        label = entry["printed_pages"] or f"p{entry['start_page']}"
+        lines.append(f"{indent}- {entry['title']} ({label})")
+    toc_md = "\n".join(lines) + "\n"
+
+    return {"entries": toc_entries}, toc_md

--- a/packages/cdk/lambda-python/manual-preprocess/src/pdf.py
+++ b/packages/cdk/lambda-python/manual-preprocess/src/pdf.py
@@ -8,8 +8,9 @@ Responsibilities (design doc section 4 steps 2/4/5, section 9):
   (MIT). Pages where no number can be read map to null (residual task E = plan A).
 - Extract a table of contents from the PDF outline (bookmarks) with pypdf, if present.
 
-OCR routing for pages with little/no extractable text (Amazon Textract) is NOT done
-here; it is added in phase B6. In B5 such pages simply keep a short/empty page text.
+OCR routing for pages with little/no extractable text (Amazon Textract) is not done
+here; it lives in app.py / src/ocr.py (phase B6), which replaces the text of pages
+that fall below the threshold.
 """
 
 import os

--- a/packages/cdk/lambda-python/manual-preprocess/src/splitter.py
+++ b/packages/cdk/lambda-python/manual-preprocess/src/splitter.py
@@ -1,0 +1,124 @@
+"""Page splitting for text-origin manuals (TXT / Markdown).
+
+This module turns a plain-text or Markdown document into a list of "pages".
+A page is the unit of reading and citation; it does NOT carry routing precision
+(search is the primary navigation path). See design doc section 4 step 3 and 12.1.
+
+Rules (residual task D, decided 2026-06-01):
+- TXT: split every PAGE_CHAR_LIMIT characters (D-1 = 2000).
+- Markdown: split at heading boundaries. A heading at level L owns everything up
+  to the next heading whose level is <= L (deeper subheadings stay together).
+  Content before the first heading, and files with no heading at all, are split
+  by fixed character count. Any heading section longer than the limit is further
+  split by fixed character count (D-2).
+"""
+
+import re
+from typing import List, Tuple
+
+PAGE_CHAR_LIMIT = 2000
+
+# A Markdown ATX heading: 1-3 leading '#' followed by a space. We intentionally
+# only treat #, ## and ### as page boundaries (design doc section 4 step 3).
+_HEADING_RE = re.compile(r"^(#{1,3})\s")
+
+
+def split_fixed(text: str, limit: int = PAGE_CHAR_LIMIT) -> List[str]:
+    """Split text into chunks of at most `limit` characters."""
+    if limit <= 0:
+        raise ValueError("limit must be positive")
+    stripped = text.strip()
+    if not stripped:
+        return []
+    return [text[i : i + limit] for i in range(0, len(text), limit)]
+
+
+def split_txt(text: str, limit: int = PAGE_CHAR_LIMIT) -> List[str]:
+    """Split a plain-text document by fixed character count."""
+    pages = split_fixed(text, limit)
+    # Guarantee at least one page so page_count >= 1 for a non-empty file.
+    return pages if pages else [text]
+
+
+def _heading_level(line: str) -> int:
+    """Return the heading level (1-3) of a line, or 0 if it is not a heading."""
+    m = _HEADING_RE.match(line)
+    return len(m.group(1)) if m else 0
+
+
+def split_markdown(text: str, limit: int = PAGE_CHAR_LIMIT) -> List[str]:
+    """Split a Markdown document by heading boundaries with a fixed-size fallback."""
+    lines = text.splitlines(keepends=True)
+
+    # Collect heading positions and their levels.
+    headings: List[Tuple[int, int]] = []  # (line_index, level)
+    for idx, line in enumerate(lines):
+        level = _heading_level(line)
+        if level:
+            headings.append((idx, level))
+
+    # No heading anywhere: behave like TXT (D-2).
+    if not headings:
+        return split_txt(text, limit)
+
+    pages: List[str] = []
+
+    # Content before the first heading -> fixed split (D-2).
+    first_heading_line = headings[0][0]
+    if first_heading_line > 0:
+        pre = "".join(lines[:first_heading_line])
+        pages.extend(split_fixed(pre, limit))
+
+    # Walk headings; a heading owns everything up to the next heading whose
+    # level is <= its own (same or higher rank). Deeper headings are absorbed.
+    i = 0
+    while i < len(headings):
+        start, level = headings[i]
+        j = i + 1
+        while j < len(headings) and headings[j][1] > level:
+            j += 1
+        end = headings[j][0] if j < len(headings) else len(lines)
+        section = "".join(lines[start:end])
+        # A single section longer than the limit is further split (D-2).
+        if len(section) > limit:
+            pages.extend(split_fixed(section, limit))
+        else:
+            pages.append(section)
+        i = j
+
+    return pages if pages else [text]
+
+
+def split_pages(text: str, ext: str, limit: int = PAGE_CHAR_LIMIT) -> List[str]:
+    """Split a text-origin document into pages based on its extension."""
+    if ext == "md":
+        return split_markdown(text, limit)
+    return split_txt(text, limit)
+
+
+if __name__ == "__main__":
+    # Lightweight self-checks (local verification only; no AWS dependency).
+    txt = "a" * 4500
+    assert len(split_txt(txt)) == 3, "TXT should split into 3 pages of <=2000 chars"
+
+    md = "# A\nintro\n## B\nbbb\n## C\nccc\n# D\nddd\n"
+    md_pages = split_markdown(md)
+    # '# A' absorbs '## B' and '## C'; '# D' is a separate page.
+    assert len(md_pages) == 2, f"expected 2 pages, got {len(md_pages)}: {md_pages}"
+    assert md_pages[0].startswith("# A"), md_pages[0]
+    assert md_pages[1].startswith("# D"), md_pages[1]
+
+    siblings = "## B\nbbb\n## C\nccc\n"
+    assert len(split_markdown(siblings)) == 2, "sibling level-2 headings split"
+
+    no_heading = "x" * 2500
+    assert len(split_markdown(no_heading)) == 2, "no-heading markdown uses fixed split"
+
+    pre = "lead text\n" + "y" * 2500 + "\n# H\nbody\n"
+    pre_pages = split_markdown(pre)
+    assert pre_pages[-1].startswith("# H"), pre_pages[-1]
+
+    long_section = "# Big\n" + "z" * 5000
+    assert len(split_markdown(long_section)) >= 3, "long section re-split by chars"
+
+    print("splitter self-checks passed")

--- a/packages/cdk/lambda/manual/createUploadUrl.ts
+++ b/packages/cdk/lambda/manual/createUploadUrl.ts
@@ -1,0 +1,87 @@
+import { v4 as uuidv4 } from 'uuid';
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, PutCommand } from '@aws-sdk/lib-dynamodb';
+import {
+  error,
+  isAdmin,
+  ok,
+  stripExtension,
+  validateUploadFormat,
+} from './utils';
+
+const s3 = new S3Client({});
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+// Presigned PUT URL validity (decided 2026-05-29: 15 minutes).
+const URL_EXPIRES_IN = 15 * 60;
+
+interface CreateUploadUrlRequest {
+  filename: string;
+  contentType?: string;
+  title?: string;
+  description?: string;
+}
+
+/**
+ * POST /manuals
+ * Issues a presigned PUT URL for a manual original and immediately creates the
+ * DynamoDB metadata item with status=processing (D1 case 1).
+ */
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    if (!isAdmin(event)) {
+      return error(403, 'Forbidden: admin group required');
+    }
+
+    const req: CreateUploadUrlRequest = JSON.parse(event.body ?? '{}');
+    if (!req.filename) {
+      return error(400, 'filename is required');
+    }
+
+    const check = validateUploadFormat(req.filename, req.contentType);
+    if (!check.valid) {
+      return error(400, check.reason ?? 'Unsupported file format');
+    }
+
+    const manualId = uuidv4();
+    const key = `${manualId}/original.${check.ext}`;
+    const now = new Date().toISOString();
+
+    await ddb.send(
+      new PutCommand({
+        TableName: process.env.TABLE_NAME,
+        Item: {
+          manual_id: manualId,
+          title: req.title || stripExtension(req.filename),
+          description: req.description ?? '',
+          status: 'processing',
+          error_detail: '',
+          page_count: 0,
+          original_filename: req.filename,
+          created_at: now,
+          updated_at: now,
+        },
+      })
+    );
+
+    const uploadUrl = await getSignedUrl(
+      s3,
+      new PutObjectCommand({
+        Bucket: process.env.BUCKET_NAME,
+        Key: key,
+        ContentType: req.contentType,
+      }),
+      { expiresIn: URL_EXPIRES_IN }
+    );
+
+    return ok({ manualId, key, uploadUrl });
+  } catch (e) {
+    console.log(e);
+    return error(500, 'Internal Server Error');
+  }
+};

--- a/packages/cdk/lambda/manual/deleteManual.ts
+++ b/packages/cdk/lambda/manual/deleteManual.ts
@@ -7,7 +7,7 @@ import {
 } from '@aws-sdk/client-s3';
 import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
 import { DynamoDBDocumentClient, DeleteCommand } from '@aws-sdk/lib-dynamodb';
-import { error, isAdmin, ok } from './utils';
+import { error, isAdmin, isValidManualId, ok } from './utils';
 
 const s3 = new S3Client({});
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
@@ -56,6 +56,9 @@ export const handler = async (
     const manualId = event.pathParameters?.manualId;
     if (!manualId) {
       return error(400, 'manualId is required');
+    }
+    if (!isValidManualId(manualId)) {
+      return error(400, 'manualId must be a valid UUID');
     }
 
     await deletePrefix(process.env.BUCKET_NAME!, `${manualId}/`);

--- a/packages/cdk/lambda/manual/deleteManual.ts
+++ b/packages/cdk/lambda/manual/deleteManual.ts
@@ -1,0 +1,75 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import {
+  DeleteObjectsCommand,
+  ListObjectsV2Command,
+  ListObjectsV2CommandOutput,
+  S3Client,
+} from '@aws-sdk/client-s3';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, DeleteCommand } from '@aws-sdk/lib-dynamodb';
+import { error, isAdmin, ok } from './utils';
+
+const s3 = new S3Client({});
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+// Delete every object under the given prefix (handles pagination).
+const deletePrefix = async (bucket: string, prefix: string): Promise<void> => {
+  let continuationToken: string | undefined = undefined;
+  do {
+    const listed: ListObjectsV2CommandOutput = await s3.send(
+      new ListObjectsV2Command({
+        Bucket: bucket,
+        Prefix: prefix,
+        ContinuationToken: continuationToken,
+      })
+    );
+    const keys = (listed.Contents ?? [])
+      .map((o) => o.Key)
+      .filter((k): k is string => !!k);
+    if (keys.length > 0) {
+      await s3.send(
+        new DeleteObjectsCommand({
+          Bucket: bucket,
+          Delete: { Objects: keys.map((Key) => ({ Key })) },
+        })
+      );
+    }
+    continuationToken = listed.IsTruncated
+      ? listed.NextContinuationToken
+      : undefined;
+  } while (continuationToken);
+};
+
+/**
+ * DELETE /manuals/{manualId}
+ * Removes the DynamoDB item and all S3 objects (original + derived artifacts)
+ * under the manual prefix.
+ */
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    if (!isAdmin(event)) {
+      return error(403, 'Forbidden: admin group required');
+    }
+
+    const manualId = event.pathParameters?.manualId;
+    if (!manualId) {
+      return error(400, 'manualId is required');
+    }
+
+    await deletePrefix(process.env.BUCKET_NAME!, `${manualId}/`);
+
+    await ddb.send(
+      new DeleteCommand({
+        TableName: process.env.TABLE_NAME,
+        Key: { manual_id: manualId },
+      })
+    );
+
+    return ok({ manualId, deleted: true });
+  } catch (e) {
+    console.log(e);
+    return error(500, 'Internal Server Error');
+  }
+};

--- a/packages/cdk/lambda/manual/listManuals.ts
+++ b/packages/cdk/lambda/manual/listManuals.ts
@@ -1,0 +1,43 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import {
+  DynamoDBDocumentClient,
+  ScanCommand,
+  ScanCommandOutput,
+} from '@aws-sdk/lib-dynamodb';
+import { error, isAdmin, ok } from './utils';
+
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+/**
+ * GET /manuals
+ * Returns all manuals in this environment. The number of manuals per environment
+ * is expected to be small, so a Scan (no GSI) is sufficient (decided 2026-05-29).
+ */
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    if (!isAdmin(event)) {
+      return error(403, 'Forbidden: admin group required');
+    }
+
+    const items: Record<string, unknown>[] = [];
+    let lastEvaluatedKey: Record<string, unknown> | undefined = undefined;
+    do {
+      const res: ScanCommandOutput = await ddb.send(
+        new ScanCommand({
+          TableName: process.env.TABLE_NAME,
+          ExclusiveStartKey: lastEvaluatedKey,
+        })
+      );
+      items.push(...(res.Items ?? []));
+      lastEvaluatedKey = res.LastEvaluatedKey;
+    } while (lastEvaluatedKey);
+
+    return ok({ manuals: items });
+  } catch (e) {
+    console.log(e);
+    return error(500, 'Internal Server Error');
+  }
+};

--- a/packages/cdk/lambda/manual/markFailed.ts
+++ b/packages/cdk/lambda/manual/markFailed.ts
@@ -1,0 +1,94 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient, UpdateCommand } from '@aws-sdk/lib-dynamodb';
+
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+// An original object key looks like "{manual_id}/original.{ext}" (mirrors the
+// preprocessing Lambda's _ORIGINAL_KEY_RE).
+const ORIGINAL_KEY_RE = /^([^/]+)\/original\.[A-Za-z0-9]+$/;
+
+// The async failure destination receives an envelope wrapping the ORIGINAL event
+// that was sent to the preprocessing Lambda, so we recover manual ids the same way
+// the preprocessing handler does: from a reprocess payload ({ manual_id }) or from
+// the S3 ObjectCreated records.
+const extractManualIds = (payload: unknown): string[] => {
+  if (!payload || typeof payload !== 'object') {
+    return [];
+  }
+  const p = payload as {
+    manual_id?: unknown;
+    Records?: Array<{ s3?: { object?: { key?: unknown } } }>;
+  };
+  if (typeof p.manual_id === 'string' && p.manual_id.length > 0) {
+    return [p.manual_id];
+  }
+  const ids: string[] = [];
+  for (const record of p.Records ?? []) {
+    const rawKey = record?.s3?.object?.key;
+    if (typeof rawKey !== 'string') {
+      continue;
+    }
+    // S3 event keys are URL-encoded with '+' for spaces (urllib unquote_plus).
+    const key = decodeURIComponent(rawKey.replace(/\+/g, ' '));
+    const match = key.match(ORIGINAL_KEY_RE);
+    if (match) {
+      ids.push(match[1]);
+    }
+  }
+  return ids;
+};
+
+interface AsyncFailureEvent {
+  requestPayload?: unknown;
+  requestContext?: { condition?: string };
+}
+
+/**
+ * onFailure destination for the preprocessing Lambda.
+ *
+ * The preprocessing handler catches ordinary exceptions and records status=failed
+ * itself, but a hard failure (Lambda timeout / out-of-memory) kills the process
+ * before that runs, leaving the manual stuck at status=processing forever. This
+ * Lambda is invoked by the async failure destination after retries are exhausted
+ * and flips such stuck items to failed.
+ *
+ * The update is conditional on status still being "processing" so a late
+ * destination misfire cannot clobber a manual that actually completed (or was
+ * already marked failed). The processing lock attributes are cleared at the same
+ * time.
+ */
+export const handler = async (event: AsyncFailureEvent): Promise<void> => {
+  const manualIds = extractManualIds(event?.requestPayload);
+  const condition = event?.requestContext?.condition ?? 'Unknown';
+  const detail = `Hard failure during preprocessing (likely timeout or out-of-memory): ${condition}`;
+  const now = new Date().toISOString();
+
+  for (const manualId of manualIds) {
+    try {
+      await ddb.send(
+        new UpdateCommand({
+          TableName: process.env.TABLE_NAME,
+          Key: { manual_id: manualId },
+          UpdateExpression:
+            'SET #status = :failed, error_detail = :detail, updated_at = :now REMOVE lock_owner, lock_expires_at',
+          ConditionExpression:
+            'attribute_exists(manual_id) AND #status = :processing',
+          ExpressionAttributeNames: { '#status': 'status' },
+          ExpressionAttributeValues: {
+            ':failed': 'failed',
+            ':processing': 'processing',
+            ':detail': detail,
+            ':now': now,
+          },
+        })
+      );
+      console.log(`Marked manual ${manualId} as failed (${condition}).`);
+    } catch (e) {
+      if ((e as { name?: string }).name === 'ConditionalCheckFailedException') {
+        // Item is already terminal (completed / failed) or was deleted; skip.
+        continue;
+      }
+      console.log(e);
+    }
+  }
+};

--- a/packages/cdk/lambda/manual/reprocessManual.ts
+++ b/packages/cdk/lambda/manual/reprocessManual.ts
@@ -1,0 +1,140 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import {
+  DeleteObjectsCommand,
+  ListObjectsV2Command,
+  ListObjectsV2CommandOutput,
+  S3Client,
+} from '@aws-sdk/client-s3';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  UpdateCommand,
+} from '@aws-sdk/lib-dynamodb';
+import {
+  InvokeCommand,
+  LambdaClient,
+  InvocationType,
+} from '@aws-sdk/client-lambda';
+import { error, isAdmin, ok } from './utils';
+
+const s3 = new S3Client({});
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+const lambda = new LambdaClient({});
+
+// Delete every object under the given prefix (handles pagination).
+const deletePrefix = async (bucket: string, prefix: string): Promise<void> => {
+  let continuationToken: string | undefined = undefined;
+  do {
+    const listed: ListObjectsV2CommandOutput = await s3.send(
+      new ListObjectsV2Command({
+        Bucket: bucket,
+        Prefix: prefix,
+        ContinuationToken: continuationToken,
+      })
+    );
+    const keys = (listed.Contents ?? [])
+      .map((o) => o.Key)
+      .filter((k): k is string => !!k);
+    if (keys.length > 0) {
+      await s3.send(
+        new DeleteObjectsCommand({
+          Bucket: bucket,
+          Delete: { Objects: keys.map((Key) => ({ Key })) },
+        })
+      );
+    }
+    continuationToken = listed.IsTruncated
+      ? listed.NextContinuationToken
+      : undefined;
+  } while (continuationToken);
+};
+
+/**
+ * POST /manuals/{manualId}/reprocess
+ * Reprocess order (decided 2026-05-29, C-4):
+ *   1. set DynamoDB status=processing (and clear error_detail)
+ *   2. delete derived S3 artifacts (pages/, toc.*, page_map.json), keep the original
+ *   3. invoke the preprocessing Lambda asynchronously (Event)
+ * The preprocessing Lambda itself is implemented in phase B4. Until then
+ * PREPROCESS_FUNCTION_ARN is empty and the invoke step is skipped (C-5).
+ */
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    if (!isAdmin(event)) {
+      return error(403, 'Forbidden: admin group required');
+    }
+
+    const manualId = event.pathParameters?.manualId;
+    if (!manualId) {
+      return error(400, 'manualId is required');
+    }
+
+    const tableName = process.env.TABLE_NAME;
+    const bucket = process.env.BUCKET_NAME!;
+
+    const existing = await ddb.send(
+      new GetCommand({
+        TableName: tableName,
+        Key: { manual_id: manualId },
+      })
+    );
+    if (!existing.Item) {
+      return error(404, 'Manual not found');
+    }
+
+    // 1. status -> processing
+    await ddb.send(
+      new UpdateCommand({
+        TableName: tableName,
+        Key: { manual_id: manualId },
+        UpdateExpression:
+          'SET #status = :processing, error_detail = :empty, updated_at = :now',
+        ExpressionAttributeNames: { '#status': 'status' },
+        ExpressionAttributeValues: {
+          ':processing': 'processing',
+          ':empty': '',
+          ':now': new Date().toISOString(),
+        },
+      })
+    );
+
+    // 2. delete derived artifacts (keep the original)
+    await deletePrefix(bucket, `${manualId}/pages/`);
+    await s3.send(
+      new DeleteObjectsCommand({
+        Bucket: bucket,
+        Delete: {
+          Objects: [
+            { Key: `${manualId}/toc.md` },
+            { Key: `${manualId}/toc.json` },
+            { Key: `${manualId}/page_map.json` },
+          ],
+        },
+      })
+    );
+
+    // 3. invoke the preprocessing Lambda (wired in B4)
+    const preprocessArn = process.env.PREPROCESS_FUNCTION_ARN ?? '';
+    if (preprocessArn.length > 0) {
+      await lambda.send(
+        new InvokeCommand({
+          FunctionName: preprocessArn,
+          InvocationType: InvocationType.Event,
+          Payload: Buffer.from(JSON.stringify({ manual_id: manualId })),
+        })
+      );
+    } else {
+      console.log(
+        'PREPROCESS_FUNCTION_ARN is not set yet (B4 pending); skipping invoke.'
+      );
+    }
+
+    return ok({ manualId, status: 'processing' });
+  } catch (e) {
+    console.log(e);
+    return error(500, 'Internal Server Error');
+  }
+};

--- a/packages/cdk/lambda/manual/reprocessManual.ts
+++ b/packages/cdk/lambda/manual/reprocessManual.ts
@@ -16,7 +16,7 @@ import {
   LambdaClient,
   InvocationType,
 } from '@aws-sdk/client-lambda';
-import { error, isAdmin, ok } from './utils';
+import { error, isAdmin, isValidManualId, ok } from './utils';
 
 const s3 = new S3Client({});
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
@@ -70,6 +70,9 @@ export const handler = async (
     const manualId = event.pathParameters?.manualId;
     if (!manualId) {
       return error(400, 'manualId is required');
+    }
+    if (!isValidManualId(manualId)) {
+      return error(400, 'manualId must be a valid UUID');
     }
 
     const tableName = process.env.TABLE_NAME;

--- a/packages/cdk/lambda/manual/updateManual.ts
+++ b/packages/cdk/lambda/manual/updateManual.ts
@@ -1,0 +1,77 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import {
+  DynamoDBDocumentClient,
+  UpdateCommand,
+} from '@aws-sdk/lib-dynamodb';
+import { error, isAdmin, ok } from './utils';
+
+const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
+
+interface UpdateManualRequest {
+  title?: string;
+  description?: string;
+}
+
+/**
+ * PATCH /manuals/{manualId}
+ * Updates the editable metadata (title / description). Only the provided fields
+ * are changed. The item must already exist (guarded by a condition).
+ */
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    if (!isAdmin(event)) {
+      return error(403, 'Forbidden: admin group required');
+    }
+
+    const manualId = event.pathParameters?.manualId;
+    if (!manualId) {
+      return error(400, 'manualId is required');
+    }
+
+    const req: UpdateManualRequest = JSON.parse(event.body ?? '{}');
+    if (req.title === undefined && req.description === undefined) {
+      return error(400, 'title or description is required');
+    }
+
+    const setExpressions: string[] = ['updated_at = :now'];
+    const names: Record<string, string> = {};
+    const values: Record<string, unknown> = {
+      ':now': new Date().toISOString(),
+    };
+
+    // Use ExpressionAttributeNames to avoid any DynamoDB reserved-word collision.
+    if (req.title !== undefined) {
+      setExpressions.push('#title = :title');
+      names['#title'] = 'title';
+      values[':title'] = req.title;
+    }
+    if (req.description !== undefined) {
+      setExpressions.push('#description = :description');
+      names['#description'] = 'description';
+      values[':description'] = req.description;
+    }
+
+    const res = await ddb.send(
+      new UpdateCommand({
+        TableName: process.env.TABLE_NAME,
+        Key: { manual_id: manualId },
+        UpdateExpression: `SET ${setExpressions.join(', ')}`,
+        ExpressionAttributeNames: names,
+        ExpressionAttributeValues: values,
+        ConditionExpression: 'attribute_exists(manual_id)',
+        ReturnValues: 'ALL_NEW',
+      })
+    );
+
+    return ok({ manual: res.Attributes });
+  } catch (e) {
+    if ((e as { name?: string }).name === 'ConditionalCheckFailedException') {
+      return error(404, 'Manual not found');
+    }
+    console.log(e);
+    return error(500, 'Internal Server Error');
+  }
+};

--- a/packages/cdk/lambda/manual/updateManual.ts
+++ b/packages/cdk/lambda/manual/updateManual.ts
@@ -4,7 +4,7 @@ import {
   DynamoDBDocumentClient,
   UpdateCommand,
 } from '@aws-sdk/lib-dynamodb';
-import { error, isAdmin, ok } from './utils';
+import { error, isAdmin, isValidManualId, ok } from './utils';
 
 const ddb = DynamoDBDocumentClient.from(new DynamoDBClient({}));
 
@@ -29,6 +29,9 @@ export const handler = async (
     const manualId = event.pathParameters?.manualId;
     if (!manualId) {
       return error(400, 'manualId is required');
+    }
+    if (!isValidManualId(manualId)) {
+      return error(400, 'manualId must be a valid UUID');
     }
 
     const req: UpdateManualRequest = JSON.parse(event.body ?? '{}');

--- a/packages/cdk/lambda/manual/utils.ts
+++ b/packages/cdk/lambda/manual/utils.ts
@@ -1,0 +1,95 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+
+// Cognito group that is allowed to manage manuals.
+// The existing GenU User Pool already has this group (verified 2026-05-29).
+export const ADMIN_GROUP = 'admin';
+
+// Allowed upload formats (scope confirmed 2026-06-01: PDF / TXT / Markdown only).
+export const ALLOWED_EXTENSIONS = ['pdf', 'txt', 'md'];
+
+// Content-Type is an auxiliary check; extension is the primary check because some
+// clients send application/octet-stream for txt / md uploads.
+export const ALLOWED_CONTENT_TYPES = [
+  'application/pdf',
+  'text/plain',
+  'text/markdown',
+  'text/x-markdown',
+  'application/octet-stream',
+  '',
+];
+
+const JSON_HEADERS = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+};
+
+export const ok = (body: unknown): APIGatewayProxyResult => ({
+  statusCode: 200,
+  headers: JSON_HEADERS,
+  body: JSON.stringify(body),
+});
+
+export const error = (
+  statusCode: number,
+  message: string
+): APIGatewayProxyResult => ({
+  statusCode,
+  headers: JSON_HEADERS,
+  body: JSON.stringify({ message }),
+});
+
+// The Cognito authorizer of API Gateway serializes cognito:groups inconsistently
+// (e.g. "admin", "[admin]" or "[admin, user]"), so parse defensively.
+export const parseGroups = (raw: unknown): string[] => {
+  if (typeof raw !== 'string' || raw.length === 0) {
+    return [];
+  }
+  return raw
+    .replace(/^\[/, '')
+    .replace(/\]$/, '')
+    .split(/[\s,]+/)
+    .map((g) => g.trim())
+    .filter((g) => g.length > 0);
+};
+
+export const isAdmin = (event: APIGatewayProxyEvent): boolean => {
+  const claims = event.requestContext.authorizer?.claims;
+  if (!claims) {
+    return false;
+  }
+  return parseGroups(claims['cognito:groups']).includes(ADMIN_GROUP);
+};
+
+// Extract a lowercase extension (without the dot) from a filename.
+export const getExtension = (filename: string): string => {
+  const match = filename.toLowerCase().match(/\.([a-z0-9]+)$/);
+  return match ? match[1] : '';
+};
+
+// Validate the upload format by extension (primary) and Content-Type (auxiliary).
+export const validateUploadFormat = (
+  filename: string,
+  contentType: string | undefined
+): { valid: boolean; ext: string; reason?: string } => {
+  const ext = getExtension(filename);
+  if (!ALLOWED_EXTENSIONS.includes(ext)) {
+    return {
+      valid: false,
+      ext,
+      reason: `Unsupported extension: .${ext}. Allowed: ${ALLOWED_EXTENSIONS.join(', ')}`,
+    };
+  }
+  const ct = (contentType ?? '').toLowerCase();
+  if (!ALLOWED_CONTENT_TYPES.includes(ct)) {
+    return {
+      valid: false,
+      ext,
+      reason: `Unsupported Content-Type: ${contentType}`,
+    };
+  }
+  return { valid: true, ext };
+};
+
+// Strip the extension from a filename to build a default title.
+export const stripExtension = (filename: string): string =>
+  filename.replace(/\.[^/.]+$/, '');

--- a/packages/cdk/lambda/manual/utils.ts
+++ b/packages/cdk/lambda/manual/utils.ts
@@ -60,6 +60,15 @@ export const isAdmin = (event: APIGatewayProxyEvent): boolean => {
   return parseGroups(claims['cognito:groups']).includes(ADMIN_GROUP);
 };
 
+// manualId is a server-generated UUID (createUploadUrl uses uuidv4). The admin
+// endpoints take it as a path parameter and use it as an S3 prefix / DynamoDB key,
+// so validate the format before use to reject path traversal and arbitrary-prefix
+// inputs. The check is version-agnostic (canonical 8-4-4-4-12 hex layout).
+const MANUAL_ID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export const isValidManualId = (id: string): boolean => MANUAL_ID_RE.test(id);
+
 // Extract a lowercase extension (without the dot) from a filename.
 export const getExtension = (filename: string): string => {
   const match = filename.toLowerCase().match(/\.([a-z0-9]+)$/);

--- a/packages/cdk/lib/construct/manual-rag/admin-api.ts
+++ b/packages/cdk/lib/construct/manual-rag/admin-api.ts
@@ -1,0 +1,170 @@
+import { Duration } from 'aws-cdk-lib';
+import {
+  AuthorizationType,
+  CognitoUserPoolsAuthorizer,
+  Cors,
+  LambdaIntegration,
+  ResponseType,
+  RestApi,
+} from 'aws-cdk-lib/aws-apigateway';
+import { UserPool, UserPoolClient } from 'aws-cdk-lib/aws-cognito';
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { Construct } from 'constructs';
+import { LAMBDA_RUNTIME_NODEJS } from '../../../consts';
+import { ManualStorage } from './storage';
+
+export interface ManualAdminApiProps {
+  readonly userPool: UserPool;
+  readonly userPoolClient: UserPoolClient;
+  readonly storage: ManualStorage;
+}
+
+/**
+ * Manual admin API (B2).
+ * REST API + management Lambdas behind a Cognito authorizer. Authorization to the
+ * "admin" group is enforced inside each Lambda (the Cognito authorizer itself does
+ * not restrict by group). Endpoints:
+ *   POST   /manuals                     - issue presigned upload URL + create item
+ *   GET    /manuals                     - list manuals
+ *   DELETE /manuals/{manualId}          - delete item + S3 objects
+ *   PATCH  /manuals/{manualId}          - update title / description
+ *   POST   /manuals/{manualId}/reprocess- reprocess (clear artifacts + invoke B4)
+ */
+export class ManualAdminApi extends Construct {
+  public readonly api: RestApi;
+
+  constructor(scope: Construct, id: string, props: ManualAdminApiProps) {
+    super(scope, id);
+
+    const { userPool, userPoolClient, storage } = props;
+    const { bucket, table } = storage;
+
+    const commonEnv = {
+      TABLE_NAME: table.tableName,
+      BUCKET_NAME: bucket.bucketName,
+      USER_POOL_ID: userPool.userPoolId,
+      USER_POOL_CLIENT_ID: userPoolClient.userPoolClientId,
+    };
+
+    const defineFunction = (name: string, entry: string) =>
+      new NodejsFunction(this, name, {
+        runtime: LAMBDA_RUNTIME_NODEJS,
+        entry,
+        timeout: Duration.minutes(1),
+        environment: commonEnv,
+      });
+
+    // POST /manuals
+    const createUploadUrlFunction = defineFunction(
+      'CreateUploadUrl',
+      './lambda/manual/createUploadUrl.ts'
+    );
+    table.grantWriteData(createUploadUrlFunction);
+    bucket.grantPut(createUploadUrlFunction);
+
+    // GET /manuals
+    const listManualsFunction = defineFunction(
+      'ListManuals',
+      './lambda/manual/listManuals.ts'
+    );
+    table.grantReadData(listManualsFunction);
+
+    // DELETE /manuals/{manualId}
+    const deleteManualFunction = defineFunction(
+      'DeleteManual',
+      './lambda/manual/deleteManual.ts'
+    );
+    table.grantReadWriteData(deleteManualFunction);
+    bucket.grantRead(deleteManualFunction);
+    bucket.grantDelete(deleteManualFunction);
+
+    // POST /manuals/{manualId}/reprocess
+    // PREPROCESS_FUNCTION_ARN is wired in B4; empty for now (the handler guards).
+    const reprocessManualFunction = new NodejsFunction(
+      this,
+      'ReprocessManual',
+      {
+        runtime: LAMBDA_RUNTIME_NODEJS,
+        entry: './lambda/manual/reprocessManual.ts',
+        timeout: Duration.minutes(1),
+        environment: {
+          ...commonEnv,
+          PREPROCESS_FUNCTION_ARN: '',
+        },
+      }
+    );
+    table.grantReadWriteData(reprocessManualFunction);
+    bucket.grantRead(reprocessManualFunction);
+    bucket.grantDelete(reprocessManualFunction);
+
+    // PATCH /manuals/{manualId}
+    const updateManualFunction = defineFunction(
+      'UpdateManual',
+      './lambda/manual/updateManual.ts'
+    );
+    table.grantReadWriteData(updateManualFunction);
+
+    // API Gateway with Cognito authorizer
+    const authorizer = new CognitoUserPoolsAuthorizer(this, 'Authorizer', {
+      cognitoUserPools: [userPool],
+    });
+    const commonAuthorizerProps = {
+      authorizationType: AuthorizationType.COGNITO,
+      authorizer,
+    };
+
+    const api = new RestApi(this, 'Api', {
+      deployOptions: {
+        stageName: 'api',
+      },
+      defaultCorsPreflightOptions: {
+        allowOrigins: Cors.ALL_ORIGINS,
+        allowMethods: Cors.ALL_METHODS,
+      },
+      cloudWatchRole: true,
+      defaultMethodOptions: commonAuthorizerProps,
+    });
+
+    api.addGatewayResponse('Api4XX', {
+      type: ResponseType.DEFAULT_4XX,
+      responseHeaders: { 'Access-Control-Allow-Origin': "'*'" },
+    });
+    api.addGatewayResponse('Api5XX', {
+      type: ResponseType.DEFAULT_5XX,
+      responseHeaders: { 'Access-Control-Allow-Origin': "'*'" },
+    });
+
+    const manualsResource = api.root.addResource('manuals');
+    manualsResource.addMethod(
+      'POST',
+      new LambdaIntegration(createUploadUrlFunction),
+      commonAuthorizerProps
+    );
+    manualsResource.addMethod(
+      'GET',
+      new LambdaIntegration(listManualsFunction),
+      commonAuthorizerProps
+    );
+
+    const manualResource = manualsResource.addResource('{manualId}');
+    manualResource.addMethod(
+      'DELETE',
+      new LambdaIntegration(deleteManualFunction),
+      commonAuthorizerProps
+    );
+    manualResource.addMethod(
+      'PATCH',
+      new LambdaIntegration(updateManualFunction),
+      commonAuthorizerProps
+    );
+
+    const reprocessResource = manualResource.addResource('reprocess');
+    reprocessResource.addMethod(
+      'POST',
+      new LambdaIntegration(reprocessManualFunction),
+      commonAuthorizerProps
+    );
+
+    this.api = api;
+  }
+}

--- a/packages/cdk/lib/construct/manual-rag/admin-api.ts
+++ b/packages/cdk/lib/construct/manual-rag/admin-api.ts
@@ -32,6 +32,9 @@ export interface ManualAdminApiProps {
  */
 export class ManualAdminApi extends Construct {
   public readonly api: RestApi;
+  // Exposed so the stack can wire PREPROCESS_FUNCTION_ARN and grant invoke once
+  // the preprocessing Lambda exists (B4).
+  public readonly reprocessManualFunction: NodejsFunction;
 
   constructor(scope: Construct, id: string, props: ManualAdminApiProps) {
     super(scope, id);
@@ -96,6 +99,7 @@ export class ManualAdminApi extends Construct {
     table.grantReadWriteData(reprocessManualFunction);
     bucket.grantRead(reprocessManualFunction);
     bucket.grantDelete(reprocessManualFunction);
+    this.reprocessManualFunction = reprocessManualFunction;
 
     // PATCH /manuals/{manualId}
     const updateManualFunction = defineFunction(

--- a/packages/cdk/lib/construct/manual-rag/preprocess.ts
+++ b/packages/cdk/lib/construct/manual-rag/preprocess.ts
@@ -5,10 +5,15 @@ import {
   Architecture,
   IFunction,
 } from 'aws-cdk-lib/aws-lambda';
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
 import { EventType } from 'aws-cdk-lib/aws-s3';
 import { LambdaDestination } from 'aws-cdk-lib/aws-s3-notifications';
+// Same class name as the s3-notifications LambdaDestination above; alias to avoid
+// the collision (this one is the async-invoke onFailure destination).
+import { LambdaDestination as LambdaFailureDestination } from 'aws-cdk-lib/aws-lambda-destinations';
 import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
+import { LAMBDA_RUNTIME_NODEJS } from '../../../consts';
 import { ManualStorage } from './storage';
 
 export interface ManualPreprocessProps {
@@ -38,6 +43,21 @@ export class ManualPreprocess extends Construct {
 
     const { bucket, table } = props.storage;
 
+    // onFailure destination for the preprocessing Lambda. The handler records
+    // status=failed for ordinary exceptions itself, but a hard failure (timeout /
+    // out-of-memory) kills the process first and would leave the manual stuck at
+    // status=processing. This Lambda runs after async retries are exhausted and
+    // flips such stuck items to failed.
+    const markFailedFunction = new NodejsFunction(this, 'MarkFailed', {
+      runtime: LAMBDA_RUNTIME_NODEJS,
+      entry: './lambda/manual/markFailed.ts',
+      timeout: Duration.minutes(1),
+      environment: {
+        TABLE_NAME: table.tableName,
+      },
+    });
+    table.grantWriteData(markFailedFunction);
+
     const preprocessFunction = new DockerImageFunction(this, 'Function', {
       code: DockerImageCode.fromImageAsset('./lambda-python/manual-preprocess'),
       memorySize: 2048,
@@ -48,6 +68,7 @@ export class ManualPreprocess extends Construct {
         BUCKET_NAME: bucket.bucketName,
         TABLE_NAME: table.tableName,
       },
+      onFailure: new LambdaFailureDestination(markFailedFunction),
     });
 
     // Reads originals, writes page texts / page_map.json, updates manual status.

--- a/packages/cdk/lib/construct/manual-rag/preprocess.ts
+++ b/packages/cdk/lib/construct/manual-rag/preprocess.ts
@@ -6,6 +6,7 @@ import {
   IFunction,
 } from 'aws-cdk-lib/aws-lambda';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
+import { Platform } from 'aws-cdk-lib/aws-ecr-assets';
 import { EventType } from 'aws-cdk-lib/aws-s3';
 import { LambdaDestination } from 'aws-cdk-lib/aws-s3-notifications';
 // Same class name as the s3-notifications LambdaDestination above; alias to avoid
@@ -59,7 +60,13 @@ export class ManualPreprocess extends Construct {
     table.grantWriteData(markFailedFunction);
 
     const preprocessFunction = new DockerImageFunction(this, 'Function', {
-      code: DockerImageCode.fromImageAsset('./lambda-python/manual-preprocess'),
+      // Force an amd64 image regardless of the build host (e.g. Apple Silicon),
+      // so it matches the X86_64 Lambda architecture below. Same pattern as
+      // closed-web.ts. Without this, fromImageAsset builds for the host arch and
+      // an arm64 Mac would produce an image that mismatches the function.
+      code: DockerImageCode.fromImageAsset('./lambda-python/manual-preprocess', {
+        platform: Platform.LINUX_AMD64,
+      }),
       memorySize: 2048,
       ephemeralStorageSize: Size.mebibytes(2048),
       timeout: Duration.minutes(15),

--- a/packages/cdk/lib/construct/manual-rag/preprocess.ts
+++ b/packages/cdk/lib/construct/manual-rag/preprocess.ts
@@ -15,16 +15,18 @@ export interface ManualPreprocessProps {
 }
 
 /**
- * Preprocessing Lambda for the Manual RAG feature (B4).
+ * Preprocessing Lambda for the Manual RAG feature (B4/B5).
  *
- * Docker Image (Python 3.13, AWS Lambda base image) bundling poppler-utils for the
- * PDF rasterization added in B5. The function is event-driven, not an HTTP server:
- * it is triggered by S3 ObjectCreated events for {manual_id}/original.txt|md and by
- * direct invoke ({ manual_id }) from the reprocess Lambda.
+ * Docker Image (Python 3.13, AWS Lambda base image) bundling poppler-utils
+ * (pdftoppm) for PDF rasterization. The function is event-driven, not an HTTP
+ * server: it is triggered by S3 ObjectCreated events for
+ * {manual_id}/original.txt|md|pdf and by direct invoke ({ manual_id }) from the
+ * reprocess Lambda.
  *
- * B4 scope is TXT / Markdown: split into page texts under {manual_id}/pages/, write
- * page_map.json (printed page = null), and update DynamoDB status. PDF/OCR come in
- * B5/B6; original.pdf is intentionally NOT wired to the trigger here.
+ * TXT / Markdown (B4): split into page texts under {manual_id}/pages/, write
+ * page_map.json (printed page = null). PDF (B5): rasterize pages to PNG, extract
+ * per-page text, read printed numbers from footers into page_map.json, and emit
+ * toc.* from bookmarks. OCR for image-only pages (Amazon Textract) comes in B6.
  */
 export class ManualPreprocess extends Construct {
   public readonly function: IFunction;
@@ -51,19 +53,16 @@ export class ManualPreprocess extends Construct {
     table.grantReadWriteData(preprocessFunction);
 
     // S3 trigger for normal uploads. The suffix filter matches only the original
-    // files (exact tail "original.txt" / "original.md"); derived artifacts such as
-    // pages/page_0001.md do not match, preventing a self-trigger loop. original.pdf
-    // is wired in B5. The handler also guards against non-original keys.
-    bucket.addEventNotification(
-      EventType.OBJECT_CREATED,
-      new LambdaDestination(preprocessFunction),
-      { suffix: 'original.txt' }
-    );
-    bucket.addEventNotification(
-      EventType.OBJECT_CREATED,
-      new LambdaDestination(preprocessFunction),
-      { suffix: 'original.md' }
-    );
+    // files (exact tail "original.txt" / "original.md" / "original.pdf"); derived
+    // artifacts such as pages/page_0001.md|png do not match, preventing a
+    // self-trigger loop. The handler also guards against non-original keys.
+    for (const suffix of ['original.txt', 'original.md', 'original.pdf']) {
+      bucket.addEventNotification(
+        EventType.OBJECT_CREATED,
+        new LambdaDestination(preprocessFunction),
+        { suffix }
+      );
+    }
 
     this.function = preprocessFunction;
   }

--- a/packages/cdk/lib/construct/manual-rag/preprocess.ts
+++ b/packages/cdk/lib/construct/manual-rag/preprocess.ts
@@ -1,0 +1,70 @@
+import { Duration, Size } from 'aws-cdk-lib';
+import {
+  DockerImageFunction,
+  DockerImageCode,
+  Architecture,
+  IFunction,
+} from 'aws-cdk-lib/aws-lambda';
+import { EventType } from 'aws-cdk-lib/aws-s3';
+import { LambdaDestination } from 'aws-cdk-lib/aws-s3-notifications';
+import { Construct } from 'constructs';
+import { ManualStorage } from './storage';
+
+export interface ManualPreprocessProps {
+  readonly storage: ManualStorage;
+}
+
+/**
+ * Preprocessing Lambda for the Manual RAG feature (B4).
+ *
+ * Docker Image (Python 3.13, AWS Lambda base image) bundling poppler-utils for the
+ * PDF rasterization added in B5. The function is event-driven, not an HTTP server:
+ * it is triggered by S3 ObjectCreated events for {manual_id}/original.txt|md and by
+ * direct invoke ({ manual_id }) from the reprocess Lambda.
+ *
+ * B4 scope is TXT / Markdown: split into page texts under {manual_id}/pages/, write
+ * page_map.json (printed page = null), and update DynamoDB status. PDF/OCR come in
+ * B5/B6; original.pdf is intentionally NOT wired to the trigger here.
+ */
+export class ManualPreprocess extends Construct {
+  public readonly function: IFunction;
+
+  constructor(scope: Construct, id: string, props: ManualPreprocessProps) {
+    super(scope, id);
+
+    const { bucket, table } = props.storage;
+
+    const preprocessFunction = new DockerImageFunction(this, 'Function', {
+      code: DockerImageCode.fromImageAsset('./lambda-python/manual-preprocess'),
+      memorySize: 2048,
+      ephemeralStorageSize: Size.mebibytes(2048),
+      timeout: Duration.minutes(15),
+      architecture: Architecture.X86_64,
+      environment: {
+        BUCKET_NAME: bucket.bucketName,
+        TABLE_NAME: table.tableName,
+      },
+    });
+
+    // Reads originals, writes page texts / page_map.json, updates manual status.
+    bucket.grantReadWrite(preprocessFunction);
+    table.grantReadWriteData(preprocessFunction);
+
+    // S3 trigger for normal uploads. The suffix filter matches only the original
+    // files (exact tail "original.txt" / "original.md"); derived artifacts such as
+    // pages/page_0001.md do not match, preventing a self-trigger loop. original.pdf
+    // is wired in B5. The handler also guards against non-original keys.
+    bucket.addEventNotification(
+      EventType.OBJECT_CREATED,
+      new LambdaDestination(preprocessFunction),
+      { suffix: 'original.txt' }
+    );
+    bucket.addEventNotification(
+      EventType.OBJECT_CREATED,
+      new LambdaDestination(preprocessFunction),
+      { suffix: 'original.md' }
+    );
+
+    this.function = preprocessFunction;
+  }
+}

--- a/packages/cdk/lib/construct/manual-rag/preprocess.ts
+++ b/packages/cdk/lib/construct/manual-rag/preprocess.ts
@@ -7,6 +7,7 @@ import {
 } from 'aws-cdk-lib/aws-lambda';
 import { EventType } from 'aws-cdk-lib/aws-s3';
 import { LambdaDestination } from 'aws-cdk-lib/aws-s3-notifications';
+import { PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
 import { ManualStorage } from './storage';
 
@@ -15,7 +16,7 @@ export interface ManualPreprocessProps {
 }
 
 /**
- * Preprocessing Lambda for the Manual RAG feature (B4/B5).
+ * Preprocessing Lambda for the Manual RAG feature (B4/B5/B6).
  *
  * Docker Image (Python 3.13, AWS Lambda base image) bundling poppler-utils
  * (pdftoppm) for PDF rasterization. The function is event-driven, not an HTTP
@@ -26,7 +27,8 @@ export interface ManualPreprocessProps {
  * TXT / Markdown (B4): split into page texts under {manual_id}/pages/, write
  * page_map.json (printed page = null). PDF (B5): rasterize pages to PNG, extract
  * per-page text, read printed numbers from footers into page_map.json, and emit
- * toc.* from bookmarks. OCR for image-only pages (Amazon Textract) comes in B6.
+ * toc.* from bookmarks. OCR (B6): PDF pages with little/no extractable text are
+ * read from their PNG via Amazon Textract DetectDocumentText.
  */
 export class ManualPreprocess extends Construct {
   public readonly function: IFunction;
@@ -51,6 +53,16 @@ export class ManualPreprocess extends Construct {
     // Reads originals, writes page texts / page_map.json, updates manual status.
     bucket.grantReadWrite(preprocessFunction);
     table.grantReadWriteData(preprocessFunction);
+
+    // OCR for image-only / low-text PDF pages (B6). Only DetectDocumentText is
+    // granted (AnalyzeDocument is not used). Textract reads the page PNG via an
+    // S3Object reference, which is already covered by the bucket read grant.
+    preprocessFunction.addToRolePolicy(
+      new PolicyStatement({
+        actions: ['textract:DetectDocumentText'],
+        resources: ['*'],
+      })
+    );
 
     // S3 trigger for normal uploads. The suffix filter matches only the original
     // files (exact tail "original.txt" / "original.md" / "original.pdf"); derived

--- a/packages/cdk/lib/construct/manual-rag/storage.ts
+++ b/packages/cdk/lib/construct/manual-rag/storage.ts
@@ -1,0 +1,43 @@
+import { Construct } from 'constructs';
+import { RemovalPolicy } from 'aws-cdk-lib';
+import {
+  Bucket,
+  BlockPublicAccess,
+  BucketEncryption,
+} from 'aws-cdk-lib/aws-s3';
+import * as ddb from 'aws-cdk-lib/aws-dynamodb';
+
+/**
+ * Storage for the Manual RAG feature (B1).
+ * - S3: stores manual originals, page images (PNG), page texts (MD), table of
+ *   contents and page_map.json (key layout: design doc section 3.1).
+ * - DynamoDB: single table holding manual metadata (9 attributes, design doc section 3.2).
+ *
+ * removalPolicy is RETAIN because manual originals and metadata are user assets and
+ * must not be deleted by accident (decided 2026-05-29).
+ * IAM grants for the Lambdas / API Gateway / AgentCore are added in later phases
+ * (B2 onward) by referencing these resources.
+ */
+export class ManualStorage extends Construct {
+  public readonly bucket: Bucket;
+  public readonly table: ddb.Table;
+
+  constructor(scope: Construct, id: string) {
+    super(scope, id);
+
+    this.bucket = new Bucket(this, 'ManualBucket', {
+      blockPublicAccess: BlockPublicAccess.BLOCK_ALL,
+      encryption: BucketEncryption.S3_MANAGED,
+      removalPolicy: RemovalPolicy.RETAIN,
+    });
+
+    this.table = new ddb.Table(this, 'ManualTable', {
+      partitionKey: {
+        name: 'manual_id',
+        type: ddb.AttributeType.STRING,
+      },
+      billingMode: ddb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: RemovalPolicy.RETAIN,
+    });
+  }
+}

--- a/packages/cdk/lib/create-stacks.ts
+++ b/packages/cdk/lib/create-stacks.ts
@@ -6,6 +6,7 @@ import { AgentStack } from './agent-stack';
 import { RagKnowledgeBaseStack } from './rag-knowledge-base-stack';
 import { GuardrailStack } from './guardrail-stack';
 import { AgentCoreStack } from './agent-core-stack';
+import { ManualRagStack } from './manual-rag-stack';
 import { ProcessedStackInput } from './stack-input';
 import { VideoTmpBucketStack } from './video-tmp-bucket-stack';
 import { ApplicationInferenceProfileStack } from './application-inference-profile-stack';
@@ -299,6 +300,26 @@ export const createStacks = (app: cdk.App, params: ProcessedStackInput) => {
     new DeletionPolicySetter(cdk.RemovalPolicy.DESTROY)
   );
 
+  // Manual RAG feature (B1: storage / B2: admin API).
+  // Created after GenerativeAiUseCasesStack so the admin API authorizer can use its
+  // Cognito UserPool. When the flag is false (default) the stack is not created and
+  // no reference is added, so existing behavior is fully preserved.
+  const manualRagStack = params.manualRagEnabled
+    ? new ManualRagStack(app, `ManualRagStack${params.env}`, {
+        env: {
+          account: params.account,
+          region: params.region,
+        },
+        params: params,
+        userPool: generativeAiUseCasesStack.userPool,
+        userPoolClient: generativeAiUseCasesStack.userPoolClient,
+        crossRegionReferences: true,
+      })
+    : null;
+  if (manualRagStack) {
+    manualRagStack.addDependency(generativeAiUseCasesStack);
+  }
+
   const dashboardStack = updatedParams.dashboard
     ? new DashboardStack(
         app,
@@ -325,6 +346,7 @@ export const createStacks = (app: cdk.App, params: ProcessedStackInput) => {
     guardrailStack,
     agentCoreStack,
     generativeAiUseCasesStack,
+    manualRagStack,
     dashboardStack,
   };
 };

--- a/packages/cdk/lib/manual-rag-stack.ts
+++ b/packages/cdk/lib/manual-rag-stack.ts
@@ -1,9 +1,10 @@
-import { Stack, StackProps } from 'aws-cdk-lib';
+import { CfnOutput, Stack, StackProps } from 'aws-cdk-lib';
 import { UserPool, UserPoolClient } from 'aws-cdk-lib/aws-cognito';
 import { Construct } from 'constructs';
 import { ProcessedStackInput } from './stack-input';
 import { ManualStorage } from './construct/manual-rag/storage';
 import { ManualAdminApi } from './construct/manual-rag/admin-api';
+import { ManualPreprocess } from './construct/manual-rag/preprocess';
 
 export interface ManualRagStackProps extends StackProps {
   readonly params: ProcessedStackInput;
@@ -22,12 +23,14 @@ export interface ManualRagStackProps extends StackProps {
  *
  * B1: storage skeleton (S3 + DynamoDB).
  * B2: manual admin API (REST API + management Lambdas).
- * The chat relay Lambda / preprocessing Lambda / AgentCore Runtime wiring is added
- * in later phases.
+ * B4: preprocessing Lambda (TXT/Markdown page splitting), wired to S3 events and to
+ *     the reprocess Lambda via PREPROCESS_FUNCTION_ARN.
+ * The chat relay Lambda / AgentCore Runtime wiring is added in later phases.
  */
 export class ManualRagStack extends Stack {
   public readonly storage: ManualStorage;
   public readonly adminApi: ManualAdminApi;
+  public readonly preprocess: ManualPreprocess;
 
   constructor(scope: Construct, id: string, props: ManualRagStackProps) {
     super(scope, id, props);
@@ -38,6 +41,31 @@ export class ManualRagStack extends Stack {
       userPool: props.userPool,
       userPoolClient: props.userPoolClient,
       storage: this.storage,
+    });
+
+    this.preprocess = new ManualPreprocess(this, 'ManualPreprocess', {
+      storage: this.storage,
+    });
+
+    // Let the reprocess Lambda invoke the preprocessing Lambda (B2 left this as an
+    // empty placeholder env var; B4 fills it in).
+    this.adminApi.reprocessManualFunction.addEnvironment(
+      'PREPROCESS_FUNCTION_ARN',
+      this.preprocess.function.functionArn
+    );
+    this.preprocess.function.grantInvoke(
+      this.adminApi.reprocessManualFunction
+    );
+
+    // Outputs for the (separately developed) GenU frontend to wire against.
+    new CfnOutput(this, 'ManualAdminApiEndpoint', {
+      value: this.adminApi.api.url,
+    });
+    new CfnOutput(this, 'ManualBucketName', {
+      value: this.storage.bucket.bucketName,
+    });
+    new CfnOutput(this, 'ManualTableName', {
+      value: this.storage.table.tableName,
     });
   }
 }

--- a/packages/cdk/lib/manual-rag-stack.ts
+++ b/packages/cdk/lib/manual-rag-stack.ts
@@ -25,6 +25,8 @@ export interface ManualRagStackProps extends StackProps {
  * B2: manual admin API (REST API + management Lambdas).
  * B4: preprocessing Lambda (TXT/Markdown page splitting), wired to S3 events and to
  *     the reprocess Lambda via PREPROCESS_FUNCTION_ARN.
+ * B5: PDF support in the same preprocessing Lambda (page images, text extraction,
+ *     page_map from footers, toc from bookmarks); original.pdf added to the trigger.
  * The chat relay Lambda / AgentCore Runtime wiring is added in later phases.
  */
 export class ManualRagStack extends Stack {

--- a/packages/cdk/lib/manual-rag-stack.ts
+++ b/packages/cdk/lib/manual-rag-stack.ts
@@ -1,0 +1,43 @@
+import { Stack, StackProps } from 'aws-cdk-lib';
+import { UserPool, UserPoolClient } from 'aws-cdk-lib/aws-cognito';
+import { Construct } from 'constructs';
+import { ProcessedStackInput } from './stack-input';
+import { ManualStorage } from './construct/manual-rag/storage';
+import { ManualAdminApi } from './construct/manual-rag/admin-api';
+
+export interface ManualRagStackProps extends StackProps {
+  readonly params: ProcessedStackInput;
+  // Cognito resources owned by GenerativeAiUseCasesStack, injected from
+  // create-stacks.ts (this stack is created after it). Used by the admin API
+  // authorizer (B2).
+  readonly userPool: UserPool;
+  readonly userPoolClient: UserPoolClient;
+}
+
+/**
+ * Stack that groups the infrastructure of the Manual RAG feature.
+ * The authoritative design lives in the FIXER.Medical.AgentCore repository at
+ * docs/dev-diary/naito/documents/manual-implementation-plan.md, and the GenU-side
+ * CDK procedure in manual-cdk-deploy-plan.md.
+ *
+ * B1: storage skeleton (S3 + DynamoDB).
+ * B2: manual admin API (REST API + management Lambdas).
+ * The chat relay Lambda / preprocessing Lambda / AgentCore Runtime wiring is added
+ * in later phases.
+ */
+export class ManualRagStack extends Stack {
+  public readonly storage: ManualStorage;
+  public readonly adminApi: ManualAdminApi;
+
+  constructor(scope: Construct, id: string, props: ManualRagStackProps) {
+    super(scope, id, props);
+
+    this.storage = new ManualStorage(this, 'ManualStorage');
+
+    this.adminApi = new ManualAdminApi(this, 'ManualAdminApi', {
+      userPool: props.userPool,
+      userPoolClient: props.userPoolClient,
+      storage: this.storage,
+    });
+  }
+}

--- a/packages/cdk/lib/stack-input.ts
+++ b/packages/cdk/lib/stack-input.ts
@@ -197,6 +197,8 @@ const baseStackInputSchema = z.object({
   guardrailEnabled: z.boolean().default(false),
   // Usecase builder
   useCaseBuilderEnabled: z.boolean().default(true),
+  // Manual RAG feature (manual reference mode)
+  manualRagEnabled: z.boolean().default(false),
   // Flows
   flows: z
     .array(


### PR DESCRIPTION
## Description of Changes

汎用マニュアルRAG機能のGenU側インフラ基盤を追加します。

### 追加内容
- **B1 ストレージ**: S3(原本/派生成果物) + DynamoDB(メタデータ)構成 (RETAIN)
- **B2 管理API**: Cognito認可付きREST API + 管理Lambda群
  - `POST /manuals`(presigned URL発行+メタ作成) / `GET /manuals` / `DELETE`・`PATCH /manuals/{id}` / `POST /manuals/{id}/reprocess`
- **B4/B5/B6 前処理Lambda(Docker/Python)**: TXT・Markdownのページ分割、PDFのラスタライズ・テキスト抽出・page_map・toc生成、低テキストページのTextract OCR
- **B7**: AgentCore接続点をCDK計画書に追記

### 堅牢性改善(レビュー指摘対応)
- ハード障害(timeout/OOM)時のstatus "processing" 固着を onFailure Destination(`markFailed`)で `failed` に回復
- 同一manualの並行前処理をDynamoDB条件付きロックで直列化
- `manualId` のUUID形式バリデーション追加

### 既存ユーザーへの影響
- 新規スタック(`ManualRagStack`)の追加のみ。既存スタック・機能への破壊的変更なし。

## Checklist
- [x] Modified relevant documentation(CDK計画書 / 設計書を更新)
- [ ] Verified operation in local environment(未デプロイ検証)
- [ ] Executed `npm run cdk:test`(スナップショット未実行)

## Related Issues
（該当があれば追記）

🤖 Generated with [Claude Code](https://claude.com/claude-code)