### PR TITLE
feat: ライセンスプラン管理と月次利用回数制限機能を追加

### DIFF
--- a/packages/cdk/lambda/admin/assignUserLicense.ts
+++ b/packages/cdk/lambda/admin/assignUserLicense.ts
@@ -1,0 +1,36 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import {
+  AssignUserLicenseRequest,
+  AssignUserLicenseResponse,
+} from 'generative-ai-use-cases';
+import { isAdmin, getUserId, successResponse, errorResponse } from './utils';
+import { getPlan, assignPlan, getMyLicenseInfo } from '../utils/license';
+
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    if (!isAdmin(event)) {
+      return errorResponse(403, 'Admin access required');
+    }
+    const username = event.pathParameters?.username;
+    if (!username) {
+      return errorResponse(400, 'username is required');
+    }
+    const req: AssignUserLicenseRequest = JSON.parse(event.body ?? '{}');
+    if (req.planId !== null) {
+      const plan = await getPlan(req.planId);
+      if (!plan || !plan.enabled) {
+        return errorResponse(400, 'Plan not found or disabled');
+      }
+    }
+    await assignPlan(username, req.planId, getUserId(event));
+
+    const license = await getMyLicenseInfo(username);
+    const body: AssignUserLicenseResponse = { license };
+    return successResponse(body);
+  } catch (error) {
+    console.log(error);
+    return errorResponse(500, 'Internal Server Error');
+  }
+};

--- a/packages/cdk/lambda/admin/createLicensePlan.ts
+++ b/packages/cdk/lambda/admin/createLicensePlan.ts
@@ -1,0 +1,47 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import * as crypto from 'crypto';
+import {
+  CreateLicensePlanRequest,
+  CreateLicensePlanResponse,
+  LicensePlan,
+} from 'generative-ai-use-cases';
+import { isAdmin, successResponse, errorResponse } from './utils';
+import { putPlan } from '../utils/license';
+
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    if (!isAdmin(event)) {
+      return errorResponse(403, 'Admin access required');
+    }
+    const req: CreateLicensePlanRequest = JSON.parse(event.body ?? '{}');
+    if (
+      !req.name ||
+      !Number.isFinite(req.monthlyLimit) ||
+      req.monthlyLimit < 0
+    ) {
+      return errorResponse(
+        400,
+        'name and a non-negative monthlyLimit are required'
+      );
+    }
+
+    const now = new Date().toISOString();
+    const plan: LicensePlan = {
+      planId: crypto.randomUUID(),
+      name: req.name,
+      monthlyLimit: req.monthlyLimit,
+      enabled: req.enabled ?? true,
+      createdDate: now,
+      updatedDate: now,
+    };
+    await putPlan(plan);
+
+    const body: CreateLicensePlanResponse = { plan };
+    return successResponse(body, 201);
+  } catch (error) {
+    console.log(error);
+    return errorResponse(500, 'Internal Server Error');
+  }
+};

--- a/packages/cdk/lambda/admin/deleteLicensePlan.ts
+++ b/packages/cdk/lambda/admin/deleteLicensePlan.ts
@@ -1,0 +1,31 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { isAdmin, successResponse, errorResponse } from './utils';
+import { getPlan, putPlan } from '../utils/license';
+
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    if (!isAdmin(event)) {
+      return errorResponse(403, 'Admin access required');
+    }
+    const planId = event.pathParameters?.planId;
+    if (!planId) {
+      return errorResponse(400, 'planId is required');
+    }
+    const existing = await getPlan(planId);
+    if (!existing) {
+      return errorResponse(404, 'Plan not found');
+    }
+    // Disable instead of delete, so assignments referencing the plan stay resolvable (design doc 5.1)
+    await putPlan({
+      ...existing,
+      enabled: false,
+      updatedDate: new Date().toISOString(),
+    });
+    return successResponse({ planId, enabled: false });
+  } catch (error) {
+    console.log(error);
+    return errorResponse(500, 'Internal Server Error');
+  }
+};

--- a/packages/cdk/lambda/admin/getUserLicense.ts
+++ b/packages/cdk/lambda/admin/getUserLicense.ts
@@ -1,0 +1,24 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { GetUserLicenseResponse } from 'generative-ai-use-cases';
+import { isAdmin, successResponse, errorResponse } from './utils';
+import { getMyLicenseInfo } from '../utils/license';
+
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    if (!isAdmin(event)) {
+      return errorResponse(403, 'Admin access required');
+    }
+    const username = event.pathParameters?.username;
+    if (!username) {
+      return errorResponse(400, 'username is required');
+    }
+    const license = await getMyLicenseInfo(username);
+    const body: GetUserLicenseResponse = { license };
+    return successResponse(body);
+  } catch (error) {
+    console.log(error);
+    return errorResponse(500, 'Internal Server Error');
+  }
+};

--- a/packages/cdk/lambda/admin/listLicensePlans.ts
+++ b/packages/cdk/lambda/admin/listLicensePlans.ts
@@ -1,0 +1,20 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { ListLicensePlansResponse } from 'generative-ai-use-cases';
+import { isAdmin, successResponse, errorResponse } from './utils';
+import { listPlans } from '../utils/license';
+
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    if (!isAdmin(event)) {
+      return errorResponse(403, 'Admin access required');
+    }
+    const plans = await listPlans();
+    const body: ListLicensePlansResponse = { plans };
+    return successResponse(body);
+  } catch (error) {
+    console.log(error);
+    return errorResponse(500, 'Internal Server Error');
+  }
+};

--- a/packages/cdk/lambda/admin/updateLicensePlan.ts
+++ b/packages/cdk/lambda/admin/updateLicensePlan.ts
@@ -1,0 +1,42 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import {
+  UpdateLicensePlanRequest,
+  UpdateLicensePlanResponse,
+} from 'generative-ai-use-cases';
+import { isAdmin, successResponse, errorResponse } from './utils';
+import { getPlan, putPlan } from '../utils/license';
+
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    if (!isAdmin(event)) {
+      return errorResponse(403, 'Admin access required');
+    }
+    const planId = event.pathParameters?.planId;
+    if (!planId) {
+      return errorResponse(400, 'planId is required');
+    }
+    const existing = await getPlan(planId);
+    if (!existing) {
+      return errorResponse(404, 'Plan not found');
+    }
+    const req: UpdateLicensePlanRequest = JSON.parse(event.body ?? '{}');
+    const updated = {
+      ...existing,
+      ...(req.name !== undefined && { name: req.name }),
+      ...(req.monthlyLimit !== undefined && {
+        monthlyLimit: req.monthlyLimit,
+      }),
+      ...(req.enabled !== undefined && { enabled: req.enabled }),
+      updatedDate: new Date().toISOString(),
+    };
+    await putPlan(updated);
+
+    const body: UpdateLicensePlanResponse = { plan: updated };
+    return successResponse(body);
+  } catch (error) {
+    console.log(error);
+    return errorResponse(500, 'Internal Server Error');
+  }
+};

--- a/packages/cdk/lambda/getMyLicense.ts
+++ b/packages/cdk/lambda/getMyLicense.ts
@@ -1,0 +1,30 @@
+import { APIGatewayProxyEvent, APIGatewayProxyResult } from 'aws-lambda';
+import { GetMyLicenseResponse } from 'generative-ai-use-cases';
+import { getMyLicenseInfo } from './utils/license';
+
+const CORS_HEADERS = {
+  'Content-Type': 'application/json',
+  'Access-Control-Allow-Origin': '*',
+};
+
+export const handler = async (
+  event: APIGatewayProxyEvent
+): Promise<APIGatewayProxyResult> => {
+  try {
+    const userId = event.requestContext.authorizer!.claims['cognito:username'];
+    const license = await getMyLicenseInfo(userId);
+    const body: GetMyLicenseResponse = { license };
+    return {
+      statusCode: 200,
+      headers: CORS_HEADERS,
+      body: JSON.stringify(body),
+    };
+  } catch (error) {
+    console.error('Error getting license info:', error);
+    return {
+      statusCode: 500,
+      headers: CORS_HEADERS,
+      body: JSON.stringify({ message: 'Internal server error' }),
+    };
+  }
+};

