### PR TITLE
[codex] Add sanitized GenU CI/CD workflows

### DIFF
--- a/.github/workflows/genu-manual-deploy.yml
+++ b/.github/workflows/genu-manual-deploy.yml
@@ -1,0 +1,141 @@
+name: GenU Manual Deploy
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Deployment environment manifest
+        required: true
+        default: dev
+        type: choice
+        options:
+          - dev
+      deploy_confirmation:
+        description: Type deploy to run cdk deploy
+        required: true
+        type: string
+
+permissions:
+  id-token: write
+  contents: read
+  actions: read
+
+concurrency:
+  group: genu-manual-deploy-${{ github.ref }}-${{ inputs.environment }}
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    timeout-minutes: 120
+    env:
+      ENVIRONMENT_NAME: ${{ vars.GENU_ENVIRONMENT_NAME || inputs.environment }}
+      CDK_CONTEXT_ENV: ${{ vars.GENU_CDK_CONTEXT_ENV }}
+      AWS_ACCOUNT_ID: ${{ vars.GENU_AWS_ACCOUNT_ID || vars.AWS_ACCOUNT_ID }}
+      DEPLOYMENT_REGION: ${{ vars.GENU_DEPLOYMENT_REGION || vars.AWS_REGION }}
+      MODEL_REGION: ${{ vars.GENU_MODEL_REGION }}
+      AGENTCORE_REGION: ${{ vars.GENU_AGENTCORE_REGION }}
+      GENU_STACK_NAME: ${{ vars.GENU_STACK_NAME }}
+      GENU_OUTPUTS_SSM_PREFIX: ${{ vars.GENU_OUTPUTS_SSM_PREFIX }}
+      AGENTCORE_RUNTIMES_JSON: ${{ vars.GENU_AGENTCORE_RUNTIMES_JSON }}
+      DEPLOY_ROLE_ARN: ${{ secrets.GENU_DEPLOY_ROLE_ARN || vars.GENU_DEPLOY_ROLE_ARN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Confirm manual deploy
+        run: |
+          test "${{ inputs.deploy_confirmation }}" = "deploy"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Validate required CI/CD variables
+        run: |
+          required=(
+            ENVIRONMENT_NAME
+            CDK_CONTEXT_ENV
+            AWS_ACCOUNT_ID
+            DEPLOYMENT_REGION
+            MODEL_REGION
+            AGENTCORE_REGION
+            GENU_STACK_NAME
+            GENU_OUTPUTS_SSM_PREFIX
+            AGENTCORE_RUNTIMES_JSON
+            DEPLOY_ROLE_ARN
+          )
+          for name in "${required[@]}"; do
+            test -n "${!name}" || {
+              echo "${name} is required" >&2
+              exit 1
+            }
+          done
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.DEPLOY_ROLE_ARN }}
+          aws-region: ${{ env.DEPLOYMENT_REGION }}
+
+      - name: Verify AWS account
+        run: |
+          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          test "${ACCOUNT_ID}" = "${AWS_ACCOUNT_ID}"
+          echo "CDK_DEFAULT_ACCOUNT=${ACCOUNT_ID}" >> "${GITHUB_ENV}"
+          echo "CDK_DEFAULT_REGION=${DEPLOYMENT_REGION}" >> "${GITHUB_ENV}"
+          aws configure get region
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate CI/CD manifest and CDK context
+        run: node scripts/validate-cicd-config.mjs
+
+      - name: Validate AgentCore runtimes
+        run: node scripts/validate-agentcore-runtimes.mjs
+
+      - name: Build CDK
+        run: npm -w packages/cdk run build
+
+      - name: CDK synth
+        working-directory: packages/cdk
+        run: npx cdk synth --all -c env="${CDK_CONTEXT_ENV}"
+
+      - name: CDK diff
+        working-directory: packages/cdk
+        run: npx cdk diff --all -c env="${CDK_CONTEXT_ENV}"
+
+      - name: CDK deploy
+        working-directory: packages/cdk
+        run: |
+          npx cdk deploy --all \
+            -c env="${CDK_CONTEXT_ENV}" \
+            --require-approval never \
+            --outputs-file ../../genu-cdk-outputs.json
+
+      - name: Collect CloudFormation outputs
+        run: |
+          mkdir -p cicd-outputs
+          aws cloudformation describe-stacks \
+            --stack-name "${GENU_STACK_NAME}" \
+            --region "${DEPLOYMENT_REGION}" \
+            --query 'Stacks[0].Outputs' \
+            --output json > "cicd-outputs/${ENVIRONMENT_NAME}-genu-stack-outputs.json"
+          cp genu-cdk-outputs.json "cicd-outputs/${ENVIRONMENT_NAME}-cdk-outputs.json"
+
+      - name: Export CloudFormation outputs to SSM
+        run: |
+          node scripts/export-cfn-outputs-to-ssm.mjs \
+            --output-file "cicd-outputs/${ENVIRONMENT_NAME}-ssm-output-parameters.json"
+
+      - name: Upload deployment outputs
+        uses: actions/upload-artifact@v4
+        with:
+          name: genu-${{ inputs.environment }}-deployment-outputs
+          path: cicd-outputs/
+          if-no-files-found: error

