### PR TITLE
feat: AIエージェント実行の観測ログ(agent_run / llm_call)基盤を追加

### DIFF
--- a/packages/cdk/.eslintrc.cjs
+++ b/packages/cdk/.eslintrc.cjs
@@ -32,6 +32,9 @@ module.exports = {
         // SendGrid email copy; not shipped, so i18n 警告の対象外とする。
         'scripts/preview-emails.ts',
         'scripts/send-test-mail.ts',
+        // SendGrid メールのレンダリング結果（日本語の本文・ラベル）を検証する
+        // ユニットテスト。アサーション文字列が日本語になるため i18n 警告の対象外とする。
+        'test/lambda/customEmailSender.test.ts',
       ],
       rules: {
         'i18nhelper/no-jp-string': 'off',

--- a/packages/cdk/lambda/agentObservability.ts
+++ b/packages/cdk/lambda/agentObservability.ts
@@ -1,0 +1,144 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import {
+  AppendAgentLlmCallsRequest,
+  CompleteAgentRunRequest,
+  StartAgentRunRequest,
+} from 'generative-ai-use-cases';
+import {
+  appendAgentLlmCalls,
+  completeAgentRun,
+  startAgentRun,
+} from './repositoryAgentObservability';
+
+class ValidationError extends Error {}
+
+const jsonResponse = (
+  statusCode: number,
+  body: Record<string, unknown>
+): APIGatewayProxyResult => ({
+  statusCode,
+  headers: {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+  },
+  body: JSON.stringify(body),
+});
+
+const parseBody = (event: APIGatewayProxyEvent): unknown => {
+  if (!event.body) {
+    throw new ValidationError('Request body is required');
+  }
+  return JSON.parse(event.body);
+};
+
+const isObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const requireString = (obj: Record<string, unknown>, key: string): string => {
+  const value = obj[key];
+  if (typeof value !== 'string' || value.length === 0) {
+    throw new ValidationError(`${key} is required`);
+  }
+  return value;
+};
+
+const parseStartRun = (body: unknown): StartAgentRunRequest => {
+  if (!isObject(body)) {
+    throw new ValidationError('Request body must be an object');
+  }
+  return {
+    agent_run_id: requireString(body, 'agent_run_id'),
+    agent_id: requireString(body, 'agent_id'),
+    session_id:
+      typeof body.session_id === 'string' ? body.session_id : undefined,
+    chat_id: typeof body.chat_id === 'string' ? body.chat_id : undefined,
+    started_at: requireString(body, 'started_at'),
+  };
+};
+
+const parseCompleteRun = (body: unknown): CompleteAgentRunRequest => {
+  if (!isObject(body)) {
+    throw new ValidationError('Request body must be an object');
+  }
+  const status = requireString(body, 'status');
+  if (status !== 'succeeded' && status !== 'failed') {
+    throw new ValidationError('status must be succeeded or failed');
+  }
+  return {
+    agent_run_id: requireString(body, 'agent_run_id'),
+    agent_id: requireString(body, 'agent_id'),
+    session_id:
+      typeof body.session_id === 'string' ? body.session_id : undefined,
+    chat_id: typeof body.chat_id === 'string' ? body.chat_id : undefined,
+    user_message_id:
+      typeof body.user_message_id === 'string'
+        ? body.user_message_id
+        : undefined,
+    assistant_message_id:
+      typeof body.assistant_message_id === 'string'
+        ? body.assistant_message_id
+        : undefined,
+    started_at:
+      typeof body.started_at === 'string' ? body.started_at : undefined,
+    ended_at: requireString(body, 'ended_at'),
+    status,
+    error_type:
+      typeof body.error_type === 'string' || body.error_type === null
+        ? body.error_type
+        : undefined,
+  };
+};
+
+const parseAppendLlmCalls = (body: unknown): AppendAgentLlmCallsRequest => {
+  if (!isObject(body)) {
+    throw new ValidationError('Request body must be an object');
+  }
+  if (!Array.isArray(body.llm_calls)) {
+    throw new ValidationError('llm_calls must be an array');
+  }
+  return {
+    agent_run_id: requireString(body, 'agent_run_id'),
+    llm_calls: body.llm_calls as AppendAgentLlmCallsRequest['llm_calls'],
+  };
+};
+
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    const operation = event.pathParameters?.operation;
+    const userId: string =
+      event.requestContext.authorizer!.claims['cognito:username'];
+    const runBase = {
+      tenant_id: process.env.TENANT_ID!,
+      environment_id: process.env.ENVIRONMENT_ID!,
+      user_id: userId,
+    };
+    const body = parseBody(event);
+
+    if (operation === 'start-run') {
+      await startAgentRun(parseStartRun(body), runBase);
+      return jsonResponse(200, { ok: true });
+    }
+
+    if (operation === 'complete-run') {
+      await completeAgentRun(parseCompleteRun(body), runBase);
+      return jsonResponse(200, { ok: true });
+    }
+
+    if (operation === 'llm-calls') {
+      const req = parseAppendLlmCalls(body);
+      await appendAgentLlmCalls(req.agent_run_id, req.llm_calls);
+      return jsonResponse(200, { ok: true });
+    }
+
+    return jsonResponse(404, { message: 'Unknown observability operation' });
+  } catch (error) {
+    console.log(error);
+    const message = error instanceof Error ? error.message : 'Invalid request';
+    return jsonResponse(error instanceof ValidationError ? 400 : 500, {
+      message:
+        error instanceof ValidationError ? message : 'Internal Server Error',
+    });
+  }
+};

--- a/packages/cdk/lambda/repository.ts
+++ b/packages/cdk/lambda/repository.ts
@@ -355,6 +355,8 @@ export const batchCreateMessages = async (
         usecase: m.usecase,
         llmType: m.llmType ?? '',
         metadata: m.metadata,
+        ...(m.agentRunId && { agentRunId: m.agentRunId }),
+        ...(m.agentId && { agentId: m.agentId }),
       };
     }
   );