--- a/packages/cdk/lambda/predictStream.ts
+++ b/packages/cdk/lambda/predictStream.ts
@@ -1,9 +1,13 @@
+/* eslint-disable i18nhelper/no-jp-string */
 import { Handler, Context } from 'aws-lambda';
 import { PredictRequest } from 'generative-ai-use-cases';
 import api from './utils/api';
 import { defaultModel } from './utils/models';
 import { invokeStreamWithTools } from './utils/bedrockApiWithTools';
 import { supportsToolUse } from './utils/toolUseSupport';
+import { streamingChunk } from './utils/streamingChunk';
+import { verifyToken } from './utils/auth';
+import { checkAndIncrementUsage } from './utils/license';
 
 declare global {
   namespace awslambda {
@@ -27,6 +31,27 @@ export const handler = awslambda.streamifyResponse(
   async (event, responseStream, context) => {
     context.callbackWaitsForEmptyEventLoop = false;
     const model = event.model || defaultModel;
+
+    // License limit enforcement: chat use cases only (design 6-B).
+    // Unassigned users and idToken verification failures are treated as unlimited,
+    // either in checkAndIncrementUsage or here (design 6-C, same tolerance pattern as bedrockKbApi.ts).
+    if (isChatUsecase(event.id)) {
+      const payload = await verifyToken(event.idToken || '');
+      const userId = payload?.['cognito:username'] as string | undefined;
+      if (userId) {
+        const result = await checkAndIncrementUsage(userId);
+        if (!result.allowed) {
+          responseStream.write(
+            streamingChunk({
+              text: `今月の利用上限（${result.limit}回）に達しました。毎月1日にリセットされます。`,
+              stopReason: 'error',
+            })
+          );
+          responseStream.end();
+          return;
+        }
+      }
+    }
 
     const hasSearchKey =
       !!process.env.SEARCH_API_KEY || !!process.env.SEARCH_API_KEY_SSM_PARAM;

--- a/packages/cdk/lambda/utils/license.ts
+++ b/packages/cdk/lambda/utils/license.ts
@@ -1,0 +1,195 @@
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import {
+  DynamoDBDocumentClient,
+  GetCommand,
+  PutCommand,
+  UpdateCommand,
+  QueryCommand,
+} from '@aws-sdk/lib-dynamodb';
+import { LicensePlan, UserLicense } from 'generative-ai-use-cases';
+
+const LICENSE_TABLE_NAME = process.env.LICENSE_TABLE_NAME!;
+const dynamoDb = new DynamoDBClient({});
+const dynamoDbDocument = DynamoDBDocumentClient.from(dynamoDb);
+
+const PLANS_PK = 'plans';
+const USAGE_TTL_SECONDS = 13 * 31 * 24 * 60 * 60; // ~13 months
+
+// Current-month key (Asia/Tokyo based) YYYY-MM
+export const currentMonthKey = (): string => {
+  const jst = new Date(
+    new Date().toLocaleString('en-US', { timeZone: 'Asia/Tokyo' })
+  );
+  return `${jst.getFullYear()}-${`${jst.getMonth() + 1}`.padStart(2, '0')}`;
+};
+
+// Next reset date (1st of next month, Asia/Tokyo)
+export const nextResetDate = (): string => {
+  const jst = new Date(
+    new Date().toLocaleString('en-US', { timeZone: 'Asia/Tokyo' })
+  );
+  return new Date(jst.getFullYear(), jst.getMonth() + 1, 1)
+    .toISOString()
+    .slice(0, 10);
+};
+
+const toPlan = (item: Record<string, unknown>): LicensePlan => ({
+  planId: item.planId as string,
+  name: item.name as string,
+  monthlyLimit: item.monthlyLimit as number,
+  enabled: item.enabled as boolean,
+  createdDate: item.createdDate as string,
+  updatedDate: item.updatedDate as string,
+});
+
+export const listPlans = async (): Promise<LicensePlan[]> => {
+  const res = await dynamoDbDocument.send(
+    new QueryCommand({
+      TableName: LICENSE_TABLE_NAME,
+      KeyConditionExpression: 'pk = :pk',
+      ExpressionAttributeValues: { ':pk': PLANS_PK },
+    })
+  );
+  return (res.Items ?? []).map(toPlan);
+};
+
+export const getPlan = async (planId: string): Promise<LicensePlan | null> => {
+  const res = await dynamoDbDocument.send(
+    new GetCommand({
+      TableName: LICENSE_TABLE_NAME,
+      Key: { pk: PLANS_PK, sk: `plan#${planId}` },
+    })
+  );
+  return res.Item ? toPlan(res.Item) : null;
+};
+
+export const putPlan = async (plan: LicensePlan): Promise<void> => {
+  await dynamoDbDocument.send(
+    new PutCommand({
+      TableName: LICENSE_TABLE_NAME,
+      Item: { pk: PLANS_PK, sk: `plan#${plan.planId}`, ...plan },
+    })
+  );
+};
+
+export const getAssignedPlanId = async (
+  userId: string
+): Promise<string | null> => {
+  const res = await dynamoDbDocument.send(
+    new GetCommand({
+      TableName: LICENSE_TABLE_NAME,
+      Key: { pk: `user#${userId}`, sk: 'assignment' },
+    })
+  );
+  return (res.Item?.planId as string | null | undefined) ?? null;
+};
+
+export const assignPlan = async (
+  userId: string,
+  planId: string | null,
+  assignedBy: string
+): Promise<void> => {
+  await dynamoDbDocument.send(
+    new PutCommand({
+      TableName: LICENSE_TABLE_NAME,
+      Item: {
+        pk: `user#${userId}`,
+        sk: 'assignment',
+        planId,
+        assignedBy,
+        assignedDate: new Date().toISOString(),
+      },
+    })
+  );
+};
+
+export const getUsageCount = async (userId: string): Promise<number> => {
+  const res = await dynamoDbDocument.send(
+    new GetCommand({
+      TableName: LICENSE_TABLE_NAME,
+      Key: { pk: `user#${userId}`, sk: `usage#${currentMonthKey()}` },
+    })
+  );
+  return (res.Item?.count as number | undefined) ?? 0;
+};
+
+export type EnforcementResult =
+  | { allowed: true; unlimited: true }
+  | { allowed: true; unlimited: false; count: number; limit: number }
+  | { allowed: false; limit: number };
+
+// Conditionally and atomically increment the current-month counter.
+// Unassigned users and disabled plans are unlimited (design 6-C).
+export const checkAndIncrementUsage = async (
+  userId: string
+): Promise<EnforcementResult> => {
+  const planId = await getAssignedPlanId(userId);
+  if (!planId) {
+    return { allowed: true, unlimited: true };
+  }
+
+  const plan = await getPlan(planId);
+  if (!plan || !plan.enabled) {
+    // The assigned plan has been deleted or disabled: do not block the user's generation
+    return { allowed: true, unlimited: true };
+  }
+
+  const sk = `usage#${currentMonthKey()}`;
+  const ttl = Math.floor(Date.now() / 1000) + USAGE_TTL_SECONDS;
+
+  try {
+    const res = await dynamoDbDocument.send(
+      new UpdateCommand({
+        TableName: LICENSE_TABLE_NAME,
+        Key: { pk: `user#${userId}`, sk },
+        UpdateExpression:
+          'SET #count = if_not_exists(#count, :zero) + :one, updatedDate = :now, #ttl = if_not_exists(#ttl, :ttl)',
+        ConditionExpression: 'attribute_not_exists(#count) OR #count < :limit',
+        ExpressionAttributeNames: { '#count': 'count', '#ttl': 'ttl' },
+        ExpressionAttributeValues: {
+          ':zero': 0,
+          ':one': 1,
+          ':limit': plan.monthlyLimit,
+          ':now': new Date().toISOString(),
+          ':ttl': ttl,
+        },
+        ReturnValues: 'UPDATED_NEW',
+      })
+    );
+    return {
+      allowed: true,
+      unlimited: false,
+      count: (res.Attributes?.count as number) ?? 0,
+      limit: plan.monthlyLimit,
+    };
+  } catch (e) {
+    if ((e as { name?: string }).name === 'ConditionalCheckFailedException') {
+      return { allowed: false, limit: plan.monthlyLimit };
+    }
+    throw e;
+  }
+};
+
+export const getMyLicenseInfo = async (
+  userId: string
+): Promise<UserLicense> => {
+  const planId = await getAssignedPlanId(userId);
+  if (!planId) {
+    return { planId: null, planName: null, usage: null };
+  }
+  const plan = await getPlan(planId);
+  if (!plan) {
+    return { planId: null, planName: null, usage: null };
+  }
+  const count = await getUsageCount(userId);
+  return {
+    planId: plan.planId,
+    planName: plan.name,
+    usage: {
+      count,
+      limit: plan.monthlyLimit,
+      remaining: Math.max(plan.monthlyLimit - count, 0),
+      resetDate: nextResetDate(),
+    },
+  };
+};

--- a/packages/cdk/lib/construct/admin-api.ts
+++ b/packages/cdk/lib/construct/admin-api.ts
@@ -6,6 +6,7 @@ import {
   RestApi,
 } from 'aws-cdk-lib/aws-apigateway';
 import { UserPool } from 'aws-cdk-lib/aws-cognito';
+import { Table } from 'aws-cdk-lib/aws-dynamodb';
 import { Effect, PolicyStatement } from 'aws-cdk-lib/aws-iam';
 import { Construct } from 'constructs';
 import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
@@ -15,6 +16,7 @@ import { IVpc, ISecurityGroup } from 'aws-cdk-lib/aws-ec2';
 export interface AdminApiProps {
   readonly userPool: UserPool;
   readonly api: RestApi;
+  readonly licenseTable: Table;
   readonly vpc?: IVpc;
   readonly securityGroups?: ISecurityGroup[];
 }
@@ -23,7 +25,7 @@ export class AdminApi extends Construct {
   constructor(scope: Construct, id: string, props: AdminApiProps) {
     super(scope, id);
 
-    const { userPool, api, vpc, securityGroups } = props;
+    const { userPool, api, licenseTable, vpc, securityGroups } = props;
 
     const authorizer = new CognitoUserPoolsAuthorizer(this, 'AdminAuthorizer', {
       cognitoUserPools: [userPool],
@@ -184,6 +186,89 @@ export class AdminApi extends Construct {
     );
     updatePasswordPolicyFunction.addToRolePolicy(cognitoAdminPolicy);
 
+    // License plan CRUD (admin only, no Cognito calls needed)
+    const licenseEnv = { LICENSE_TABLE_NAME: licenseTable.tableName };
+
+    const listLicensePlansFunction = new NodejsFunction(
+      this,
+      'ListLicensePlans',
+      {
+        runtime: LAMBDA_RUNTIME_NODEJS,
+        entry: './lambda/admin/listLicensePlans.ts',
+        timeout: Duration.minutes(1),
+        environment: licenseEnv,
+        vpc,
+        securityGroups,
+      }
+    );
+    licenseTable.grantReadData(listLicensePlansFunction);
+
+    const createLicensePlanFunction = new NodejsFunction(
+      this,
+      'CreateLicensePlan',
+      {
+        runtime: LAMBDA_RUNTIME_NODEJS,
+        entry: './lambda/admin/createLicensePlan.ts',
+        timeout: Duration.minutes(1),
+        environment: licenseEnv,
+        vpc,
+        securityGroups,
+      }
+    );
+    licenseTable.grantWriteData(createLicensePlanFunction);
+
+    const updateLicensePlanFunction = new NodejsFunction(
+      this,
+      'UpdateLicensePlan',
+      {
+        runtime: LAMBDA_RUNTIME_NODEJS,
+        entry: './lambda/admin/updateLicensePlan.ts',
+        timeout: Duration.minutes(1),
+        environment: licenseEnv,
+        vpc,
+        securityGroups,
+      }
+    );
+    licenseTable.grantReadWriteData(updateLicensePlanFunction);
+
+    const deleteLicensePlanFunction = new NodejsFunction(
+      this,
+      'DeleteLicensePlan',
+      {
+        runtime: LAMBDA_RUNTIME_NODEJS,
+        entry: './lambda/admin/deleteLicensePlan.ts',
+        timeout: Duration.minutes(1),
+        environment: licenseEnv,
+        vpc,
+        securityGroups,
+      }
+    );
+    licenseTable.grantReadWriteData(deleteLicensePlanFunction);
+
+    const assignUserLicenseFunction = new NodejsFunction(
+      this,
+      'AssignUserLicense',
+      {
+        runtime: LAMBDA_RUNTIME_NODEJS,
+        entry: './lambda/admin/assignUserLicense.ts',
+        timeout: Duration.minutes(1),
+        environment: licenseEnv,
+        vpc,
+        securityGroups,
+      }
+    );
+    licenseTable.grantReadWriteData(assignUserLicenseFunction);
+
+    const getUserLicenseFunction = new NodejsFunction(this, 'GetUserLicense', {
+      runtime: LAMBDA_RUNTIME_NODEJS,
+      entry: './lambda/admin/getUserLicense.ts',
+      timeout: Duration.minutes(1),
+      environment: licenseEnv,
+      vpc,
+      securityGroups,
+    });
+    licenseTable.grantReadData(getUserLicenseFunction);
+
     // --- API Gateway Resources ---
 
     const adminResource = api.root.addResource('admin');
@@ -255,6 +340,23 @@ export class AdminApi extends Construct {
       commonAuthorizerProps
     );
 
+    // /admin/users/{username}/license
+    const userLicenseResource = userResource.addResource('license');
+
+    // GET /admin/users/{username}/license
+    userLicenseResource.addMethod(
+      'GET',
+      new LambdaIntegration(getUserLicenseFunction),
+      commonAuthorizerProps
+    );
+
+    // PUT /admin/users/{username}/license
+    userLicenseResource.addMethod(
+      'PUT',
+      new LambdaIntegration(assignUserLicenseFunction),
+      commonAuthorizerProps
+    );
+
     // /admin/password-policy
     const passwordPolicyResource = adminResource.addResource('password-policy');
 
@@ -269,6 +371,41 @@ export class AdminApi extends Construct {
     passwordPolicyResource.addMethod(
       'PUT',
       new LambdaIntegration(updatePasswordPolicyFunction),
+      commonAuthorizerProps
+    );
+
+    // /admin/license/plans
+    const licenseResource = adminResource.addResource('license');
+    const licensePlansResource = licenseResource.addResource('plans');
+
+    // GET /admin/license/plans
+    licensePlansResource.addMethod(
+      'GET',
+      new LambdaIntegration(listLicensePlansFunction),
+      commonAuthorizerProps
+    );
+
+    // POST /admin/license/plans
+    licensePlansResource.addMethod(
+      'POST',
+      new LambdaIntegration(createLicensePlanFunction),
+      commonAuthorizerProps
+    );
+
+    // /admin/license/plans/{planId}
+    const licensePlanResource = licensePlansResource.addResource('{planId}');
+
+    // PUT /admin/license/plans/{planId}
+    licensePlanResource.addMethod(
+      'PUT',
+      new LambdaIntegration(updateLicensePlanFunction),
+      commonAuthorizerProps
+    );
+
+    // DELETE /admin/license/plans/{planId}
+    licensePlanResource.addMethod(
+      'DELETE',
+      new LambdaIntegration(deleteLicensePlanFunction),
       commonAuthorizerProps
     );
   }

--- a/packages/cdk/lib/construct/api.ts
+++ b/packages/cdk/lib/construct/api.ts
@@ -77,6 +77,7 @@ export interface BackendApiProps {
   readonly table: Table;
   readonly statsTable: Table;
   readonly agentObservabilityTable: Table;
+  readonly licenseTable: Table;
   readonly knowledgeBaseId?: string;
   readonly agents?: string;
   readonly guardrailIdentify?: string;
@@ -116,6 +117,7 @@ export class Api extends Construct {
       userPool,
       userPoolClient,
       table,
+      licenseTable,
       idPool,
       knowledgeBaseId,
       queryDecompositionEnabled,
@@ -240,6 +242,7 @@ export class Api extends Construct {
         CROSS_ACCOUNT_BEDROCK_ROLE_ARN: crossAccountBedrockRoleArn ?? '',
         BUCKET_NAME: fileBucket.bucketName,
         KNOWLEDGE_BASE_ID: knowledgeBaseId ?? '',
+        LICENSE_TABLE_NAME: licenseTable.tableName,
         ...(props.guardrailIdentify
           ? { GUARDRAIL_IDENTIFIER: props.guardrailIdentify }
           : {}),
@@ -271,6 +274,9 @@ export class Api extends Construct {
     });
     fileBucket.grantReadWrite(predictStreamFunction);
     predictStreamFunction.grantInvoke(idPool.authenticatedRole);
+    // License enforcement: predictStream reads plan/assignment and increments
+    // the monthly usage counter, so it needs read/write on the license table.
+    licenseTable.grantReadWriteData(predictStreamFunction);
 
     // Grant SSM SecureString read for the search API key when configured.
     if (props.searchApiKeySsmParameterName) {
@@ -923,6 +929,19 @@ export class Api extends Construct {
     table.grantReadData(getTokenUsageFunction);
     props.statsTable.grantReadData(getTokenUsageFunction);
 
+    // Lambda function for getting the caller's own license (plan + monthly usage)
+    const getMyLicenseFunction = new NodejsFunction(this, 'GetMyLicense', {
+      runtime: LAMBDA_RUNTIME_NODEJS,
+      entry: './lambda/getMyLicense.ts',
+      timeout: Duration.minutes(15),
+      environment: {
+        LICENSE_TABLE_NAME: licenseTable.tableName,
+      },
+      vpc,
+      securityGroups,
+    });
+    licenseTable.grantReadData(getMyLicenseFunction);
+
     // API Gateway
     const authorizer = new CognitoUserPoolsAuthorizer(this, 'Authorizer', {
       cognitoUserPools: [userPool],
@@ -1223,6 +1242,15 @@ export class Api extends Construct {
     tokenUsageResource.addMethod(
       'GET',
       new LambdaIntegration(getTokenUsageFunction),
+      commonAuthorizerProps
+    );
+
+    // GET: /license/me (caller's own license: plan + current month usage)
+    const licenseResource = api.root.addResource('license');
+    const licenseMeResource = licenseResource.addResource('me');
+    licenseMeResource.addMethod(
+      'GET',
+      new LambdaIntegration(getMyLicenseFunction),
       commonAuthorizerProps
     );
 

--- a/packages/cdk/lib/construct/database.ts
+++ b/packages/cdk/lib/construct/database.ts
@@ -11,6 +11,7 @@ export class Database extends Construct {
   public readonly table: ddb.Table;
   public readonly statsTable: ddb.Table;
   public readonly agentObservabilityTable: ddb.Table;
+  public readonly licenseTable: ddb.Table;
   public readonly feedbackIndexName: string;
 
   constructor(scope: Construct, id: string) {
@@ -117,9 +118,40 @@ export class Database extends Construct {
       },
     });
 
+    // License table: plan definitions (pk='plans'), per-user plan assignment,
+    // and monthly usage counters (pk=`user#<userId>`). TTL only applies to
+    // usage-counter items (which carry a `ttl` attribute); plan/assignment
+    // items never set `ttl` and are therefore never auto-deleted.
+    const licenseTable = new ddb.Table(this, 'LicenseTable', {
+      partitionKey: {
+        name: 'pk',
+        type: ddb.AttributeType.STRING,
+      },
+      sortKey: {
+        name: 'sk',
+        type: ddb.AttributeType.STRING,
+      },
+      billingMode: ddb.BillingMode.PAY_PER_REQUEST,
+      pointInTimeRecoverySpecification: {
+        pointInTimeRecoveryEnabled: true,
+      },
+      deletionProtection: true,
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+      timeToLiveAttribute: 'ttl',
+    });
+    licenseTable.node.addMetadata(
+      BACKUP_PROTECTED_METADATA_KEY,
+      BACKUP_PROTECTED_METADATA_VALUE
+    );
+    cdk.Tags.of(licenseTable).add(
+      BACKUP_PROTECTED_TAG.key,
+      BACKUP_PROTECTED_TAG.value
+    );
+
     this.table = table;
     this.statsTable = statsTable;
     this.agentObservabilityTable = agentObservabilityTable;
+    this.licenseTable = licenseTable;
     this.feedbackIndexName = feedbackIndexName;
   }
 }

--- a/packages/cdk/lib/generative-ai-use-cases-stack.ts
+++ b/packages/cdk/lib/generative-ai-use-cases-stack.ts
@@ -180,6 +180,7 @@ export class GenerativeAiUseCasesStack extends Stack {
       table: database.table,
       statsTable: database.statsTable,
       agentObservabilityTable: database.agentObservabilityTable,
+      licenseTable: database.licenseTable,
       knowledgeBaseId: params.ragKnowledgeBaseId || props.knowledgeBaseId,
       agents: agentsJson,
       guardrailIdentify: props.guardrailIdentifier,
@@ -197,6 +198,7 @@ export class GenerativeAiUseCasesStack extends Stack {
     new AdminApi(this, 'AdminApi', {
       userPool: auth.userPool,
       api: api.api,
+      licenseTable: database.licenseTable,
       vpc: props.vpc,
       securityGroups,
     });
@@ -514,6 +516,7 @@ export class GenerativeAiUseCasesStack extends Stack {
       database.table,
       database.statsTable,
       database.agentObservabilityTable,
+      database.licenseTable,
     ];
     if (useCaseBuilder) {
       ddbTables.push(useCaseBuilder.useCaseBuilderTable);

--- a/packages/types/src/index.d.ts
+++ b/packages/types/src/index.d.ts
@@ -21,3 +21,4 @@ export * from './agent-core';
 export * from './agent-builder';
 export * from './mcp-servers';
 export * from './admin';
+export * from './license';

--- a/packages/types/src/license.d.ts
+++ b/packages/types/src/license.d.ts
@@ -1,0 +1,64 @@
+// License API Types
+
+export type LicensePlan = {
+  planId: string;
+  name: string;
+  monthlyLimit: number;
+  enabled: boolean;
+  createdDate: string;
+  updatedDate: string;
+};
+
+export type LicenseUsage = {
+  count: number;
+  limit: number;
+  remaining: number;
+  resetDate: string; // 次回リセット日（Asia/Tokyo, 翌月1日）
+};
+
+// planId が null = 未割当（無制限）。usage も null。
+export type UserLicense = {
+  planId: string | null;
+  planName: string | null;
+  usage: LicenseUsage | null;
+};
+
+export type ListLicensePlansResponse = {
+  plans: LicensePlan[];
+};
+
+export type CreateLicensePlanRequest = {
+  name: string;
+  monthlyLimit: number;
+  enabled?: boolean;
+};
+
+export type CreateLicensePlanResponse = {
+  plan: LicensePlan;
+};
+
+export type UpdateLicensePlanRequest = {
+  name?: string;
+  monthlyLimit?: number;
+  enabled?: boolean;
+};
+
+export type UpdateLicensePlanResponse = {
+  plan: LicensePlan;
+};
+
+export type AssignUserLicenseRequest = {
+  planId: string | null; // null で解除
+};
+
+export type AssignUserLicenseResponse = {
+  license: UserLicense;
+};
+
+export type GetUserLicenseResponse = {
+  license: UserLicense;
+};
+
+export type GetMyLicenseResponse = {
+  license: UserLicense;
+};

--- a/packages/web/public/locales/translation/en.yaml
+++ b/packages/web/public/locales/translation/en.yaml
@@ -13,6 +13,7 @@ admin:
     save_error: Failed to update password policy.
     save_success: Password policy updated successfully.
   tabs:
+    license: License Management
     password_policy: Password Policy
     user_management: User Management
   title: Admin Settings
@@ -891,6 +892,33 @@ language:
   th: Thai
   vi: Vietnamese
   zh: Chinese
+license:
+  assign_action: Assign license
+  assign_error: Failed to assign the license.
+  assign_title: Assign License
+  assigning_user: 'Setting license for {{email}}'
+  badge:
+    remaining: '{{remaining}}/{{limit}} left'
+  column_header: License
+  create_plan: Create Plan
+  create_plan_title: Create New Plan
+  delete_confirm: 'Are you sure you want to delete the plan "{{name}}"? Users assigned to it will no longer have a usage limit.'
+  delete_confirm_title: Confirm Plan Deletion
+  delete_plan: Delete
+  edit_plan_title: Edit Plan
+  enabled: Enabled
+  enabled_no: Disabled
+  enabled_yes: Enabled
+  monthly_limit: Monthly Usage Limit
+  plan_create_error: Failed to create the plan.
+  plan_delete_error: Failed to delete the plan.
+  plan_name: Plan Name
+  plan_update_error: Failed to update the plan.
+  plans_total: '{{count}} plans'
+  remaining_count: '{{remaining}}/{{limit}} left'
+  select_plan: Select a plan
+  times_per_month: '{{count}} times/month'
+  unassigned: Unassigned
 mcp_chat:
   loading_message: Connecting to MCP server. This may take some time. Please wait...
   title: MCP Chat

--- a/packages/web/public/locales/translation/ja.yaml
+++ b/packages/web/public/locales/translation/ja.yaml
@@ -13,6 +13,7 @@ admin:
     save_error: パスワードポリシーの更新に失敗しました。
     save_success: パスワードポリシーを更新しました。
   tabs:
+    license: ライセンス管理
     password_policy: パスワードポリシー
     user_management: ユーザ管理
   title: 管理者設定
@@ -734,6 +735,33 @@ language:
   th: タイ語
   vi: ベトナム語
   zh: 中国語
+license:
+  assign_action: ライセンス割当
+  assign_error: ライセンスの割当に失敗しました。
+  assign_title: ライセンス割当
+  assigning_user: '{{email}} のライセンスを設定'
+  badge:
+    remaining: '残り {{remaining}}/{{limit}} 回'
+  column_header: ライセンス
+  create_plan: プラン作成
+  create_plan_title: 新規プラン作成
+  delete_confirm: 'プラン「{{name}}」を削除してもよろしいですか？割当済みのユーザは利用回数が無制限になります。'
+  delete_confirm_title: プラン削除の確認
+  delete_plan: 削除
+  edit_plan_title: プラン編集
+  enabled: 有効/無効
+  enabled_no: 無効
+  enabled_yes: 有効
+  monthly_limit: 月間利用上限
+  plan_create_error: プランの作成に失敗しました。
+  plan_delete_error: プランの削除に失敗しました。
+  plan_name: プラン名
+  plan_update_error: プランの更新に失敗しました。
+  plans_total: '{{count}} 件のプラン'
+  remaining_count: '残り {{remaining}}/{{limit}} 回'
+  select_plan: プランを選択
+  times_per_month: '{{count}} 回/月'
+  unassigned: 未割当
 mcp_chat:
   loading_message: MCP サーバーと接続しています。時間がかかる場合があります。そのまま待機してください...
   title: MCP チャット

--- a/packages/web/public/locales/translation/ko.yaml
+++ b/packages/web/public/locales/translation/ko.yaml
@@ -418,6 +418,9 @@ language:
   th: 태국어
   vi: 베트남어
   zh: 중국어
+license:
+  badge:
+    remaining: '{{remaining}}/{{limit}}회 남음'
 mcp_chat:
   loading_message: MCP 서버에 연결 중입니다. 시간이 걸릴 수 있습니다. 기다려주세요...
   title: MCP 채팅

--- a/packages/web/public/locales/translation/th.yaml
+++ b/packages/web/public/locales/translation/th.yaml
@@ -563,6 +563,9 @@ language:
   ko: ภาษาเกาหลี
   th: ภาษาไทย
   zh: ภาษาจีน
+license:
+  badge:
+    remaining: 'เหลือ {{remaining}}/{{limit}} ครั้ง'
 meetingMinutes:
   auto_generate: สร้างอัตโนมัติ
   clear_minutes: ล้างรายงานการประชุม

--- a/packages/web/public/locales/translation/vi.yaml
+++ b/packages/web/public/locales/translation/vi.yaml
@@ -547,6 +547,9 @@ language:
   ko: Tiếng Hàn
   th: tiếng Thái
   zh: Tiếng Trung
+license:
+  badge:
+    remaining: 'Còn {{remaining}}/{{limit}} lần'
 meetingMinutes:
   auto_generate: Tự động tạo
   clear_minutes: Xóa biên bản

--- a/packages/web/public/locales/translation/zh.yaml
+++ b/packages/web/public/locales/translation/zh.yaml
@@ -451,6 +451,9 @@ language:
   ja: 日语
   ko: 韩语
   zh: 中文
+license:
+  badge:
+    remaining: '剩余 {{remaining}}/{{limit}} 次'
 meetingMinutes:
   auto_generate: 自动生成
   clear_minutes: 清除会议纪要

--- a/packages/web/src/components/Drawer.tsx
+++ b/packages/web/src/components/Drawer.tsx
@@ -9,6 +9,7 @@ import Switch from './Switch';
 import Button from './Button';
 import { useTranslation } from 'react-i18next';
 import useUserSetting from '../hooks/useUserSetting';
+import useLicense from '../hooks/useLicense';
 
 export type ItemProps = DrawerItemProps & {
   display: 'usecase' | 'tool' | 'none';
@@ -22,6 +23,7 @@ const Drawer: React.FC<Props> = (props) => {
   const { t } = useTranslation();
   const navigate = useNavigate();
   const { settingShowUseCaseBuilder } = useUserSetting();
+  const { license, usage } = useLicense();
 
   const usecases = useMemo(() => {
     return props.items.filter((i) => i.display === 'usecase');
@@ -40,6 +42,14 @@ const Drawer: React.FC<Props> = (props) => {
 
   const [settingVisibility, setSettingVisibility] = useState(false);
 
+  // Usage meter ratio: 0 (exhausted) to 1 (full). A limit of 0 is abnormal and treated as exhausted.
+  const usageRatio =
+    usage && usage.limit > 0
+      ? Math.min(Math.max(usage.remaining / usage.limit, 0), 1)
+      : 0;
+  const isExhausted = !!usage && usage.remaining <= 0;
+  const isLow = !isExhausted && usageRatio <= 0.2;
+
   return (
     <>
       <DrawerBase>
@@ -55,6 +65,45 @@ const Drawer: React.FC<Props> = (props) => {
             />
             <div className="border-b" />
           </>
+        )}
+        {license?.planId && usage && (
+          <div className="bg-sidebar-accent/20 mx-3 my-1 rounded-md px-2.5 py-1.5">
+            <div className="flex items-baseline justify-between gap-2 text-xs">
+              <span className="text-sidebar-text-muted truncate">
+                {license.planName}
+              </span>
+              <span
+                className={`shrink-0 font-medium tabular-nums ${
+                  isExhausted
+                    ? 'text-red-300'
+                    : isLow
+                      ? 'text-amber-300'
+                      : 'text-sidebar-text'
+                }`}>
+                {t('license.badge.remaining', {
+                  remaining: usage.remaining,
+                  limit: usage.limit,
+                })}
+              </span>
+            </div>
+            <div
+              className="bg-sidebar-bg mt-1.5 h-1 overflow-hidden rounded-full"
+              role="progressbar"
+              aria-valuenow={usage.remaining}
+              aria-valuemin={0}
+              aria-valuemax={usage.limit}>
+              <div
+                className={`h-full rounded-full transition-all duration-500 ${
+                  isExhausted
+                    ? 'bg-red-400'
+                    : isLow
+                      ? 'bg-amber-400'
+                      : 'bg-sidebar-text'
+                }`}
+                style={{ width: `${usageRatio * 100}%` }}
+              />
+            </div>
+          </div>
         )}
         <div className="text-sidebar-text-muted mx-3 my-1 flex items-center justify-between text-xs">
           <div>

--- a/packages/web/src/hooks/useChat.ts
+++ b/packages/web/src/hooks/useChat.ts
@@ -20,6 +20,7 @@ import { useEffect, useMemo } from 'react';
 import { v4 as uuid } from 'uuid';
 import useChatApi from './useChatApi';
 import useChatList from './useChatList';
+import { mutate as mutateSwr } from 'swr';
 import { SWRInfiniteKeyedMutator } from 'swr/infinite';
 import { getPrompter } from '../prompts';
 import { findModelByModelId } from './useModel';
@@ -686,6 +687,9 @@ const useChatState = create<{
     }
 
     setWriting(id, false);
+
+    // Sending a chat increments the monthly license counter, so refresh the remaining-count badge
+    mutateSwr('/license/me');
 
     // Postprocessing of messages (example: addition of footnote)
     if (postProcessOutput) {

--- a/packages/web/src/hooks/useLicense.ts
+++ b/packages/web/src/hooks/useLicense.ts
@@ -1,0 +1,22 @@
+import { useMemo } from 'react';
+import useLicenseApi from './useLicenseApi';
+
+// Self-service hook for the current user's license/usage info (e.g. header remaining-count badge)
+const useLicense = () => {
+  const { data, error, isLoading, mutate } = useLicenseApi().getMyLicense();
+
+  const license = useMemo(() => data?.license ?? null, [data]);
+  const usage = useMemo(() => license?.usage ?? null, [license]);
+
+  return {
+    license,
+    usage,
+    remaining: usage?.remaining ?? null,
+    limit: usage?.limit ?? null,
+    isLoading,
+    isError: !!error,
+    mutate,
+  };
+};
+
+export default useLicense;

--- a/packages/web/src/hooks/useLicenseApi.ts
+++ b/packages/web/src/hooks/useLicenseApi.ts
@@ -1,0 +1,78 @@
+import useHttp from './useHttp';
+import {
+  ListLicensePlansResponse,
+  CreateLicensePlanRequest,
+  CreateLicensePlanResponse,
+  UpdateLicensePlanRequest,
+  UpdateLicensePlanResponse,
+  AssignUserLicenseRequest,
+  AssignUserLicenseResponse,
+  GetUserLicenseResponse,
+  GetMyLicenseResponse,
+} from 'generative-ai-use-cases';
+
+const useLicenseApi = () => {
+  const http = useHttp();
+
+  return {
+    // --- Admin: License Plan CRUD ---
+
+    listLicensePlans: () => {
+      return http.get<ListLicensePlansResponse>('/admin/license/plans');
+    },
+
+    createLicensePlan: async (req: CreateLicensePlanRequest) => {
+      const res = await http.post<
+        CreateLicensePlanResponse,
+        CreateLicensePlanRequest
+      >('/admin/license/plans', req);
+      return res.data;
+    },
+
+    updateLicensePlan: async (
+      planId: string,
+      req: UpdateLicensePlanRequest
+    ) => {
+      const res = await http.put<
+        UpdateLicensePlanResponse,
+        UpdateLicensePlanRequest
+      >(`/admin/license/plans/${encodeURIComponent(planId)}`, req);
+      return res.data;
+    },
+
+    deleteLicensePlan: async (planId: string) => {
+      await http.delete(`/admin/license/plans/${encodeURIComponent(planId)}`);
+    },
+
+    // --- Admin: User License Assignment ---
+
+    getUserLicense: (username: string | null) => {
+      return http.get<GetUserLicenseResponse>(
+        username ? `/admin/users/${encodeURIComponent(username)}/license` : null
+      );
+    },
+
+    assignUserLicense: async (
+      username: string,
+      req: AssignUserLicenseRequest
+    ) => {
+      const res = await http.put<
+        AssignUserLicenseResponse,
+        AssignUserLicenseRequest
+      >(`/admin/users/${encodeURIComponent(username)}/license`, req);
+      return res.data;
+    },
+
+    // --- Self-service ---
+
+    getMyLicense: () => {
+      // For the remaining-count badge: the counter advances on each chat, so refetch periodically
+      return http.get<GetMyLicenseResponse>('/license/me', {
+        refreshInterval: 60_000,
+        revalidateOnFocus: true,
+      });
+    },
+  };
+};
+
+export default useLicenseApi;

--- a/packages/web/src/pages/admin/AdminPage.tsx
+++ b/packages/web/src/pages/admin/AdminPage.tsx
@@ -1,12 +1,13 @@
 import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { PiUsers, PiLock } from 'react-icons/pi';
+import { PiUsers, PiLock, PiCreditCard } from 'react-icons/pi';
 import useAdmin from '../../hooks/useAdmin';
 import Alert from '../../components/Alert';
 import UserManagement from './UserManagement';
 import PasswordPolicySettings from './PasswordPolicySettings';
+import LicenseManagement from './LicenseManagement';
 
-type Tab = 'users' | 'passwordPolicy';
+type Tab = 'users' | 'passwordPolicy' | 'license';
 
 const AdminPage: React.FC = () => {
   const { t } = useTranslation();
@@ -34,6 +35,11 @@ const AdminPage: React.FC = () => {
       label: t('admin.tabs.password_policy'),
       icon: <PiLock className="mr-1.5" />,
     },
+    {
+      key: 'license',
+      label: t('admin.tabs.license'),
+      icon: <PiCreditCard className="mr-1.5" />,
+    },
   ];
 
   return (
@@ -60,6 +66,7 @@ const AdminPage: React.FC = () => {
 
       {activeTab === 'users' && <UserManagement />}
       {activeTab === 'passwordPolicy' && <PasswordPolicySettings />}
+      {activeTab === 'license' && <LicenseManagement />}
     </div>
   );
 };

--- a/packages/web/src/pages/admin/LicenseManagement.tsx
+++ b/packages/web/src/pages/admin/LicenseManagement.tsx
@@ -1,0 +1,288 @@
+// License plan management tab. Provides CRUD for plans (name / monthly limit / enabled).
+// APIs come from useLicenseApi() (listLicensePlans/createLicensePlan/updateLicensePlan/deleteLicensePlan).
+// Not to be confused with useLicense(), the hook for the caller's own remaining-count badge.
+import React, { useCallback, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { PiPlus, PiPencil, PiTrash } from 'react-icons/pi';
+import useLicenseApi from '../../hooks/useLicenseApi';
+import Button from '../../components/Button';
+import Alert from '../../components/Alert';
+import ModalDialog from '../../components/ModalDialog';
+import Switch from '../../components/Switch';
+import { LicensePlan } from 'generative-ai-use-cases';
+
+const DEFAULT_MONTHLY_LIMIT = 100;
+
+const LicenseManagement: React.FC = () => {
+  const { t } = useTranslation();
+  const {
+    listLicensePlans,
+    createLicensePlan,
+    updateLicensePlan,
+    deleteLicensePlan,
+  } = useLicenseApi();
+  const { data, mutate, isLoading } = listLicensePlans();
+
+  const plans = data?.plans ?? [];
+
+  // Create/Edit dialog (shared form)
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [editingPlan, setEditingPlan] = useState<LicensePlan | null>(null);
+  const [formName, setFormName] = useState('');
+  const [formMonthlyLimit, setFormMonthlyLimit] = useState(
+    DEFAULT_MONTHLY_LIMIT
+  );
+  const [formEnabled, setFormEnabled] = useState(true);
+  const [formLoading, setFormLoading] = useState(false);
+  const [formError, setFormError] = useState('');
+
+  // Delete confirm dialog
+  const [isDeleteOpen, setIsDeleteOpen] = useState(false);
+  const [deletingPlan, setDeletingPlan] = useState<LicensePlan | null>(null);
+  const [deleteLoading, setDeleteLoading] = useState(false);
+
+  const [error, setError] = useState('');
+
+  const openCreateDialog = useCallback(() => {
+    setEditingPlan(null);
+    setFormName('');
+    setFormMonthlyLimit(DEFAULT_MONTHLY_LIMIT);
+    setFormEnabled(true);
+    setFormError('');
+    setIsFormOpen(true);
+  }, []);
+
+  const openEditDialog = useCallback((plan: LicensePlan) => {
+    setEditingPlan(plan);
+    setFormName(plan.name);
+    setFormMonthlyLimit(plan.monthlyLimit);
+    setFormEnabled(plan.enabled);
+    setFormError('');
+    setIsFormOpen(true);
+  }, []);
+
+  const openDeleteDialog = useCallback((plan: LicensePlan) => {
+    setDeletingPlan(plan);
+    setIsDeleteOpen(true);
+  }, []);
+
+  const handleSubmit = useCallback(async () => {
+    if (!formName.trim() || formMonthlyLimit <= 0) return;
+    setFormLoading(true);
+    setFormError('');
+    try {
+      if (editingPlan) {
+        await updateLicensePlan(editingPlan.planId, {
+          name: formName.trim(),
+          monthlyLimit: formMonthlyLimit,
+          enabled: formEnabled,
+        });
+      } else {
+        await createLicensePlan({
+          name: formName.trim(),
+          monthlyLimit: formMonthlyLimit,
+          enabled: formEnabled,
+        });
+      }
+      await mutate();
+      setIsFormOpen(false);
+    } catch (e: unknown) {
+      const err = e as { response?: { data?: { error?: string } } };
+      setFormError(
+        err?.response?.data?.error ??
+          (editingPlan
+            ? t('license.plan_update_error')
+            : t('license.plan_create_error'))
+      );
+    } finally {
+      setFormLoading(false);
+    }
+  }, [
+    editingPlan,
+    formName,
+    formMonthlyLimit,
+    formEnabled,
+    createLicensePlan,
+    updateLicensePlan,
+    mutate,
+    t,
+  ]);
+
+  const handleDelete = useCallback(async () => {
+    if (!deletingPlan) return;
+    setDeleteLoading(true);
+    setError('');
+    try {
+      await deleteLicensePlan(deletingPlan.planId);
+      await mutate();
+      setIsDeleteOpen(false);
+      setDeletingPlan(null);
+    } catch {
+      setError(t('license.plan_delete_error'));
+    } finally {
+      setDeleteLoading(false);
+    }
+  }, [deletingPlan, deleteLicensePlan, mutate, t]);
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center py-8 text-gray-500">
+        {t('common.loading')}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {error && (
+        <Alert
+          severity="error"
+          className="mb-4"
+          onDissmiss={() => setError('')}>
+          {error}
+        </Alert>
+      )}
+
+      <div className="mb-4 flex items-center justify-between">
+        <div className="text-sm text-gray-600">
+          {t('license.plans_total', { count: plans.length })}
+        </div>
+        <Button onClick={openCreateDialog}>
+          <PiPlus className="mr-1" />
+          {t('license.create_plan')}
+        </Button>
+      </div>
+
+      <div className="overflow-x-auto">
+        <table className="w-full text-left text-sm">
+          <thead>
+            <tr className="border-b bg-gray-50 text-xs text-gray-500">
+              <th className="px-3 py-2">{t('license.plan_name')}</th>
+              <th className="px-3 py-2">{t('license.monthly_limit')}</th>
+              <th className="px-3 py-2">{t('license.enabled')}</th>
+              <th className="px-3 py-2">{t('admin.users.actions')}</th>
+            </tr>
+          </thead>
+          <tbody>
+            {plans.map((plan) => (
+              <tr key={plan.planId} className="border-b hover:bg-gray-50">
+                <td className="px-3 py-2">{plan.name}</td>
+                <td className="px-3 py-2">
+                  {t('license.times_per_month', { count: plan.monthlyLimit })}
+                </td>
+                <td className="px-3 py-2">
+                  {plan.enabled ? (
+                    <span className="inline-flex rounded-full bg-green-100 px-2 py-0.5 text-xs text-green-700">
+                      {t('license.enabled_yes')}
+                    </span>
+                  ) : (
+                    <span className="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-xs text-gray-600">
+                      {t('license.enabled_no')}
+                    </span>
+                  )}
+                </td>
+                <td className="px-3 py-2">
+                  <div className="flex gap-1">
+                    <button
+                      className="rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+                      title={t('common.edit')}
+                      onClick={() => openEditDialog(plan)}>
+                      <PiPencil />
+                    </button>
+                    <button
+                      className="rounded p-1 text-gray-500 hover:bg-red-50 hover:text-red-600"
+                      title={t('common.delete')}
+                      onClick={() => openDeleteDialog(plan)}>
+                      <PiTrash />
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Create/Edit Plan Dialog */}
+      <ModalDialog
+        isOpen={isFormOpen}
+        title={
+          editingPlan
+            ? t('license.edit_plan_title')
+            : t('license.create_plan_title')
+        }
+        onClose={() => setIsFormOpen(false)}>
+        <div className="space-y-4">
+          {formError && <Alert severity="error">{formError}</Alert>}
+          <div>
+            <label className="mb-1 block text-sm font-medium">
+              {t('license.plan_name')}
+            </label>
+            <input
+              type="text"
+              className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-gray-400 focus:outline-none focus:ring-0"
+              value={formName}
+              onChange={(e) => setFormName(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="mb-1 block text-sm font-medium">
+              {t('license.monthly_limit')}
+            </label>
+            <input
+              type="number"
+              min={1}
+              className="w-full rounded border border-gray-300 px-3 py-2 text-sm focus:border-gray-400 focus:outline-none focus:ring-0"
+              value={formMonthlyLimit}
+              onChange={(e) =>
+                setFormMonthlyLimit(parseInt(e.target.value, 10) || 0)
+              }
+            />
+          </div>
+          <div className="flex items-center justify-between">
+            <label className="text-sm font-medium">
+              {t('license.enabled')}
+            </label>
+            <Switch checked={formEnabled} label="" onSwitch={setFormEnabled} />
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button outlined onClick={() => setIsFormOpen(false)}>
+              {t('common.cancel')}
+            </Button>
+            <Button
+              onClick={handleSubmit}
+              loading={formLoading}
+              disabled={!formName.trim() || formMonthlyLimit <= 0}>
+              {t('common.save')}
+            </Button>
+          </div>
+        </div>
+      </ModalDialog>
+
+      {/* Delete Confirm Dialog */}
+      <ModalDialog
+        isOpen={isDeleteOpen}
+        title={t('license.delete_confirm_title')}
+        onClose={() => setIsDeleteOpen(false)}>
+        <div className="space-y-4">
+          <div className="text-sm">
+            {t('license.delete_confirm', { name: deletingPlan?.name })}
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button outlined onClick={() => setIsDeleteOpen(false)}>
+              {t('common.cancel')}
+            </Button>
+            <Button
+              onClick={handleDelete}
+              loading={deleteLoading}
+              className="bg-red-500 text-white">
+              {t('license.delete_plan')}
+            </Button>
+          </div>
+        </div>
+      </ModalDialog>
+    </div>
+  );
+};
+
+export default LicenseManagement;

--- a/packages/web/src/pages/admin/UserManagement.tsx
+++ b/packages/web/src/pages/admin/UserManagement.tsx
@@ -1,4 +1,8 @@
-import React, { useCallback, useMemo, useState } from 'react';
+// User management tab. In addition to the existing features, it provides a
+// license type / current-month remaining-count column and an assignment dialog.
+// License APIs (listLicensePlans/getUserLicense/assignUserLicense) come from useLicenseApi().
+// getUserLicense(username) returns SWR ({ data, mutate, isLoading }); assignUserLicense returns a Promise.
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   PiPlus,
@@ -7,13 +11,120 @@ import {
   PiCheckCircle,
   PiUserGear,
   PiShieldSlash,
+  PiCreditCard,
 } from 'react-icons/pi';
 import useAdminApi from '../../hooks/useAdminApi';
 import useAdmin from '../../hooks/useAdmin';
+import useLicenseApi from '../../hooks/useLicenseApi';
 import Button from '../../components/Button';
 import Alert from '../../components/Alert';
 import ModalDialog from '../../components/ModalDialog';
-import { AdminUser } from 'generative-ai-use-cases';
+import { AdminUser, LicensePlan } from 'generative-ai-use-cases';
+
+const UserLicenseCell: React.FC<{ username: string }> = ({ username }) => {
+  const { t } = useTranslation();
+  const { getUserLicense } = useLicenseApi();
+  const { data, isLoading } = getUserLicense(username);
+
+  if (isLoading || !data) {
+    // eslint-disable-next-line @shopify/jsx-no-hardcoded-content
+    return <span className="text-xs text-gray-400">-</span>;
+  }
+
+  const { license } = data;
+
+  if (!license.planId) {
+    return (
+      <span className="text-xs text-gray-500">{t('license.unassigned')}</span>
+    );
+  }
+
+  return (
+    <div className="text-xs">
+      <div>{license.planName}</div>
+      {license.usage && (
+        <div className="text-gray-500">
+          {t('license.remaining_count', {
+            remaining: license.usage.remaining,
+            limit: license.usage.limit,
+          })}
+        </div>
+      )}
+    </div>
+  );
+};
+
+const AssignLicenseDialog: React.FC<{
+  user: AdminUser;
+  plans: LicensePlan[];
+  onClose: () => void;
+}> = ({ user, plans, onClose }) => {
+  const { t } = useTranslation();
+  const { getUserLicense, assignUserLicense } = useLicenseApi();
+  const { data, mutate } = getUserLicense(user.username);
+
+  const [selectedPlanId, setSelectedPlanId] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState('');
+
+  useEffect(() => {
+    if (data?.license) {
+      setSelectedPlanId(data.license.planId ?? '');
+    }
+  }, [data]);
+
+  const handleAssign = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      await assignUserLicense(user.username, {
+        planId: selectedPlanId || null,
+      });
+      await mutate();
+      onClose();
+    } catch (e: unknown) {
+      const err = e as { response?: { data?: { error?: string } } };
+      setError(err?.response?.data?.error ?? t('license.assign_error'));
+    } finally {
+      setLoading(false);
+    }
+  }, [user, selectedPlanId, assignUserLicense, mutate, onClose, t]);
+
+  return (
+    <ModalDialog isOpen title={t('license.assign_title')} onClose={onClose}>
+      <div className="space-y-4">
+        {error && <Alert severity="error">{error}</Alert>}
+        <div className="text-sm">
+          {t('license.assigning_user', { email: user.email })}
+        </div>
+        <div>
+          <label className="mb-1 block text-sm font-medium">
+            {t('license.select_plan')}
+          </label>
+          <select
+            value={selectedPlanId}
+            onChange={(e) => setSelectedPlanId(e.target.value)}
+            className="w-full rounded border border-gray-300 px-2 py-2 text-sm focus:border-gray-400 focus:outline-none focus:ring-0">
+            <option value="">{t('license.unassigned')}</option>
+            {plans.map((plan) => (
+              <option key={plan.planId} value={plan.planId}>
+                {plan.name}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button outlined onClick={onClose}>
+            {t('common.cancel')}
+          </Button>
+          <Button onClick={handleAssign} loading={loading}>
+            {t('common.save')}
+          </Button>
+        </div>
+      </div>
+    </ModalDialog>
+  );
+};
 
 const UserManagement: React.FC = () => {
   const { t } = useTranslation();
@@ -27,10 +138,16 @@ const UserManagement: React.FC = () => {
     resetMfa,
   } = useAdminApi();
   const { currentUsername } = useAdmin();
+  const { listLicensePlans } = useLicenseApi();
 
   const { data, mutate, isLoading } = listUsers();
+  const { data: licensePlansData } = listLicensePlans();
 
   const users = useMemo(() => data?.users ?? [], [data]);
+  const licensePlans = useMemo(
+    () => licensePlansData?.plans ?? [],
+    [licensePlansData]
+  );
 
   // Create user dialog
   const [isCreateOpen, setIsCreateOpen] = useState(false);
@@ -54,6 +171,9 @@ const UserManagement: React.FC = () => {
   const [isResetMfaOpen, setIsResetMfaOpen] = useState(false);
   const [resetMfaUser, setResetMfaUser] = useState<AdminUser | null>(null);
   const [resetMfaLoading, setResetMfaLoading] = useState(false);
+
+  // Assign license dialog
+  const [assigningUser, setAssigningUser] = useState<AdminUser | null>(null);
 
   // Action loading state
   const [actionLoading, setActionLoading] = useState<string | null>(null);
@@ -211,6 +331,7 @@ const UserManagement: React.FC = () => {
               <th className="px-3 py-2">{t('admin.users.status')}</th>
               <th className="px-3 py-2">{t('admin.users.enabled')}</th>
               <th className="px-3 py-2">{t('admin.users.role')}</th>
+              <th className="px-3 py-2">{t('license.column_header')}</th>
               <th className="px-3 py-2">{t('admin.users.created')}</th>
               <th className="px-3 py-2">{t('admin.users.actions')}</th>
             </tr>
@@ -260,6 +381,9 @@ const UserManagement: React.FC = () => {
                     </span>
                   )}
                 </td>
+                <td className="px-3 py-2">
+                  <UserLicenseCell username={user.username} />
+                </td>
                 <td className="px-3 py-2 text-xs text-gray-500">
                   {new Date(user.createdDate).toLocaleDateString()}
                 </td>
@@ -284,6 +408,12 @@ const UserManagement: React.FC = () => {
                       disabled={isSelf(user.username)}
                       onClick={() => openGroupsDialog(user)}>
                       <PiUserGear />
+                    </button>
+                    <button
+                      className="rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700 disabled:opacity-30"
+                      title={t('license.assign_action')}
+                      onClick={() => setAssigningUser(user)}>
+                      <PiCreditCard />
                     </button>
                     <button
                       className="rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-gray-700 disabled:opacity-30"
@@ -441,6 +571,15 @@ const UserManagement: React.FC = () => {
           </div>
         </div>
       </ModalDialog>
+
+      {/* Assign License Dialog */}
+      {assigningUser && (
+        <AssignLicenseDialog
+          user={assigningUser}
+          plans={licensePlans}
+          onClose={() => setAssigningUser(null)}
+        />
+      )}
     </div>
   );
 };


### PR DESCRIPTION
- ライセンスプランのCRUDとユーザへの割当を行う管理API・管理画面タブを追加
- チャット送信時にDynamoDBの条件付きアトミックインクリメントで月次利用回数を計上し、上限到達時は生成をブロック（未割当ユーザは無制限）
- サイドバーにプラン名・残り回数・残量メーターのバッジを表示（送信直後のSWR再取得と60秒ポーリングで自動更新）
- license.* / admin.tabs.license の翻訳キーを6言語分追加

## Description of Changes

Please explain the changes in detail.
If there is any impact on existing users (compatibility, degradation, breaking changes, etc.), be sure to include it in the explanation.

## Checklist

- [ ] Modified relevant documentation
- [ ] Verified operation in local environment
- [ ] Executed `npm run cdk:test` and if there are snapshot differences, execute `npm run cdk:test:update-snapshot` to update snapshots

## Related Issues

Please list related issues as much as possible.