--- a/.github/workflows/genu-manual-deploy.yml
+++ b/.github/workflows/genu-manual-deploy.yml
@@ -39,6 +39,7 @@ jobs:
       GENU_STACK_NAME: ${{ vars.GENU_STACK_NAME }}
       GENU_OUTPUTS_SSM_PREFIX: ${{ vars.GENU_OUTPUTS_SSM_PREFIX }}
       AGENTCORE_RUNTIMES_JSON: ${{ vars.GENU_AGENTCORE_RUNTIMES_JSON }}
+      CDK_CONTEXT_JSON: ${{ secrets.GENU_CDK_CONTEXT_JSON || vars.GENU_CDK_CONTEXT_JSON }}
       DEPLOY_ROLE_ARN: ${{ secrets.GENU_DEPLOY_ROLE_ARN || vars.GENU_DEPLOY_ROLE_ARN }}
 
     steps:
@@ -92,6 +93,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Materialize sanitized CDK context
+        run: node scripts/materialize-cicd-cdk-context.mjs
 
       - name: Validate CI/CD manifest and CDK context
         run: node scripts/validate-cicd-config.mjs

--- a/.github/workflows/genu-validate-only.yml
+++ b/.github/workflows/genu-validate-only.yml
@@ -1,0 +1,94 @@
+name: GenU Validate Only
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: Deployment environment
+        required: true
+        default: dev
+        type: choice
+        options:
+          - dev
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    timeout-minutes: 30
+    env:
+      ENVIRONMENT_NAME: ${{ vars.GENU_ENVIRONMENT_NAME || inputs.environment }}
+      CDK_CONTEXT_ENV: ${{ vars.GENU_CDK_CONTEXT_ENV }}
+      AWS_ACCOUNT_ID: ${{ vars.GENU_AWS_ACCOUNT_ID || vars.AWS_ACCOUNT_ID }}
+      DEPLOYMENT_REGION: ${{ vars.GENU_DEPLOYMENT_REGION || vars.AWS_REGION }}
+      MODEL_REGION: ${{ vars.GENU_MODEL_REGION }}
+      AGENTCORE_REGION: ${{ vars.GENU_AGENTCORE_REGION }}
+      GENU_STACK_NAME: ${{ vars.GENU_STACK_NAME }}
+      GENU_OUTPUTS_SSM_PREFIX: ${{ vars.GENU_OUTPUTS_SSM_PREFIX }}
+      AGENTCORE_RUNTIMES_JSON: ${{ vars.GENU_AGENTCORE_RUNTIMES_JSON }}
+      VALIDATE_ROLE_ARN: ${{ secrets.GENU_VALIDATE_ROLE_ARN || vars.GENU_VALIDATE_ROLE_ARN }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Validate required CI/CD variables
+        run: |
+          required=(
+            ENVIRONMENT_NAME
+            CDK_CONTEXT_ENV
+            AWS_ACCOUNT_ID
+            DEPLOYMENT_REGION
+            MODEL_REGION
+            AGENTCORE_REGION
+            GENU_STACK_NAME
+            GENU_OUTPUTS_SSM_PREFIX
+            AGENTCORE_RUNTIMES_JSON
+            VALIDATE_ROLE_ARN
+          )
+          for name in "${required[@]}"; do
+            test -n "${!name}" || {
+              echo "${name} is required" >&2
+              exit 1
+            }
+          done
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.VALIDATE_ROLE_ARN }}
+          aws-region: ${{ env.DEPLOYMENT_REGION }}
+
+      - name: Verify AWS account
+        run: |
+          ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+          test "${ACCOUNT_ID}" = "${AWS_ACCOUNT_ID}"
+          echo "CDK_DEFAULT_ACCOUNT=${ACCOUNT_ID}" >> "${GITHUB_ENV}"
+          echo "CDK_DEFAULT_REGION=${DEPLOYMENT_REGION}" >> "${GITHUB_ENV}"
+          aws configure get region
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate CI/CD manifest and CDK context
+        run: node scripts/validate-cicd-config.mjs
+
+      - name: Validate AgentCore runtimes
+        run: node scripts/validate-agentcore-runtimes.mjs
+
+      - name: Build CDK
+        run: npm -w packages/cdk run build
+
+      - name: CDK synth
+        working-directory: packages/cdk
+        run: npx cdk synth --all -c env="${CDK_CONTEXT_ENV}"