--- a/packages/cdk/lambda/repositoryAgentObservability.ts
+++ b/packages/cdk/lambda/repositoryAgentObservability.ts
@@ -1,0 +1,143 @@
+import {
+  AgentCoreLlmCallEvent,
+  CompleteAgentRunRequest,
+  StartAgentRunRequest,
+} from 'generative-ai-use-cases';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import {
+  BatchWriteCommand,
+  DynamoDBDocumentClient,
+  PutCommand,
+  UpdateCommand,
+} from '@aws-sdk/lib-dynamodb';
+
+const AGENT_OBSERVABILITY_TABLE_NAME: string =
+  process.env.AGENT_OBSERVABILITY_TABLE_NAME!;
+const dynamoDb = new DynamoDBClient({});
+const dynamoDbDocument = DynamoDBDocumentClient.from(dynamoDb);
+
+type RunBase = {
+  tenant_id: string;
+  environment_id: string;
+  user_id: string;
+};
+
+const definedEntries = (item: Record<string, unknown>) =>
+  Object.fromEntries(
+    Object.entries(item).filter(([, value]) => value !== undefined)
+  );
+
+export const startAgentRun = async (
+  req: StartAgentRunRequest,
+  runBase: RunBase
+): Promise<void> => {
+  await dynamoDbDocument.send(
+    new PutCommand({
+      TableName: AGENT_OBSERVABILITY_TABLE_NAME,
+      Item: definedEntries({
+        agent_run_id: req.agent_run_id,
+        sk: 'run',
+        record_type: 'run',
+        agent_id: req.agent_id,
+        tenant_id: runBase.tenant_id,
+        environment_id: runBase.environment_id,
+        user_id: runBase.user_id,
+        session_id: req.session_id,
+        chat_id: req.chat_id,
+        started_at: req.started_at,
+        status: 'running',
+        error_type: null,
+        GSI1PK: req.agent_id,
+        GSI1SK: `${req.started_at}#${req.agent_run_id}`,
+      }),
+    })
+  );
+};
+
+export const completeAgentRun = async (
+  req: CompleteAgentRunRequest,
+  runBase: RunBase
+): Promise<void> => {
+  const startedAt = req.started_at ?? req.ended_at;
+
+  await dynamoDbDocument.send(
+    new UpdateCommand({
+      TableName: AGENT_OBSERVABILITY_TABLE_NAME,
+      Key: {
+        agent_run_id: req.agent_run_id,
+        sk: 'run',
+      },
+      UpdateExpression: `
+        SET
+          record_type = if_not_exists(record_type, :recordType),
+          agent_id = if_not_exists(agent_id, :agentId),
+          tenant_id = if_not_exists(tenant_id, :tenantId),
+          environment_id = if_not_exists(environment_id, :environmentId),
+          user_id = if_not_exists(user_id, :userId),
+          session_id = :sessionId,
+          chat_id = :chatId,
+          user_message_id = :userMessageId,
+          assistant_message_id = :assistantMessageId,
+          started_at = if_not_exists(started_at, :startedAt),
+          ended_at = :endedAt,
+          #status = :status,
+          error_type = :errorType,
+          GSI1PK = if_not_exists(GSI1PK, :agentId),
+          GSI1SK = if_not_exists(GSI1SK, :gsi1sk)
+      `,
+      ExpressionAttributeNames: {
+        '#status': 'status',
+      },
+      ExpressionAttributeValues: {
+        ':recordType': 'run',
+        ':agentId': req.agent_id,
+        ':tenantId': runBase.tenant_id,
+        ':environmentId': runBase.environment_id,
+        ':userId': runBase.user_id,
+        ':sessionId': req.session_id ?? null,
+        ':chatId': req.chat_id ?? null,
+        ':userMessageId': req.user_message_id ?? null,
+        ':assistantMessageId': req.assistant_message_id ?? null,
+        ':startedAt': startedAt,
+        ':endedAt': req.ended_at,
+        ':status': req.status,
+        ':errorType': req.error_type ?? null,
+        ':gsi1sk': `${startedAt}#${req.agent_run_id}`,
+      },
+    })
+  );
+};
+
+export const appendAgentLlmCalls = async (
+  agentRunId: string,
+  llmCalls: AgentCoreLlmCallEvent[]
+): Promise<void> => {
+  const chunkSize = 25;
+  for (let i = 0; i < llmCalls.length; i += chunkSize) {
+    const chunk = llmCalls.slice(i, i + chunkSize);
+    const res = await dynamoDbDocument.send(
+      new BatchWriteCommand({
+        RequestItems: {
+          [AGENT_OBSERVABILITY_TABLE_NAME]: chunk.map((llmCall) => ({
+            PutRequest: {
+              Item: definedEntries({
+                ...llmCall,
+                agent_run_id: agentRunId,
+                sk: `llm_call#${llmCall.created_at}#${llmCall.llm_call_id}`,
+                record_type: 'llm_call',
+                GSI1PK: llmCall.agent_id,
+                GSI1SK: `${llmCall.created_at}#${agentRunId}`,
+              }),
+            },
+          })),
+        },
+      })
+    );
+    if (
+      res.UnprocessedItems?.[AGENT_OBSERVABILITY_TABLE_NAME] &&
+      res.UnprocessedItems[AGENT_OBSERVABILITY_TABLE_NAME].length > 0
+    ) {
+      throw new Error('Some llm_call items were not processed');
+    }
+  }
+};