--- a/.github/workflows/genu-validate-only.yml
+++ b/.github/workflows/genu-validate-only.yml
@@ -30,6 +30,7 @@ jobs:
       GENU_STACK_NAME: ${{ vars.GENU_STACK_NAME }}
       GENU_OUTPUTS_SSM_PREFIX: ${{ vars.GENU_OUTPUTS_SSM_PREFIX }}
       AGENTCORE_RUNTIMES_JSON: ${{ vars.GENU_AGENTCORE_RUNTIMES_JSON }}
+      CDK_CONTEXT_JSON: ${{ secrets.GENU_CDK_CONTEXT_JSON || vars.GENU_CDK_CONTEXT_JSON }}
       VALIDATE_ROLE_ARN: ${{ secrets.GENU_VALIDATE_ROLE_ARN || vars.GENU_VALIDATE_ROLE_ARN }}
 
     steps:
@@ -79,6 +80,9 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Materialize sanitized CDK context
+        run: node scripts/materialize-cicd-cdk-context.mjs
 
       - name: Validate CI/CD manifest and CDK context
         run: node scripts/validate-cicd-config.mjs

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ site*/
 .kiro/settings
 .kiro/specs
 
+# Local CI/CD manifests can include account IDs and AWS resource names.
+config/cicd/*.json
+!config/cicd/*.example.json
+
 # Git worktree directory
 worktree/
 

--- a/config/cicd/dev.example.json
+++ b/config/cicd/dev.example.json
@@ -21,8 +21,15 @@
   "agentCoreRuntimes": [
     {
       "key": "example_runtime",
+      "name": "example_runtime",
       "required": true,
-      "arn": "arn:aws:bedrock-agentcore:aws-region-2:000000000000:runtime/example_runtime-0000000000"
+      "arn": "arn:aws:bedrock-agentcore:aws-region-2:000000000000:runtime/example_runtime-0000000000",
+      "displayName": "Example Runtime",
+      "description": "Example external AgentCore runtime."
     }
-  ]
+  ],
+  "cdkContext": {
+    "tagKey": "Project",
+    "tagValue": "example-genu-dev"
+  }
 }

--- a/config/cicd/dev.example.json
+++ b/config/cicd/dev.example.json
@@ -1,0 +1,28 @@
+{
+  "environmentName": "dev",
+  "cdkEnv": "devel",
+  "awsAccountId": "000000000000",
+  "deploymentRegion": "aws-region-1",
+  "modelRegion": "aws-region-2",
+  "agentCoreRegion": "aws-region-2",
+  "github": {
+    "repository": "owner/repository",
+    "validateRoleArn": "arn:aws:iam::000000000000:role/ExampleValidateOnlyRole",
+    "deployRoleArn": "arn:aws:iam::000000000000:role/ExampleDeployRole"
+  },
+  "stacks": {
+    "genu": "ExampleGenUStack",
+    "agentCore": "ExampleAgentCoreStack",
+    "manualRag": "ExampleManualRagStack"
+  },
+  "outputs": {
+    "ssmParameterPrefix": "/example/dev/outputs"
+  },
+  "agentCoreRuntimes": [
+    {
+      "key": "example_runtime",
+      "required": true,
+      "arn": "arn:aws:bedrock-agentcore:aws-region-2:000000000000:runtime/example_runtime-0000000000"
+    }
+  ]
+}

--- a/scripts/export-cfn-outputs-to-ssm.mjs
+++ b/scripts/export-cfn-outputs-to-ssm.mjs
@@ -1,0 +1,212 @@
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { readCicdConfig } from './lib/cicd-config.mjs';
+
+const repoRoot = process.cwd();
+const args = parseArgs(process.argv.slice(2));
+const manifest = readCicdConfig({
+  repoRoot,
+  manifestPath: args.manifest,
+});
+const outputFile = args['output-file']
+  ? path.resolve(repoRoot, args['output-file'])
+  : undefined;
+
+const region = manifest.deploymentRegion;
+const stackName = manifest.stacks?.genu;
+const parameterPrefix = manifest.outputs?.ssmParameterPrefix;
+const dryRun = args['dry-run'] === true;
+
+const errors = [];
+
+if (!region) {
+  errors.push('manifest.deploymentRegion is required');
+}
+if (!stackName) {
+  errors.push('manifest.stacks.genu is required');
+}
+if (!parameterPrefix) {
+  errors.push('manifest.outputs.ssmParameterPrefix is required');
+} else if (!/^\/[A-Za-z0-9_.\-/]+$/.test(parameterPrefix)) {
+  errors.push(
+    `manifest.outputs.ssmParameterPrefix has invalid characters: ${parameterPrefix}`
+  );
+} else if (parameterPrefix.endsWith('/')) {
+  errors.push(
+    `manifest.outputs.ssmParameterPrefix must not end with slash: ${parameterPrefix}`
+  );
+}
+
+if (errors.length > 0) {
+  fail('CloudFormation output export configuration is invalid:', errors);
+}
+
+const outputs = args['input-file']
+  ? readOutputsFromFile(path.resolve(repoRoot, args['input-file']))
+  : describeStackOutputs(stackName, region);
+
+if (outputs.length === 0) {
+  fail(`CloudFormation stack ${stackName} has no Outputs.`);
+}
+
+const parameters = outputs.map((output) => ({
+  outputKey: output.OutputKey,
+  outputValue: output.OutputValue,
+  description: output.Description,
+  parameterName: `${parameterPrefix}/${output.OutputKey}`,
+}));
+
+for (const parameter of parameters) {
+  if (
+    typeof parameter.outputKey !== 'string' ||
+    parameter.outputKey.length === 0
+  ) {
+    fail('CloudFormation output is missing OutputKey.');
+  }
+  if (typeof parameter.outputValue !== 'string') {
+    fail(
+      `${parameter.outputKey}: CloudFormation output is missing OutputValue.`
+    );
+  }
+}
+
+for (const parameter of parameters) {
+  if (dryRun) {
+    console.log(
+      `DRY-RUN put ${parameter.parameterName} (${parameter.outputValue.length} chars)`
+    );
+    continue;
+  }
+
+  runAws([
+    'ssm',
+    'put-parameter',
+    '--name',
+    parameter.parameterName,
+    '--type',
+    'String',
+    '--value',
+    parameter.outputValue,
+    '--description',
+    `GenU ${manifest.environmentName} CloudFormation output ${parameter.outputKey}`,
+    '--overwrite',
+    '--region',
+    region,
+  ]);
+
+  runAws([
+    'ssm',
+    'add-tags-to-resource',
+    '--resource-type',
+    'Parameter',
+    '--resource-id',
+    parameter.parameterName,
+    '--tags',
+    `Key=Project,Value=GenU`,
+    `Key=Environment,Value=${manifest.environmentName}`,
+    `Key=SourceStack,Value=${stackName}`,
+    `Key=ManagedBy,Value=generative-ai-use-cases-ci`,
+    '--region',
+    region,
+  ]);
+
+  console.log(`Put ${parameter.parameterName}`);
+}
+
+const summary = {
+  environmentName: manifest.environmentName,
+  stackName,
+  region,
+  parameterPrefix,
+  dryRun,
+  parameters: parameters.map((parameter) => ({
+    outputKey: parameter.outputKey,
+    parameterName: parameter.parameterName,
+  })),
+};
+
+if (outputFile) {
+  fs.mkdirSync(path.dirname(outputFile), { recursive: true });
+  fs.writeFileSync(outputFile, `${JSON.stringify(summary, null, 2)}\n`);
+}
+
+console.log(
+  `${dryRun ? 'Validated' : 'Exported'} ${parameters.length} CloudFormation outputs to ${parameterPrefix}.`
+);
+
+function parseArgs(rawArgs) {
+  const parsed = {};
+  for (let index = 0; index < rawArgs.length; index += 1) {
+    const name = rawArgs[index];
+    if (!name.startsWith('--')) {
+      fail(`Unexpected argument: ${name}`);
+    }
+
+    const key = name.slice(2);
+    if (key === 'dry-run') {
+      parsed[key] = true;
+      continue;
+    }
+
+    const value = rawArgs[index + 1];
+    if (!value || value.startsWith('--')) {
+      fail(`Missing value for ${name}`);
+    }
+    parsed[key] = value;
+    index += 1;
+  }
+  return parsed;
+}
+
+function describeStackOutputs(name, awsRegion) {
+  const result = runAws([
+    'cloudformation',
+    'describe-stacks',
+    '--stack-name',
+    name,
+    '--region',
+    awsRegion,
+    '--output',
+    'json',
+  ]);
+
+  const response = JSON.parse(result.stdout);
+  return response.Stacks?.[0]?.Outputs ?? [];
+}
+
+function readOutputsFromFile(inputFile) {
+  const payload = JSON.parse(fs.readFileSync(inputFile, 'utf8'));
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+  if (Array.isArray(payload.Outputs)) {
+    return payload.Outputs;
+  }
+  if (Array.isArray(payload.Stacks?.[0]?.Outputs)) {
+    return payload.Stacks[0].Outputs;
+  }
+  fail(`${inputFile} does not contain CloudFormation Outputs.`);
+}
+
+function runAws(awsArgs) {
+  const result = spawnSync('aws', awsArgs, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  if (result.status !== 0) {
+    const message = result.stderr.trim() || result.stdout.trim();
+    throw new Error(message);
+  }
+
+  return result;
+}
+
+function fail(message, details = []) {
+  console.error(message);
+  for (const detail of details) {
+    console.error(`- ${detail}`);
+  }
+  process.exit(1);
+}

--- a/scripts/lib/cicd-config.mjs
+++ b/scripts/lib/cicd-config.mjs
@@ -1,0 +1,71 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export function readCicdConfig(options = {}) {
+  const repoRoot = options.repoRoot ?? process.cwd();
+  const manifestPath = options.manifestPath
+    ? path.resolve(repoRoot, options.manifestPath)
+    : process.env.CI_MANIFEST_PATH
+      ? path.resolve(repoRoot, process.env.CI_MANIFEST_PATH)
+      : path.join(repoRoot, 'config/cicd/dev.json');
+
+  if (fs.existsSync(manifestPath)) {
+    return JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+  }
+
+  return readCicdConfigFromEnv();
+}
+
+function readCicdConfigFromEnv() {
+  const errors = [];
+
+  const config = {
+    environmentName: readEnv('ENVIRONMENT_NAME', errors),
+    cdkEnv: readEnv('CDK_CONTEXT_ENV', errors),
+    awsAccountId: readEnv('AWS_ACCOUNT_ID', errors),
+    deploymentRegion: readEnv('DEPLOYMENT_REGION', errors),
+    modelRegion: readEnv('MODEL_REGION', errors),
+    agentCoreRegion: readEnv('AGENTCORE_REGION', errors),
+    stacks: {
+      genu: readEnv('GENU_STACK_NAME', errors),
+      agentCore: process.env.AGENTCORE_STACK_NAME,
+      manualRag: process.env.MANUAL_RAG_STACK_NAME,
+    },
+    outputs: {
+      ssmParameterPrefix: readEnv('GENU_OUTPUTS_SSM_PREFIX', errors),
+    },
+    agentCoreRuntimes: readJsonEnv('AGENTCORE_RUNTIMES_JSON', errors),
+  };
+
+  if (errors.length > 0) {
+    console.error('CI/CD environment configuration is missing or invalid:');
+    for (const error of errors) {
+      console.error(`- ${error}`);
+    }
+    process.exit(1);
+  }
+
+  return config;
+}
+
+function readEnv(name, errors) {
+  const value = process.env[name];
+  if (!value) {
+    errors.push(`${name} is required`);
+  }
+  return value;
+}
+
+function readJsonEnv(name, errors) {
+  const value = readEnv(name, errors);
+  if (!value) {
+    return [];
+  }
+
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    errors.push(`${name} must be valid JSON: ${error.message}`);
+    return [];
+  }
+}

--- a/scripts/lib/cicd-config.mjs
+++ b/scripts/lib/cicd-config.mjs
@@ -10,10 +10,63 @@ export function readCicdConfig(options = {}) {
       : path.join(repoRoot, 'config/cicd/dev.json');
 
   if (fs.existsSync(manifestPath)) {
-    return JSON.parse(fs.readFileSync(manifestPath, 'utf8'));
+    return normalizeCicdConfig(
+      JSON.parse(fs.readFileSync(manifestPath, 'utf8'))
+    );
   }
 
   return readCicdConfigFromEnv();
+}
+
+export function normalizeCicdConfig(config) {
+  return {
+    ...config,
+    cdkContext: config.cdkContext ?? {},
+    agentCoreRuntimes: normalizeAgentCoreRuntimes(
+      config.agentCoreRuntimes ?? config.agentCoreExternalRuntimes ?? []
+    ),
+    agentCoreExternalRuntimes: normalizeAgentCoreRuntimes(
+      config.agentCoreExternalRuntimes ??
+        config.cdkContext?.agentCoreExternalRuntimes ??
+        config.agentCoreRuntimes ??
+        []
+    ).map(toCdkRuntime),
+  };
+}
+
+export function normalizeAgentCoreRuntimes(runtimes) {
+  if (!Array.isArray(runtimes)) {
+    return [];
+  }
+
+  return runtimes.map((runtime) => {
+    const key = runtime.key ?? runtime.name;
+    return {
+      ...runtime,
+      key,
+      name: runtime.name ?? key,
+      required: runtime.required ?? true,
+    };
+  });
+}
+
+function toCdkRuntime(runtime) {
+  const cdkRuntime = {
+    name: runtime.name,
+    arn: runtime.arn,
+  };
+
+  if (runtime.displayName) {
+    cdkRuntime.displayName = runtime.displayName;
+  }
+  if (runtime.description) {
+    cdkRuntime.description = runtime.description;
+  }
+  if (runtime.apps) {
+    cdkRuntime.apps = runtime.apps;
+  }
+
+  return cdkRuntime;
 }
 
 function readCicdConfigFromEnv() {
@@ -35,6 +88,7 @@ function readCicdConfigFromEnv() {
       ssmParameterPrefix: readEnv('GENU_OUTPUTS_SSM_PREFIX', errors),
     },
     agentCoreRuntimes: readJsonEnv('AGENTCORE_RUNTIMES_JSON', errors),
+    cdkContext: readOptionalJsonEnv('CDK_CONTEXT_JSON', errors),
   };
 
   if (errors.length > 0) {
@@ -45,7 +99,7 @@ function readCicdConfigFromEnv() {
     process.exit(1);
   }
 
-  return config;
+  return normalizeCicdConfig(config);
 }
 
 function readEnv(name, errors) {
@@ -67,5 +121,19 @@ function readJsonEnv(name, errors) {
   } catch (error) {
     errors.push(`${name} must be valid JSON: ${error.message}`);
     return [];
+  }
+}
+
+function readOptionalJsonEnv(name, errors) {
+  const value = process.env[name];
+  if (!value) {
+    return {};
+  }
+
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    errors.push(`${name} must be valid JSON: ${error.message}`);
+    return {};
   }
 }

--- a/scripts/materialize-cicd-cdk-context.mjs
+++ b/scripts/materialize-cicd-cdk-context.mjs
@@ -1,0 +1,70 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { readCicdConfig } from './lib/cicd-config.mjs';
+
+const repoRoot = process.cwd();
+const args = parseArgs(process.argv.slice(2));
+const manifest = readCicdConfig({
+  repoRoot,
+  manifestPath: args.manifest,
+});
+
+const cdkJsonPath = path.resolve(
+  repoRoot,
+  args['cdk-json'] ?? 'packages/cdk/cdk.json'
+);
+const outputPath = path.resolve(repoRoot, args.output ?? cdkJsonPath);
+const cdk = JSON.parse(fs.readFileSync(cdkJsonPath, 'utf8'));
+
+const requiredContext = withoutUndefined({
+  env: manifest.cdkEnv,
+  modelRegion: manifest.modelRegion,
+  agentCoreRegion: manifest.agentCoreRegion,
+  agentCoreExternalRuntimes: manifest.agentCoreExternalRuntimes,
+});
+
+const generated = {
+  ...cdk,
+  context: {
+    ...(cdk.context ?? {}),
+    ...(manifest.cdkContext ?? {}),
+    ...requiredContext,
+  },
+};
+
+fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+fs.writeFileSync(outputPath, `${JSON.stringify(generated, null, 2)}\n`);
+
+console.log(
+  `Materialized CDK context in ${path.relative(repoRoot, outputPath)}`
+);
+
+function withoutUndefined(values) {
+  return Object.fromEntries(
+    Object.entries(values).filter(([, value]) => value !== undefined)
+  );
+}
+
+function parseArgs(rawArgs) {
+  const parsed = {};
+  for (let index = 0; index < rawArgs.length; index += 1) {
+    const name = rawArgs[index];
+    if (!name.startsWith('--')) {
+      fail(`Unexpected argument: ${name}`);
+    }
+
+    const key = name.slice(2);
+    const value = rawArgs[index + 1];
+    if (!value || value.startsWith('--')) {
+      fail(`Missing value for ${name}`);
+    }
+    parsed[key] = value;
+    index += 1;
+  }
+  return parsed;
+}
+
+function fail(message) {
+  console.error(message);
+  process.exit(1);
+}

--- a/scripts/validate-agentcore-runtimes.mjs
+++ b/scripts/validate-agentcore-runtimes.mjs
@@ -1,0 +1,93 @@
+import { spawnSync } from 'node:child_process';
+import { readCicdConfig } from './lib/cicd-config.mjs';
+
+const repoRoot = process.cwd();
+const manifest = readCicdConfig({ repoRoot });
+const errors = [];
+
+function parseRuntimeArn(arn) {
+  const match = arn.match(
+    /^arn:aws:bedrock-agentcore:([^:]+):([0-9]{12}):runtime\/([A-Za-z][A-Za-z0-9_]{0,99}-[A-Za-z0-9]{10})$/
+  );
+  if (!match) {
+    throw new Error(`Invalid AgentCore runtime ARN: ${arn}`);
+  }
+  return {
+    region: match[1],
+    accountId: match[2],
+    runtimeId: match[3],
+  };
+}
+
+function getRuntime(runtime, parsedArn) {
+  const result = spawnSync(
+    'aws',
+    [
+      'bedrock-agentcore-control',
+      'get-agent-runtime',
+      '--agent-runtime-id',
+      parsedArn.runtimeId,
+      '--region',
+      parsedArn.region,
+      '--output',
+      'json',
+    ],
+    {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }
+  );
+
+  if (result.status !== 0) {
+    const message = result.stderr.trim() || result.stdout.trim();
+    throw new Error(`${runtime.key}: ${message}`);
+  }
+
+  return JSON.parse(result.stdout);
+}
+
+for (const runtime of manifest.agentCoreRuntimes) {
+  const parsedArn = parseRuntimeArn(runtime.arn);
+
+  if (parsedArn.accountId !== manifest.awsAccountId) {
+    errors.push(`${runtime.key}: ARN account is ${parsedArn.accountId}`);
+    continue;
+  }
+
+  if (parsedArn.region !== manifest.agentCoreRegion) {
+    errors.push(`${runtime.key}: ARN region is ${parsedArn.region}`);
+    continue;
+  }
+
+  try {
+    const actual = getRuntime(runtime, parsedArn);
+    if (actual.agentRuntimeArn !== runtime.arn) {
+      errors.push(`${runtime.key}: AWS returned ARN ${actual.agentRuntimeArn}`);
+    }
+    if (actual.status !== 'READY') {
+      const message = `${runtime.key}: runtime status is ${actual.status}`;
+      if (runtime.required) {
+        errors.push(message);
+      } else {
+        console.warn(`WARN: ${message}`);
+      }
+    }
+    console.log(`${runtime.key}: ${actual.status} (${actual.agentRuntimeArn})`);
+  } catch (error) {
+    if (runtime.required) {
+      errors.push(error.message);
+    } else {
+      console.warn(`WARN: ${error.message}`);
+    }
+  }
+}
+
+if (errors.length > 0) {
+  console.error('AgentCore runtime validation failed:');
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log('AgentCore runtime validation passed.');

--- a/scripts/validate-cicd-config.mjs
+++ b/scripts/validate-cicd-config.mjs
@@ -1,0 +1,109 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { readCicdConfig } from './lib/cicd-config.mjs';
+
+const repoRoot = process.cwd();
+const cdkPath = path.join(repoRoot, 'packages/cdk/cdk.json');
+
+const manifest = readCicdConfig({ repoRoot });
+const cdk = JSON.parse(fs.readFileSync(cdkPath, 'utf8'));
+const context = cdk.context ?? {};
+
+const errors = [];
+const warnings = [];
+
+function requireEqual(label, actual, expected) {
+  if (actual !== expected) {
+    errors.push(`${label}: expected ${expected}, got ${actual}`);
+  }
+}
+
+function parseArn(arn) {
+  const parts = arn.split(':');
+  if (parts.length < 6 || parts[0] !== 'arn') {
+    throw new Error(`Invalid ARN: ${arn}`);
+  }
+  return {
+    service: parts[2],
+    region: parts[3],
+    accountId: parts[4],
+    resource: parts.slice(5).join(':'),
+  };
+}
+
+requireEqual('cdk context env', context.env, manifest.cdkEnv);
+requireEqual(
+  'cdk context modelRegion',
+  context.modelRegion,
+  manifest.modelRegion
+);
+requireEqual(
+  'cdk context agentCoreRegion',
+  context.agentCoreRegion,
+  manifest.agentCoreRegion
+);
+
+const cdkRuntimeArns = new Set(
+  (context.agentCoreExternalRuntimes ?? []).map((runtime) => runtime.arn)
+);
+
+if (!manifest.outputs?.ssmParameterPrefix) {
+  errors.push('outputs.ssmParameterPrefix is required');
+} else if (!/^\/[A-Za-z0-9_.\-/]+$/.test(manifest.outputs.ssmParameterPrefix)) {
+  errors.push(
+    `outputs.ssmParameterPrefix has invalid characters: ${manifest.outputs.ssmParameterPrefix}`
+  );
+} else if (manifest.outputs.ssmParameterPrefix.endsWith('/')) {
+  errors.push(
+    `outputs.ssmParameterPrefix must not end with slash: ${manifest.outputs.ssmParameterPrefix}`
+  );
+}
+
+for (const runtime of manifest.agentCoreRuntimes) {
+  const arn = parseArn(runtime.arn);
+  requireEqual(
+    `${runtime.key} ARN account`,
+    arn.accountId,
+    manifest.awsAccountId
+  );
+  requireEqual(
+    `${runtime.key} ARN region`,
+    arn.region,
+    manifest.agentCoreRegion
+  );
+
+  if (runtime.required && !cdkRuntimeArns.has(runtime.arn)) {
+    errors.push(
+      `${runtime.key}: required runtime ARN is not present in cdk.json`
+    );
+  }
+  if (!runtime.required && !cdkRuntimeArns.has(runtime.arn)) {
+    warnings.push(
+      `${runtime.key}: optional runtime ARN is not present in cdk.json`
+    );
+  }
+}
+
+for (const runtime of context.agentCoreExternalRuntimes ?? []) {
+  const arn = parseArn(runtime.arn);
+  if (arn.accountId !== manifest.awsAccountId) {
+    errors.push(`${runtime.name}: cdk.json ARN account is ${arn.accountId}`);
+  }
+  if (arn.region !== manifest.agentCoreRegion) {
+    errors.push(`${runtime.name}: cdk.json ARN region is ${arn.region}`);
+  }
+}
+
+for (const warning of warnings) {
+  console.warn(`WARN: ${warning}`);
+}
+
+if (errors.length > 0) {
+  console.error('CI/CD configuration validation failed:');
+  for (const error of errors) {
+    console.error(`- ${error}`);
+  }
+  process.exit(1);
+}
+
+console.log('CI/CD configuration validation passed.');


### PR DESCRIPTION
## 概要

GenU本体をGitHub Actionsから安全に検証・手動デプロイできるようにするためのCI/CD追加です。

このPRでは、AWSアカウントID、Role ARN、Stack名、SSM prefix、AgentCore Runtime ARNなどの環境固有情報をGit管理から外し、GitHub Actions実行時にGitHub Environment Variables / Secretsから受け取る方式にしています。

## 変更内容

- `GenU Validate Only` workflowを追加
  - CDK設定とAgentCore Runtimeの状態確認
  - CDK build / synthの事前検証
- `GenU Manual Deploy` workflowを追加
  - 手動実行専用
  - `deploy_confirmation=deploy` の入力がある場合のみdeploy実行
  - `cdk diff` / `cdk deploy` / CloudFormation Outputs収集を実行
- CloudFormation OutputsをSSM Parameter Storeへ同期するスクリプトを追加
  - Monitoring側が後続でOutputsを参照できるようにするため
- CI/CD設定ローダーを追加
  - ローカルではignoredの `config/cicd/dev.json` を利用可能
  - GitHub Actions上では環境変数から設定を組み立てる
- `config/cicd/dev.example.json` を追加
  - 実値ではなくプレースホルダーのみ
- `config/cicd/*.json` を `.gitignore` に追加
  - 実環境の `dev.json` をGitHubへ上げないため

## GitHubに置かないもの

以下はGit管理対象から外しています。

- 実環境の `config/cicd/dev.json`
- AWSアカウントIDの実値
- Role ARNの実値
- Stack名の実値
- SSM prefixの実値
- AgentCore Runtime ARNの実値
- ローカルの `packages/cdk/cdk.json` 変更

`packages/cdk/cdk.json` には環境固有値や機密値が含まれているため、このPRには含めていません。

## GitHub側で必要な事前設定

このworkflowを実行するには、Repository Settingsの `Environments > dev` に以下を登録する必要があります。

Variables:

- `GENU_ENVIRONMENT_NAME`
- `GENU_CDK_CONTEXT_ENV`
- `GENU_AWS_ACCOUNT_ID`
- `GENU_DEPLOYMENT_REGION`
- `GENU_MODEL_REGION`
- `GENU_AGENTCORE_REGION`
- `GENU_STACK_NAME`
- `GENU_OUTPUTS_SSM_PREFIX`
- `GENU_AGENTCORE_RUNTIMES_JSON`

Secrets推奨:

- `GENU_VALIDATE_ROLE_ARN`
- `GENU_DEPLOY_ROLE_ARN`

## 注意点

- `config/cicd/dev.json` はローカル検証用として使えますが、Gitには含めません。
- このブランチは履歴を整理済みで、実値入りの `dev.json` を含まない1コミット構成にしています。
- GenU本体の実デプロイは、このPRのmerge後またはブランチ上のworkflow手動実行で行います。

## 検証

以下を実行済みです。

- `node scripts/validate-cicd-config.mjs`
- `AWS_PROFILE=GenU-dev-profile node scripts/validate-agentcore-runtimes.mjs`
- `node scripts/export-cfn-outputs-to-ssm.mjs --input-file ... --dry-run`
- `npx prettier --check ...`
- `git diff --check`
- `npm -w packages/cdk run build`