--- a/packages/cdk/lib/construct/api.ts
+++ b/packages/cdk/lib/construct/api.ts
@@ -76,6 +76,7 @@ export interface BackendApiProps {
   readonly userPoolClient: UserPoolClient;
   readonly table: Table;
   readonly statsTable: Table;
+  readonly agentObservabilityTable: Table;
   readonly knowledgeBaseId?: string;
   readonly agents?: string;
   readonly guardrailIdentify?: string;
@@ -691,6 +692,27 @@ export class Api extends Construct {
     table.grantReadWriteData(createMessagesFunction);
     props.statsTable.grantReadWriteData(createMessagesFunction);
 
+    const agentObservabilityFunction = new NodejsFunction(
+      this,
+      'AgentObservability',
+      {
+        runtime: LAMBDA_RUNTIME_NODEJS,
+        entry: './lambda/agentObservability.ts',
+        timeout: Duration.minutes(15),
+        environment: {
+          AGENT_OBSERVABILITY_TABLE_NAME:
+            props.agentObservabilityTable.tableName,
+          TENANT_ID: Stack.of(this).account,
+          ENVIRONMENT_ID: Stack.of(this).stackName,
+        },
+        vpc,
+        securityGroups,
+      }
+    );
+    props.agentObservabilityTable.grantReadWriteData(
+      agentObservabilityFunction
+    );
+
     const updateChatTitleFunction = new NodejsFunction(
       this,
       'UpdateChatTitle',
@@ -1033,6 +1055,19 @@ export class Api extends Construct {
     messagesResource.addMethod(
       'POST',
       new LambdaIntegration(createMessagesFunction),
+      commonAuthorizerProps
+    );
+
+    const agentObservabilityResource = api.root.addResource(
+      'agent-observability'
+    );
+    const agentObservabilityOperationResource =
+      agentObservabilityResource.addResource('{operation}');
+
+    // POST: /agent-observability/{operation}
+    agentObservabilityOperationResource.addMethod(
+      'POST',
+      new LambdaIntegration(agentObservabilityFunction),
       commonAuthorizerProps
     );
 

--- a/packages/cdk/lib/construct/database.ts
+++ b/packages/cdk/lib/construct/database.ts
@@ -10,6 +10,7 @@ import {
 export class Database extends Construct {
   public readonly table: ddb.Table;
   public readonly statsTable: ddb.Table;
+  public readonly agentObservabilityTable: ddb.Table;
   public readonly feedbackIndexName: string;
 
   constructor(scope: Construct, id: string) {
@@ -75,8 +76,50 @@ export class Database extends Construct {
       BACKUP_PROTECTED_TAG.value
     );
 
+    const agentObservabilityTable = new ddb.Table(
+      this,
+      'AgentObservabilityTable',
+      {
+        partitionKey: {
+          name: 'agent_run_id',
+          type: ddb.AttributeType.STRING,
+        },
+        sortKey: {
+          name: 'sk',
+          type: ddb.AttributeType.STRING,
+        },
+        billingMode: ddb.BillingMode.PAY_PER_REQUEST,
+        pointInTimeRecoverySpecification: {
+          pointInTimeRecoveryEnabled: true,
+        },
+        deletionProtection: true,
+        removalPolicy: cdk.RemovalPolicy.RETAIN,
+      }
+    );
+    agentObservabilityTable.node.addMetadata(
+      BACKUP_PROTECTED_METADATA_KEY,
+      BACKUP_PROTECTED_METADATA_VALUE
+    );
+    cdk.Tags.of(agentObservabilityTable).add(
+      BACKUP_PROTECTED_TAG.key,
+      BACKUP_PROTECTED_TAG.value
+    );
+
+    agentObservabilityTable.addGlobalSecondaryIndex({
+      indexName: 'AgentIdIndex',
+      partitionKey: {
+        name: 'GSI1PK',
+        type: ddb.AttributeType.STRING,
+      },
+      sortKey: {
+        name: 'GSI1SK',
+        type: ddb.AttributeType.STRING,
+      },
+    });
+
     this.table = table;
     this.statsTable = statsTable;
+    this.agentObservabilityTable = agentObservabilityTable;
     this.feedbackIndexName = feedbackIndexName;
   }
 }

--- a/packages/cdk/lib/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/generative-ai-use-cases-stack.ts
@@ -179,6 +179,7 @@ export class GenerativeAiUseCasesStack extends Stack {
       userPoolClient: auth.client,
       table: database.table,
       statsTable: database.statsTable,
+      agentObservabilityTable: database.agentObservabilityTable,
       knowledgeBaseId: params.ragKnowledgeBaseId || props.knowledgeBaseId,
       agents: agentsJson,
       guardrailIdentify: props.guardrailIdentifier,
@@ -509,7 +510,11 @@ export class GenerativeAiUseCasesStack extends Stack {
     });
 
     // Phase 4: DynamoDB PITR Export (daily at JST 04:30, UseCaseBuilder is conditional)
-    const ddbTables: dynamodb.ITable[] = [database.table, database.statsTable];
+    const ddbTables: dynamodb.ITable[] = [
+      database.table,
+      database.statsTable,
+      database.agentObservabilityTable,
+    ];
     if (useCaseBuilder) {
       ddbTables.push(useCaseBuilder.useCaseBuilderTable);
     }

--- a/packages/cdk/test/lambda/agentObservability.test.ts
+++ b/packages/cdk/test/lambda/agentObservability.test.ts
@@ -1,0 +1,160 @@
+import { APIGatewayProxyEvent } from 'aws-lambda';
+import { handler } from '../../lambda/agentObservability';
+import {
+  appendAgentLlmCalls,
+  completeAgentRun,
+  startAgentRun,
+} from '../../lambda/repositoryAgentObservability';
+
+jest.mock('../../lambda/repositoryAgentObservability');
+
+const mockedStartAgentRun = startAgentRun as jest.MockedFunction<
+  typeof startAgentRun
+>;
+const mockedCompleteAgentRun = completeAgentRun as jest.MockedFunction<
+  typeof completeAgentRun
+>;
+const mockedAppendAgentLlmCalls = appendAgentLlmCalls as jest.MockedFunction<
+  typeof appendAgentLlmCalls
+>;
+
+const originalEnv = process.env;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+  process.env = {
+    ...originalEnv,
+    TENANT_ID: '123456789012',
+    ENVIRONMENT_ID: 'TestStack',
+  };
+});
+
+afterAll(() => {
+  process.env = originalEnv;
+});
+
+const createEvent = (
+  operation: string,
+  body: Record<string, unknown>
+): APIGatewayProxyEvent =>
+  ({
+    body: JSON.stringify(body),
+    pathParameters: { operation },
+    requestContext: {
+      authorizer: {
+        claims: {
+          'cognito:username': 'test-user',
+        },
+      },
+    },
+  }) as unknown as APIGatewayProxyEvent;
+
+describe('agentObservability Lambda handler', () => {
+  test('starts an agent run', async () => {
+    const req = {
+      agent_run_id: 'run-1',
+      agent_id: 'medical-reimbursement-qa',
+      session_id: 'session-1',
+      started_at: '2026-06-04T00:00:00.000Z',
+    };
+
+    const result = await handler(createEvent('start-run', req));
+
+    expect(result.statusCode).toBe(200);
+    expect(mockedStartAgentRun).toHaveBeenCalledWith(req, {
+      tenant_id: '123456789012',
+      environment_id: 'TestStack',
+      user_id: 'test-user',
+    });
+  });
+
+  test('completes an agent run', async () => {
+    const req = {
+      agent_run_id: 'run-1',
+      agent_id: 'medical-reimbursement-qa',
+      session_id: 'session-1',
+      chat_id: 'chat#1',
+      user_message_id: 'user-message-1',
+      assistant_message_id: 'assistant-message-1',
+      started_at: '2026-06-04T00:00:00.000Z',
+      ended_at: '2026-06-04T00:00:01.000Z',
+      status: 'succeeded',
+      error_type: null,
+    };
+
+    const result = await handler(createEvent('complete-run', req));
+
+    expect(result.statusCode).toBe(200);
+    expect(mockedCompleteAgentRun).toHaveBeenCalledWith(req, {
+      tenant_id: '123456789012',
+      environment_id: 'TestStack',
+      user_id: 'test-user',
+    });
+  });
+
+  test('appends llm_call events', async () => {
+    const llmCall = {
+      llm_call_id: 'call-1',
+      agent_run_id: 'run-1',
+      agent_id: 'medical-reimbursement-qa',
+      model_id: 'jp.anthropic.claude-sonnet-4-5',
+      input_tokens: 10,
+      output_tokens: 5,
+      total_tokens: 15,
+      cache_read_input_tokens: 0,
+      cache_write_input_tokens: 0,
+      latency_ms: 100,
+      status: 'succeeded',
+      error_type: null,
+      created_at: '2026-06-04T00:00:00.000Z',
+    };
+
+    const result = await handler(
+      createEvent('llm-calls', {
+        agent_run_id: 'run-1',
+        llm_calls: [llmCall],
+      })
+    );
+
+    expect(result.statusCode).toBe(200);
+    expect(mockedAppendAgentLlmCalls).toHaveBeenCalledWith('run-1', [llmCall]);
+  });
+
+  test('returns 400 for invalid complete status', async () => {
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+
+    const result = await handler(
+      createEvent('complete-run', {
+        agent_run_id: 'run-1',
+        agent_id: 'medical-reimbursement-qa',
+        ended_at: '2026-06-04T00:00:01.000Z',
+        status: 'running',
+      })
+    );
+
+    expect(result.statusCode).toBe(400);
+    expect(mockedCompleteAgentRun).not.toHaveBeenCalled();
+
+    consoleLogSpy.mockRestore();
+  });
+
+  test('returns 500 when repository write fails', async () => {
+    const consoleLogSpy = jest.spyOn(console, 'log').mockImplementation();
+    mockedStartAgentRun.mockRejectedValue(new Error('ddb unavailable'));
+
+    const result = await handler(
+      createEvent('start-run', {
+        agent_run_id: 'run-1',
+        agent_id: 'medical-reimbursement-qa',
+        started_at: '2026-06-04T00:00:00.000Z',
+      })
+    );
+
+    expect(result.statusCode).toBe(500);
+    expect(JSON.parse(result.body)).toEqual({
+      message: 'Internal Server Error',
+    });
+
+    consoleLogSpy.mockRestore();
+  });
+});

--- a/packages/cdk/test/lambda/repositoryAgentObservability.test.ts
+++ b/packages/cdk/test/lambda/repositoryAgentObservability.test.ts
@@ -1,0 +1,240 @@
+import { AgentCoreLlmCallEvent } from 'generative-ai-use-cases';
+
+const sendMock = jest.fn();
+
+jest.mock('@aws-sdk/client-dynamodb', () => ({
+  DynamoDBClient: jest.fn(),
+}));
+
+jest.mock('@aws-sdk/lib-dynamodb', () => {
+  class PutCommand {
+    input: unknown;
+    constructor(input: unknown) {
+      this.input = input;
+    }
+  }
+  class UpdateCommand {
+    input: unknown;
+    constructor(input: unknown) {
+      this.input = input;
+    }
+  }
+  class BatchWriteCommand {
+    input: unknown;
+    constructor(input: unknown) {
+      this.input = input;
+    }
+  }
+
+  return {
+    DynamoDBDocumentClient: {
+      from: jest.fn(() => ({
+        send: sendMock,
+      })),
+    },
+    PutCommand,
+    UpdateCommand,
+    BatchWriteCommand,
+  };
+});
+
+describe('repositoryAgentObservability', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    sendMock.mockReset();
+    sendMock.mockResolvedValue({});
+    process.env = {
+      ...originalEnv,
+      AGENT_OBSERVABILITY_TABLE_NAME: 'AgentObservabilityTable',
+    };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  const importRepository = async () => {
+    return await import('../../lambda/repositoryAgentObservability');
+  };
+
+  test('startAgentRun writes the run item shape', async () => {
+    const { startAgentRun } = await importRepository();
+
+    await startAgentRun(
+      {
+        agent_run_id: 'run-1',
+        agent_id: 'medical-reimbursement-qa',
+        session_id: 'session-1',
+        chat_id: 'chat-1',
+        started_at: '2026-06-04T00:00:00.000Z',
+      },
+      {
+        tenant_id: '123456789012',
+        environment_id: 'TestStack',
+        user_id: 'user-1',
+      }
+    );
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(sendMock.mock.calls[0][0].input).toEqual({
+      TableName: 'AgentObservabilityTable',
+      Item: {
+        agent_run_id: 'run-1',
+        sk: 'run',
+        record_type: 'run',
+        agent_id: 'medical-reimbursement-qa',
+        tenant_id: '123456789012',
+        environment_id: 'TestStack',
+        user_id: 'user-1',
+        session_id: 'session-1',
+        chat_id: 'chat-1',
+        started_at: '2026-06-04T00:00:00.000Z',
+        status: 'running',
+        error_type: null,
+        GSI1PK: 'medical-reimbursement-qa',
+        GSI1SK: '2026-06-04T00:00:00.000Z#run-1',
+      },
+    });
+  });
+
+  test('completeAgentRun updates run status and message links', async () => {
+    const { completeAgentRun } = await importRepository();
+
+    await completeAgentRun(
+      {
+        agent_run_id: 'run-1',
+        agent_id: 'medical-reimbursement-qa',
+        session_id: 'session-1',
+        chat_id: 'chat-1',
+        user_message_id: 'user-message-1',
+        assistant_message_id: 'assistant-message-1',
+        started_at: '2026-06-04T00:00:00.000Z',
+        ended_at: '2026-06-04T00:00:01.000Z',
+        status: 'succeeded',
+        error_type: null,
+      },
+      {
+        tenant_id: '123456789012',
+        environment_id: 'TestStack',
+        user_id: 'user-1',
+      }
+    );
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(sendMock.mock.calls[0][0].input).toMatchObject({
+      TableName: 'AgentObservabilityTable',
+      Key: {
+        agent_run_id: 'run-1',
+        sk: 'run',
+      },
+      ExpressionAttributeNames: {
+        '#status': 'status',
+      },
+      ExpressionAttributeValues: {
+        ':recordType': 'run',
+        ':agentId': 'medical-reimbursement-qa',
+        ':tenantId': '123456789012',
+        ':environmentId': 'TestStack',
+        ':userId': 'user-1',
+        ':sessionId': 'session-1',
+        ':chatId': 'chat-1',
+        ':userMessageId': 'user-message-1',
+        ':assistantMessageId': 'assistant-message-1',
+        ':startedAt': '2026-06-04T00:00:00.000Z',
+        ':endedAt': '2026-06-04T00:00:01.000Z',
+        ':status': 'succeeded',
+        ':errorType': null,
+        ':gsi1sk': '2026-06-04T00:00:00.000Z#run-1',
+      },
+    });
+    expect(sendMock.mock.calls[0][0].input.UpdateExpression).toContain(
+      'user_message_id = :userMessageId'
+    );
+    expect(sendMock.mock.calls[0][0].input.UpdateExpression).toContain(
+      'assistant_message_id = :assistantMessageId'
+    );
+    expect(sendMock.mock.calls[0][0].input.UpdateExpression).toContain(
+      '#status = :status'
+    );
+  });
+
+  test('appendAgentLlmCalls writes llm_call items with the contract sort key', async () => {
+    const { appendAgentLlmCalls } = await importRepository();
+    const llmCall: AgentCoreLlmCallEvent = {
+      llm_call_id: 'call-1',
+      agent_run_id: 'run-1',
+      agent_id: 'medical-reimbursement-qa',
+      model_id: 'jp.anthropic.claude-sonnet-4-5',
+      input_tokens: 10,
+      output_tokens: 5,
+      total_tokens: 15,
+      cache_read_input_tokens: 0,
+      cache_write_input_tokens: 0,
+      latency_ms: 100,
+      status: 'succeeded',
+      error_type: null,
+      created_at: '2026-06-04T00:00:00.000Z',
+    };
+
+    await appendAgentLlmCalls('run-1', [llmCall]);
+
+    expect(sendMock).toHaveBeenCalledTimes(1);
+    expect(sendMock.mock.calls[0][0].input).toEqual({
+      RequestItems: {
+        AgentObservabilityTable: [
+          {
+            PutRequest: {
+              Item: {
+                ...llmCall,
+                agent_run_id: 'run-1',
+                sk: 'llm_call#2026-06-04T00:00:00.000Z#call-1',
+                record_type: 'llm_call',
+                GSI1PK: 'medical-reimbursement-qa',
+                GSI1SK: '2026-06-04T00:00:00.000Z#run-1',
+              },
+            },
+          },
+        ],
+      },
+    });
+  });
+
+  test('appendAgentLlmCalls throws when DynamoDB returns unprocessed items', async () => {
+    const { appendAgentLlmCalls } = await importRepository();
+    sendMock.mockResolvedValue({
+      UnprocessedItems: {
+        AgentObservabilityTable: [
+          {
+            PutRequest: {
+              Item: {
+                agent_run_id: 'run-1',
+              },
+            },
+          },
+        ],
+      },
+    });
+
+    await expect(
+      appendAgentLlmCalls('run-1', [
+        {
+          llm_call_id: 'call-1',
+          agent_run_id: 'run-1',
+          agent_id: 'medical-reimbursement-qa',
+          model_id: 'jp.anthropic.claude-sonnet-4-5',
+          input_tokens: 10,
+          output_tokens: 5,
+          total_tokens: 15,
+          cache_read_input_tokens: 0,
+          cache_write_input_tokens: 0,
+          latency_ms: 100,
+          status: 'succeeded',
+          error_type: null,
+          created_at: '2026-06-04T00:00:00.000Z',
+        },
+      ])
+    ).rejects.toThrow('Some llm_call items were not processed');
+  });
+});

--- a/packages/types/src/agent-builder.d.ts
+++ b/packages/types/src/agent-builder.d.ts
@@ -186,4 +186,5 @@ export type AgentCoreRuntimeRequest = {
   mcpServers?: MCPServerReference[]; // Changed to string array
   agentId?: string; // Agent ID for logging/tracking
   codeExecutionEnabled?: boolean; // Code execution setting
+  agentRunId?: string; // Observability: agent run id (cross-repo observability contract §3.1)
 };

--- a/packages/types/src/agent-core.d.ts
+++ b/packages/types/src/agent-core.d.ts
@@ -20,11 +20,63 @@ export type AppNotification = {
   payload: Record<string, unknown>;
 };
 
+// LLM call observability event (custom event yielded by the agent backend).
+// Collected by the frontend for observability; not shown in the UI.
+// Contract (single source of truth): cross-repo observability contract §3.2 (llm_call event schema).
+export type AgentCoreLlmCallEvent = {
+  llm_call_id: string;
+  agent_run_id: string;
+  agent_id?: string;
+  model_id: string;
+  input_tokens?: number;
+  output_tokens?: number;
+  total_tokens?: number;
+  cache_read_input_tokens?: number;
+  cache_write_input_tokens?: number;
+  latency_ms?: number | null;
+  status: 'succeeded' | 'failed'; // MVP: always 'succeeded' (see cross-repo observability contract §3.2)
+  error_type?: string | null;
+  created_at: string; // ISO8601 UTC with milliseconds, trailing Z
+};
+
+export type AgentRunStatus = 'running' | 'succeeded' | 'failed';
+
+export type StartAgentRunRequest = {
+  agent_run_id: string;
+  agent_id: string;
+  session_id?: string;
+  chat_id?: string;
+  started_at: string;
+};
+
+export type CompleteAgentRunRequest = {
+  agent_run_id: string;
+  agent_id: string;
+  session_id?: string;
+  chat_id?: string;
+  user_message_id?: string;
+  assistant_message_id?: string;
+  started_at?: string;
+  ended_at: string;
+  status: Exclude<AgentRunStatus, 'running'>;
+  error_type?: string | null;
+};
+
+export type AppendAgentLlmCallsRequest = {
+  agent_run_id: string;
+  llm_calls: AgentCoreLlmCallEvent[];
+};
+
+export type AgentObservabilityResponse = {
+  ok: boolean;
+};
+
 // AgentCore Runtime Request (extended from Strands with additional fields)
 export type AgentCoreRequest = StrandsRequest & {
   mcp_servers?: string[]; // Changed to string array
   session_id?: string;
   code_execution_enabled?: boolean;
+  agent_run_id?: string; // Observability: agent run id (cross-repo observability contract §3.1)
 };
 
 export type AgentCoreStreamResponse = StrandsStreamEvent;
@@ -285,6 +337,7 @@ export type StrandsRedactContentEvent = {
 // Main stream event type (matches the Python StreamEvent TypedDict)
 export type StrandsStreamEvent = {
   appNotification?: AppNotification;
+  llm_call?: AgentCoreLlmCallEvent; // Observability custom event (cross-repo observability contract §3.2)
   contentBlockDelta?: StrandsContentBlockDeltaEvent;
   contentBlockStart?: StrandsContentBlockStartEvent;
   contentBlockStop?: StrandsContentBlockStopEvent;

--- a/packages/types/src/message.d.ts
+++ b/packages/types/src/message.d.ts
@@ -48,6 +48,8 @@ export type UnrecordedMessage = {
   extraData?: ExtraData[];
   llmType?: string;
   metadata?: Metadata;
+  agentRunId?: string;
+  agentId?: string;
 };
 
 export type ExtraData = {

--- a/packages/web/src/hooks/useAgentCore.ts
+++ b/packages/web/src/hooks/useAgentCore.ts
@@ -56,7 +56,8 @@ const useAgentCore = (id: string) => {
     mcpServers?: string[],
     agentId?: string,
     modelId?: string, // Add modelId parameter
-    codeExecutionEnabled?: boolean // Add codeExecutionEnabled parameter
+    codeExecutionEnabled?: boolean, // Add codeExecutionEnabled parameter
+    agentRunId?: string // Observability: agent run id (cross-repo observability contract §3.1)
   ) => {
     // Use provided modelId or fall back to current model ID
     const targetModelId = modelId || getModelId();
@@ -111,6 +112,7 @@ const useAgentCore = (id: string) => {
       mcpServers,
       agentId,
       codeExecutionEnabled,
+      agentRunId,
     };
 
     await postMessage(request);

--- a/packages/web/src/hooks/useAgentCoreApi.ts
+++ b/packages/web/src/hooks/useAgentCoreApi.ts
@@ -11,6 +11,7 @@ import { fetchAuthSession } from 'aws-amplify/auth';
 import { CognitoIdentityClient } from '@aws-sdk/client-cognito-identity';
 import {
   AgentCoreRequest,
+  AgentCoreLlmCallEvent,
   Model,
   UnrecordedMessage,
   StrandsContentBlock,
@@ -21,6 +22,11 @@ import {
   convertToStrandsFormat,
   convertFilesToStrandsContentBlocks,
 } from '../utils/strandsUtils';
+import {
+  attachAgentObservabilityToMessages,
+  saveAgentObservabilityCompletionBestEffort,
+  startAgentRunBestEffort,
+} from '../utils/agentObservabilityUtils';
 import { getRegionFromArn } from '../utils/arnUtils';
 import useAppNotificationStore from './useAppNotificationStore';
 
@@ -44,14 +50,26 @@ const useAgentCoreApi = (id: string) => {
     replaceMessages,
     setPredictedTitle,
   } = useChat(id);
-  const { createMessages } = useChatApi();
+  const {
+    createMessages,
+    startAgentRun,
+    completeAgentRun,
+    appendAgentLlmCalls,
+  } = useChatApi();
 
   // Create a stream processor instance that maintains state across chunks
   const streamProcessor = useCallback(() => new StrandsStreamProcessor(), []);
 
-  // Process a chunk of Strands event data and add it to the assistant message
+  // Process a chunk of Strands event data and add it to the assistant message.
+  // onLlmCall collects observability llm_call events (cross-repo observability contract §3.2) without
+  // affecting the rendered message.
   const processChunk = useCallback(
-    (eventText: string, model: Model, processor: StrandsStreamProcessor) => {
+    (
+      eventText: string,
+      model: Model,
+      processor: StrandsStreamProcessor,
+      onLlmCall?: (llmCall: AgentCoreLlmCallEvent) => void
+    ) => {
       const processed = processor.processEvent(eventText);
 
       if (processed) {
@@ -59,6 +77,9 @@ const useAgentCoreApi = (id: string) => {
           useAppNotificationStore
             .getState()
             .pushNotification(processed.appNotification);
+        }
+        if (processed.llmCall && onLlmCall) {
+          onLlmCall(processed.llmCall);
         }
         if (processed.text || processed.trace || processed.metadata) {
           addChunkToAssistantMessage(
@@ -85,11 +106,27 @@ const useAgentCoreApi = (id: string) => {
     async (req: AgentCoreRuntimeRequest) => {
       setLoading(true);
       let isFirstChunk = true;
+      const startedAt = new Date().toISOString();
 
       // Create a new stream processor for this request
       const processor = streamProcessor();
 
+      // Observability (cross-repo observability contract §3.2): collect llm_call events from the stream.
+      // PR1 only collects and logs them; persistence via GenU API is added in PR2.
+      const llmCalls: AgentCoreLlmCallEvent[] = [];
+      const collectLlmCall = (llmCall: AgentCoreLlmCallEvent) => {
+        llmCalls.push(llmCall);
+      };
+
       try {
+        await startAgentRunBestEffort({
+          apis: { startAgentRun },
+          agentRunId: req.agentRunId,
+          agentId: req.agentId,
+          sessionId: req.sessionId,
+          startedAt,
+        });
+
         pushMessage('user', req.prompt);
         pushMessage('assistant', 'Thinking...');
 
@@ -159,6 +196,7 @@ const useAgentCoreApi = (id: string) => {
           ...(req.userId && { user_id: req.userId }),
           ...(req.mcpServers && { mcp_servers: req.mcpServers }),
           ...(req.agentId && { agent_id: req.agentId }),
+          ...(req.agentRunId && { agent_run_id: req.agentRunId }),
           ...(req.sessionId && { session_id: req.sessionId }),
           ...(req.codeExecutionEnabled !== undefined && {
             code_execution_enabled: req.codeExecutionEnabled,
@@ -217,7 +255,12 @@ const useAgentCoreApi = (id: string) => {
                   }
 
                   if (processedText.trim()) {
-                    processChunk(processedText, req.model, processor);
+                    processChunk(
+                      processedText,
+                      req.model,
+                      processor,
+                      collectLlmCall
+                    );
                   }
                 }
               }
@@ -230,7 +273,12 @@ const useAgentCoreApi = (id: string) => {
                 processedText = buffer.substring(6);
               }
               if (processedText.trim()) {
-                processChunk(processedText, req.model, processor);
+                processChunk(
+                  processedText,
+                  req.model,
+                  processor,
+                  collectLlmCall
+                );
               }
             }
           } else {
@@ -243,7 +291,8 @@ const useAgentCoreApi = (id: string) => {
             processChunk(
               JSON.stringify(response, null, 2),
               req.model,
-              processor
+              processor,
+              collectLlmCall
             );
           }
         } else {
@@ -253,28 +302,68 @@ const useAgentCoreApi = (id: string) => {
             pushMessage('assistant', '');
             isFirstChunk = false;
           }
-          processChunk(JSON.stringify(response, null, 2), req.model, processor);
+          processChunk(
+            JSON.stringify(response, null, 2),
+            req.model,
+            processor,
+            collectLlmCall
+          );
         }
+
+        // Observability (PR1): verify llm_call events were collected from the
+        // stream. Persistence via GenU API is added in PR2 (cross-repo observability contract §4 PR2).
+        console.log(
+          `[observability] collected ${llmCalls.length} llm_call event(s) for agent_run_id=${req.agentRunId ?? '(none)'}`,
+          llmCalls
+        );
 
         // Save chat history
         const chatId = await createChatIfNotExist();
         await setPredictedTitle();
-        const toBeRecordedMessages = addMessageIdsToUnrecordedMessages();
+        const toBeRecordedMessages = attachAgentObservabilityToMessages(
+          addMessageIdsToUnrecordedMessages(),
+          req.agentRunId,
+          req.agentId
+        );
         const { messages } = await createMessages(chatId, {
           messages: toBeRecordedMessages,
         });
         replaceMessages(messages);
+
+        await saveAgentObservabilityCompletionBestEffort({
+          apis: { appendAgentLlmCalls, completeAgentRun },
+          agentRunId: req.agentRunId,
+          agentId: req.agentId,
+          sessionId: req.sessionId,
+          chatId,
+          startedAt,
+          endedAt: new Date().toISOString(),
+          status: 'succeeded',
+          errorType: null,
+          llmCalls,
+          messages: toBeRecordedMessages,
+        });
       } catch (error) {
         console.error('Error invoking AgentCore Runtime:', error);
         const errorMessage =
           error instanceof Error ? error.message : 'Unknown error occurred';
-        // processChunk(`Error: ${errorMessage}`, req.model, processor);
+        // processChunk(`Error: ${errorMessage}`, req.model, processor, collectLlmCall);
         addChunkToAssistantMessage(
           errorMessage,
           undefined,
           req.model,
           undefined
         );
+        await saveAgentObservabilityCompletionBestEffort({
+          apis: { appendAgentLlmCalls, completeAgentRun },
+          agentRunId: req.agentRunId,
+          agentId: req.agentId,
+          sessionId: req.sessionId,
+          startedAt,
+          endedAt: new Date().toISOString(),
+          status: 'failed',
+          errorType: error instanceof Error ? error.name : 'UnknownError',
+        });
       } finally {
         setLoading(false);
       }
@@ -288,6 +377,9 @@ const useAgentCoreApi = (id: string) => {
       setPredictedTitle,
       addMessageIdsToUnrecordedMessages,
       createMessages,
+      startAgentRun,
+      completeAgentRun,
+      appendAgentLlmCalls,
       replaceMessages,
       popMessage,
       processChunk,

--- a/packages/web/src/hooks/useAgentCoreApi.ts
+++ b/packages/web/src/hooks/useAgentCoreApi.ts
@@ -203,11 +203,6 @@ const useAgentCoreApi = (id: string) => {
           }),
         };
 
-        console.log(
-          'AgentCoreRequest payload:',
-          JSON.stringify(agentCoreRequest, null, 2)
-        );
-
         const commandInput: InvokeAgentRuntimeCommandInput = {
           agentRuntimeArn: req.agentRuntimeArn,
           ...(req.sessionId ? { runtimeSessionId: req.sessionId } : {}),
@@ -310,13 +305,6 @@ const useAgentCoreApi = (id: string) => {
           );
         }
 
-        // Observability (PR1): verify llm_call events were collected from the
-        // stream. Persistence via GenU API is added in PR2 (cross-repo observability contract §4 PR2).
-        console.log(
-          `[observability] collected ${llmCalls.length} llm_call event(s) for agent_run_id=${req.agentRunId ?? '(none)'}`,
-          llmCalls
-        );
-
         // Save chat history
         const chatId = await createChatIfNotExist();
         await setPredictedTitle();
@@ -363,6 +351,9 @@ const useAgentCoreApi = (id: string) => {
           endedAt: new Date().toISOString(),
           status: 'failed',
           errorType: error instanceof Error ? error.name : 'UnknownError',
+          // Persist any llm_call events collected before the failure (their
+          // usage is real); the run itself is still recorded as failed.
+          llmCalls,
         });
       } finally {
         setLoading(false);

--- a/packages/web/src/hooks/useChatApi.ts
+++ b/packages/web/src/hooks/useChatApi.ts
@@ -19,6 +19,10 @@ import {
   FindShareIdResponse,
   GetSharedChatResponse,
   Chat,
+  AgentObservabilityResponse,
+  AppendAgentLlmCallsRequest,
+  CompleteAgentRunRequest,
+  StartAgentRunRequest,
 } from 'generative-ai-use-cases';
 import {
   LambdaClient,
@@ -45,6 +49,24 @@ const useChatApi = () => {
     ): Promise<CreateMessagesResponse> => {
       const chatId = decomposeId(_chatId);
       const res = await http.post(`chats/${chatId}/messages`, req);
+      return res.data;
+    },
+    startAgentRun: async (
+      req: StartAgentRunRequest
+    ): Promise<AgentObservabilityResponse> => {
+      const res = await http.post('agent-observability/start-run', req);
+      return res.data;
+    },
+    completeAgentRun: async (
+      req: CompleteAgentRunRequest
+    ): Promise<AgentObservabilityResponse> => {
+      const res = await http.post('agent-observability/complete-run', req);
+      return res.data;
+    },
+    appendAgentLlmCalls: async (
+      req: AppendAgentLlmCallsRequest
+    ): Promise<AgentObservabilityResponse> => {
+      const res = await http.post('agent-observability/llm-calls', req);
       return res.data;
     },
     deleteChat: async (chatId: string) => {

--- a/packages/web/src/pages/AgentCorePage.tsx
+++ b/packages/web/src/pages/AgentCorePage.tsx
@@ -182,13 +182,25 @@ const AgentCorePage: React.FC = () => {
           ? uploadedFileObjects.map((uploadedFile) => uploadedFile.file)
           : undefined;
 
+      // Observability (cross-repo observability contract §3.1): generate a new agent_run_id per send.
+      // agent_id is the runtime name (URL param). selectedArn is only set after
+      // agentName resolves to a runtime, so decoding agentName is reliable here.
+      const agentRunId = uuidv4();
+      const runtimeName = agentName ? decodeURIComponent(agentName) : undefined;
+
       // Invoke agent runtime with content and files
       invokeAgentRuntime(
         selectedArn,
         sessionId,
         content,
         'DEFAULT',
-        filesToSend
+        filesToSend,
+        undefined, // userId
+        undefined, // mcpServers
+        runtimeName, // agentId = runtime name (observability agent_id)
+        undefined, // modelId
+        undefined, // codeExecutionEnabled
+        agentRunId // observability agent_run_id
       );
       setContent('');
       clearFiles();
@@ -206,6 +218,7 @@ const AgentCorePage: React.FC = () => {
     sessionId,
     clearFiles,
     uploadedFiles,
+    agentName,
   ]);
 
   // Handle reset

--- a/packages/web/src/utils/agentObservabilityUtils.ts
+++ b/packages/web/src/utils/agentObservabilityUtils.ts
@@ -1,0 +1,154 @@
+import {
+  AgentCoreLlmCallEvent,
+  AppendAgentLlmCallsRequest,
+  CompleteAgentRunRequest,
+  StartAgentRunRequest,
+  ToBeRecordedMessage,
+} from 'generative-ai-use-cases';
+
+type AgentObservabilityApi = {
+  startAgentRun: (req: StartAgentRunRequest) => Promise<unknown>;
+  completeAgentRun: (req: CompleteAgentRunRequest) => Promise<unknown>;
+  appendAgentLlmCalls: (req: AppendAgentLlmCallsRequest) => Promise<unknown>;
+};
+
+type Logger = {
+  error: (...args: unknown[]) => void;
+};
+
+const canSaveAgentObservability = (
+  agentRunId?: string,
+  agentId?: string
+): agentRunId is string => !!agentRunId && !!agentId;
+
+const runBestEffort = async (
+  label: string,
+  action: () => Promise<unknown>,
+  logger: Logger = console
+) => {
+  try {
+    await action();
+  } catch (error) {
+    logger.error(`[observability] ${label} failed`, error);
+  }
+};
+
+export const attachAgentObservabilityToMessages = (
+  messages: ToBeRecordedMessage[],
+  agentRunId?: string,
+  agentId?: string
+): ToBeRecordedMessage[] => {
+  if (!canSaveAgentObservability(agentRunId, agentId)) {
+    return messages;
+  }
+
+  return messages.map((message) => {
+    if (message.role !== 'user' && message.role !== 'assistant') {
+      return message;
+    }
+    return {
+      ...message,
+      agentRunId,
+      agentId,
+    };
+  });
+};
+
+export const startAgentRunBestEffort = async ({
+  apis,
+  agentRunId,
+  agentId,
+  sessionId,
+  startedAt,
+  logger,
+}: {
+  apis: Pick<AgentObservabilityApi, 'startAgentRun'>;
+  agentRunId?: string;
+  agentId?: string;
+  sessionId?: string;
+  startedAt: string;
+  logger?: Logger;
+}) => {
+  if (!canSaveAgentObservability(agentRunId, agentId)) {
+    return;
+  }
+
+  await runBestEffort(
+    'startRun',
+    () =>
+      apis.startAgentRun({
+        agent_run_id: agentRunId,
+        agent_id: agentId!,
+        session_id: sessionId,
+        started_at: startedAt,
+      }),
+    logger
+  );
+};
+
+export const saveAgentObservabilityCompletionBestEffort = async ({
+  apis,
+  agentRunId,
+  agentId,
+  sessionId,
+  chatId,
+  startedAt,
+  endedAt,
+  status,
+  errorType,
+  llmCalls,
+  messages,
+  logger,
+}: {
+  apis: Pick<AgentObservabilityApi, 'appendAgentLlmCalls' | 'completeAgentRun'>;
+  agentRunId?: string;
+  agentId?: string;
+  sessionId?: string;
+  chatId?: string;
+  startedAt: string;
+  endedAt: string;
+  status: 'succeeded' | 'failed';
+  errorType?: string | null;
+  llmCalls?: AgentCoreLlmCallEvent[];
+  messages?: ToBeRecordedMessage[];
+  logger?: Logger;
+}) => {
+  if (!canSaveAgentObservability(agentRunId, agentId)) {
+    return;
+  }
+
+  const userMessage = messages?.find((message) => message.role === 'user');
+  const assistantMessage = messages
+    ? [...messages].reverse().find((message) => message.role === 'assistant')
+    : undefined;
+
+  if (llmCalls && llmCalls.length > 0) {
+    await runBestEffort(
+      'appendLlmCalls',
+      () =>
+        apis.appendAgentLlmCalls({
+          agent_run_id: agentRunId,
+          llm_calls: llmCalls,
+        }),
+      logger
+    );
+  }
+
+  await runBestEffort(
+    'completeRun',
+    () =>
+      apis.completeAgentRun({
+        agent_run_id: agentRunId,
+        agent_id: agentId!,
+        session_id: sessionId,
+        chat_id: chatId,
+        user_message_id: userMessage?.messageId,
+        assistant_message_id: assistantMessage?.messageId,
+        started_at: startedAt,
+        ended_at: endedAt,
+        status,
+        error_type: errorType ?? null,
+      }),
+    logger
+  );
+};

--- a/packages/web/src/utils/strandsUtils.ts
+++ b/packages/web/src/utils/strandsUtils.ts
@@ -3,6 +3,7 @@
  */
 
 import {
+  AgentCoreLlmCallEvent,
   AppNotification,
   ExtraData,
   Metadata,
@@ -312,6 +313,7 @@ export class StrandsStreamProcessor {
     trace?: string;
     metadata?: Metadata;
     appNotification?: AppNotification;
+    llmCall?: AgentCoreLlmCallEvent;
   } | null {
     try {
       const parsedEvent = JSON.parse(eventText);
@@ -324,6 +326,16 @@ export class StrandsStreamProcessor {
         return {
           text: '',
           appNotification: streamEvent.appNotification,
+        };
+      }
+
+      // Handle llm_call observability custom event (from agent backend).
+      // Collected by the caller for observability; not rendered in the UI.
+      // Contract: cross-repo observability contract §3.2.
+      if (streamEvent.llm_call) {
+        return {
+          text: '',
+          llmCall: streamEvent.llm_call,
         };
       }
 

--- a/packages/web/tests/agent-core/agentObservabilityUtils.test.ts
+++ b/packages/web/tests/agent-core/agentObservabilityUtils.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  attachAgentObservabilityToMessages,
+  saveAgentObservabilityCompletionBestEffort,
+  startAgentRunBestEffort,
+} from '../../src/utils/agentObservabilityUtils';
+import {
+  AgentCoreLlmCallEvent,
+  ToBeRecordedMessage,
+} from 'generative-ai-use-cases';
+
+const messages: ToBeRecordedMessage[] = [
+  {
+    messageId: 'user-message-1',
+    role: 'user',
+    content: 'question',
+    usecase: '/agent-core',
+  },
+  {
+    messageId: 'assistant-message-1',
+    role: 'assistant',
+    content: 'answer',
+    usecase: '/agent-core',
+  },
+];
+
+const llmCall: AgentCoreLlmCallEvent = {
+  llm_call_id: 'call-1',
+  agent_run_id: 'run-1',
+  agent_id: 'medical-reimbursement-qa',
+  model_id: 'jp.anthropic.claude-sonnet-4-5',
+  input_tokens: 10,
+  output_tokens: 5,
+  total_tokens: 15,
+  cache_read_input_tokens: 0,
+  cache_write_input_tokens: 0,
+  latency_ms: 100,
+  status: 'succeeded',
+  error_type: null,
+  created_at: '2026-06-04T00:00:00.000Z',
+};
+
+describe('agent observability helpers', () => {
+  it('attaches agentRunId and agentId only to user and assistant messages', () => {
+    const withSystemMessage: ToBeRecordedMessage[] = [
+      {
+        messageId: 'system-message-1',
+        role: 'system',
+        content: 'system',
+        usecase: '/agent-core',
+      },
+      ...messages,
+    ];
+
+    const result = attachAgentObservabilityToMessages(
+      withSystemMessage,
+      'run-1',
+      'medical-reimbursement-qa'
+    );
+
+    expect(result[0].agentRunId).toBeUndefined();
+    expect(result[1]).toMatchObject({
+      agentRunId: 'run-1',
+      agentId: 'medical-reimbursement-qa',
+    });
+    expect(result[2]).toMatchObject({
+      agentRunId: 'run-1',
+      agentId: 'medical-reimbursement-qa',
+    });
+  });
+
+  it('does not attach observability ids when either id is missing', () => {
+    const result = attachAgentObservabilityToMessages(
+      messages,
+      'run-1',
+      undefined
+    );
+
+    expect(result).toEqual(messages);
+  });
+
+  it('does not call startRun when ids are missing', async () => {
+    const startAgentRun = vi.fn();
+
+    await startAgentRunBestEffort({
+      apis: { startAgentRun },
+      agentRunId: 'run-1',
+      agentId: undefined,
+      startedAt: '2026-06-04T00:00:00.000Z',
+    });
+
+    expect(startAgentRun).not.toHaveBeenCalled();
+  });
+
+  it('continues to completeRun when appendLlmCalls fails', async () => {
+    const logger = { error: vi.fn() };
+    const appendAgentLlmCalls = vi.fn().mockRejectedValue(new Error('append'));
+    const completeAgentRun = vi.fn().mockResolvedValue({ ok: true });
+
+    await expect(
+      saveAgentObservabilityCompletionBestEffort({
+        apis: { appendAgentLlmCalls, completeAgentRun },
+        agentRunId: 'run-1',
+        agentId: 'medical-reimbursement-qa',
+        sessionId: 'session-1',
+        chatId: 'chat-1',
+        startedAt: '2026-06-04T00:00:00.000Z',
+        endedAt: '2026-06-04T00:00:01.000Z',
+        status: 'succeeded',
+        errorType: null,
+        llmCalls: [llmCall],
+        messages,
+        logger,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(appendAgentLlmCalls).toHaveBeenCalledWith({
+      agent_run_id: 'run-1',
+      llm_calls: [llmCall],
+    });
+    expect(completeAgentRun).toHaveBeenCalledWith({
+      agent_run_id: 'run-1',
+      agent_id: 'medical-reimbursement-qa',
+      session_id: 'session-1',
+      chat_id: 'chat-1',
+      user_message_id: 'user-message-1',
+      assistant_message_id: 'assistant-message-1',
+      started_at: '2026-06-04T00:00:00.000Z',
+      ended_at: '2026-06-04T00:00:01.000Z',
+      status: 'succeeded',
+      error_type: null,
+    });
+    expect(logger.error).toHaveBeenCalledWith(
+      '[observability] appendLlmCalls failed',
+      expect.any(Error)
+    );
+  });
+
+  it('does not throw when completeRun fails', async () => {
+    const logger = { error: vi.fn() };
+    const appendAgentLlmCalls = vi.fn();
+    const completeAgentRun = vi.fn().mockRejectedValue(new Error('complete'));
+
+    await expect(
+      saveAgentObservabilityCompletionBestEffort({
+        apis: { appendAgentLlmCalls, completeAgentRun },
+        agentRunId: 'run-1',
+        agentId: 'medical-reimbursement-qa',
+        startedAt: '2026-06-04T00:00:00.000Z',
+        endedAt: '2026-06-04T00:00:01.000Z',
+        status: 'failed',
+        errorType: 'RuntimeError',
+        logger,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(appendAgentLlmCalls).not.toHaveBeenCalled();
+    expect(completeAgentRun).toHaveBeenCalledWith({
+      agent_run_id: 'run-1',
+      agent_id: 'medical-reimbursement-qa',
+      session_id: undefined,
+      chat_id: undefined,
+      user_message_id: undefined,
+      assistant_message_id: undefined,
+      started_at: '2026-06-04T00:00:00.000Z',
+      ended_at: '2026-06-04T00:00:01.000Z',
+      status: 'failed',
+      error_type: 'RuntimeError',
+    });
+    expect(logger.error).toHaveBeenCalledWith(
+      '[observability] completeRun failed',
+      expect.any(Error)
+    );
+  });
+});

--- a/packages/web/tests/agent-core/strandsUtils.test.ts
+++ b/packages/web/tests/agent-core/strandsUtils.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { StrandsStreamProcessor } from '../../src/utils/strandsUtils';
+
+const line = (obj: unknown) => JSON.stringify(obj);
+
+describe('StrandsStreamProcessor.processEvent — llm_call observability event', () => {
+  it('surfaces an llm_call event as { text: "", llmCall }', () => {
+    const processor = new StrandsStreamProcessor();
+    const llmCall = {
+      llm_call_id: '11111111-1111-1111-1111-111111111111',
+      agent_run_id: 'run-123',
+      agent_id: 'medical_reimbursement_qa',
+      model_id: 'jp.anthropic.claude-sonnet-4-5',
+      input_tokens: 30078,
+      output_tokens: 116,
+      total_tokens: 30194,
+      cache_read_input_tokens: 0,
+      cache_write_input_tokens: 0,
+      latency_ms: 3271,
+      status: 'succeeded',
+      error_type: null,
+      created_at: '2026-06-04T00:00:00.000Z',
+    };
+
+    const result = processor.processEvent(
+      line({ event: { llm_call: llmCall } })
+    );
+
+    expect(result).not.toBeNull();
+    expect(result?.text).toBe('');
+    expect(result?.llmCall).toEqual(llmCall);
+  });
+
+  it('still handles metadata events', () => {
+    const processor = new StrandsStreamProcessor();
+    const result = processor.processEvent(
+      line({
+        event: {
+          metadata: {
+            usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 },
+            metrics: { latencyMs: 100 },
+          },
+        },
+      })
+    );
+
+    expect(result?.metadata?.usage.inputTokens).toBe(10);
+    expect(result?.llmCall).toBeUndefined();
+  });
+
+  it('does not treat normal text deltas as llm_call', () => {
+    const processor = new StrandsStreamProcessor();
+    const result = processor.processEvent(
+      line({ event: { contentBlockDelta: { delta: { text: 'hello' } } } })
+    );
+
+    expect(result?.text).toBe('hello');
+    expect(result?.llmCall).toBeUndefined();
+  });
+});

--- a/packages/web/vite.config.ts
+++ b/packages/web/vite.config.ts
@@ -83,8 +83,8 @@ export default defineConfig(({ mode }) => ({
     }),
   ],
   test: {
-    name: 'use-case-builder',
-    root: './tests/use-case-builder',
+    name: 'web',
+    root: './tests',
     environment: 'node',
     setupFiles: [],
   },


### PR DESCRIPTION
## 概要
  AIエージェント（AgentCore）実行の観測ログを収集・永続化する基盤を追加します。
  エージェント1回の実行単位 `agent_run` と、その中の各LLM呼び出し `llm_call` を記録し、
  トークン使用量・レイテンシ・成否を後から分析できるようにします。

 ## 変更内容

  ### バックエンド (CDK / Lambda)
  - DynamoDB テーブル `AgentObservabilityTable` を新設（PK/SK + GSI `AgentIdIndex`）
  - Lambda `agentObservability.ts` と Repository `repositoryAgentObservability.ts` を追加
  - API エンドポイント `POST /agent-observability/{operation}` を追加
    - agent_run の開始/完了、llm_call の保存に対応
  - 失敗時も `llm_call` を保存するよう修正（status: failed を記録）

  ### 型定義 (types)
  - `agent-core.d.ts` に観測ログ用の型を追加
    - `AgentCoreLlmCallEvent` / `AgentRunStatus`
    - `StartAgentRunRequest` / `CompleteAgentRunRequest`

  ### フロントエンド (web)
  - `useAgentCoreApi.ts` / `useChatApi.ts` / `useAgentCore.ts` で観測イベントを収集・送信
  - `agentObservabilityUtils.ts` / `strandsUtils.ts` でイベント整形ユーティリティを追加
  - `AgentCorePage.tsx` を観測ログ収集に対応（※ログはUIには表示しない）

  ### その他
  - `customEmailSender` テストの日本語文字列を i18n 例外に追加（テスト修正）
  - デバッグログを削除

  ## テスト
  - `agentObservability.test.ts` / `repositoryAgentObservability.test.ts`（Lambda）
  - `agentObservabilityUtils.test.ts` / `strandsUtils.test.ts`（web）